### PR TITLE
Feature/gfi-json-display

### DIFF
--- a/frontend/src/cljs/imas_seamap/map/events.cljs
+++ b/frontend/src/cljs/imas_seamap/map/events.cljs
@@ -5,7 +5,7 @@
   (:require [clojure.string :as string]
             [cljs.spec.alpha :as s]
             [imas-seamap.utils :refer [encode-state ids->layers]]
-            [imas-seamap.map.utils :refer [applicable-layers layer-name bounds->str region-stats-habitat-layer wgs84->epsg3112 feature-info-html feature-info-json get-layers-info-format group-basemap-layers]]
+            [imas-seamap.map.utils :refer [applicable-layers layer-name bounds->str region-stats-habitat-layer wgs84->epsg3112 feature-info-html feature-info-json get-layers-info-format group-basemap-layers feature-info-none]]
             [ajax.core :as ajax]
             [imas-seamap.blueprint :as b]
             [reagent.core :as r]
@@ -143,11 +143,10 @@
 (defn got-feature-info [db [_ request-id priority point info-format response]]
   (if (not= request-id (get-in db [:feature-query :request-id]))
     db                           ; Ignore late responses to old clicks
-
     (let [feature-info (case info-format
                          "text/html" (feature-info-html response)
                          "application/json" (feature-info-json response)
-                         (feature-info-html response))
+                         (feature-info-none))
           db' (update-in db [:feature-query :response-remain] dec)
           {:keys [response-priority response-remain candidate had-insecure?]} (:feature-query db')
           higher-priority? (< priority response-priority)

--- a/frontend/src/cljs/imas_seamap/map/events.cljs
+++ b/frontend/src/cljs/imas_seamap/map/events.cljs
@@ -31,50 +31,61 @@
         ;; Note, top layer, last in the list, must be first in our search string:
         layers->str   #(->> % (map layer-name) reverse (string/join ","))
         request-id    (gensym)
-        had-insecure? (->> db :map :active-layers (some #(is-insecure? (:server_url %))))]
+        had-insecure? (->> db :map :active-layers (some #(is-insecure? (:server_url %))))
+        info-format (get-layers-info-format active-layers)]
     ;; http://docs.geoserver.org/stable/en/user/services/wms/reference.html#getfeatureinfo
     (cond
       (seq active-layers)
-      {:http-xhrio (for [[server-url active-layers] by-server
-                         :let [layers   (layers->str active-layers)
-                               priority (->> active-layers
-                                             (map :category)
-                                             (map {:imagery     0
-                                                   :habitat     1
-                                                   :third-party 2})
-                                             (apply min))]]
-                     (let [info-format (get-layers-info-format active-layers)
-                           params {:REQUEST       "GetFeatureInfo"
-                                   :LAYERS        layers
-                                   :QUERY_LAYERS  layers
-                                   :WIDTH         (:x size)
-                                   :HEIGHT        (:y size)
-                                   :BBOX          (bounds->str bounds)
-                                   :FEATURE_COUNT 5
-                                   :STYLES        ""
-                                   :X             x
-                                   :Y             y
-                                   :TRANSPARENT   true
-                                   :CRS           "EPSG:4326"
-                                   :SRS           "EPSG:4326"
-                                   :FORMAT        "image/png"
-                                   :INFO_FORMAT   info-format
-                                   :SERVICE       "WMS"
-                                   :VERSION       "1.1.1"}]
-                       {:method          :get
-                        :uri             server-url
-                        :params          params
-                        :response-format (ajax/text-response-format)
-                        :on-success      [:map/got-featureinfo request-id priority point info-format]
-                        :on-failure      [:map/got-featureinfo-err request-id priority]}))
+      (cond->
        ;; Initialise marshalling-pen of data: how many in flight, and current best-priority response
-       :db         (assoc db :feature-query {:request-id        request-id
-                                             :response-remain   (count by-server)
-                                             :response-priority 99
-                                             :had-insecure?     had-insecure?
-                                             :candidate         nil}
-                          :feature       {:status   :feature-info/waiting
-                                          :location point})}
+       {:db (assoc db
+                   :feature-query {:request-id        request-id
+                                   :response-remain   (count by-server)
+                                   :response-priority 99
+                                   :had-insecure?     had-insecure?
+                                   :candidate         nil}
+                   :feature       {:status   :feature-info/waiting
+                                   :location point})}
+        
+        info-format
+        (assoc
+         :http-xhrio
+         (when info-format
+           (for [[server-url active-layers] by-server
+                 :let [layers   (layers->str active-layers)
+                       priority (->> active-layers
+                                     (map :category)
+                                     (map {:imagery     0
+                                           :habitat     1
+                                           :third-party 2})
+                                     (apply min))]]
+             (let [params {:REQUEST       "GetFeatureInfo"
+                           :LAYERS        layers
+                           :QUERY_LAYERS  layers
+                           :WIDTH         (:x size)
+                           :HEIGHT        (:y size)
+                           :BBOX          (bounds->str bounds)
+                           :FEATURE_COUNT 5
+                           :STYLES        ""
+                           :X             x
+                           :Y             y
+                           :TRANSPARENT   true
+                           :CRS           "EPSG:4326"
+                           :SRS           "EPSG:4326"
+                           :FORMAT        "image/png"
+                           :INFO_FORMAT   info-format
+                           :SERVICE       "WMS"
+                           :VERSION       "1.1.1"}]
+               {:method          :get
+                :uri             server-url
+                :params          params
+                :response-format (ajax/text-response-format)
+                :on-success      [:map/got-featureinfo request-id priority point info-format]
+                :on-failure      [:map/got-featureinfo-err request-id priority]}))))
+        
+        (not info-format)
+        (assoc
+         :dispatch [:map/got-featureinfo request-id nil point nil]))
 
       ;; This is the fall-through case for "layers are visible, but
       ;; they're http so we can't query them":

--- a/frontend/src/cljs/imas_seamap/map/utils.cljs
+++ b/frontend/src/cljs/imas_seamap/map/utils.cljs
@@ -212,6 +212,14 @@
                        :layers      (or detail_layer layer_name)})
         str)))
 
+(defn feature-info-none
+  []
+  {:info (str
+          "<div>"
+          "<h4>No info available</h4>"
+          "Layer summary not configured"
+          "</div>")})
+
 (defn feature-info-html
   [response]
   (let [parsed (.parseFromString (js/DOMParser.) response "text/html")
@@ -234,14 +242,6 @@
               "<table>" property-rows "</table>"
               "</div>")}
       {:status :feature-info/empty})))
-
-(defn feature-info-none
-  []
-  {:info (str
-          "<div>"
-          "<h4>No info available</h4>"
-          "Layer summary not configured"
-          "</div>")})
 
 (def info-format
   {1 "text/html"

--- a/frontend/src/cljs/imas_seamap/map/utils.cljs
+++ b/frontend/src/cljs/imas_seamap/map/utils.cljs
@@ -243,7 +243,7 @@
               "<h4>" id "</h4>"
               "<table>" property-rows "</table>"
               "</div>")}
-      (feature-info-none))))
+      {:status :feature-info/empty})))
 
 (def info-format
   {1 "text/html"

--- a/frontend/src/cljs/imas_seamap/map/utils.cljs
+++ b/frontend/src/cljs/imas_seamap/map/utils.cljs
@@ -234,9 +234,7 @@
         id (get-in parsed ["features" 0 "id"])
         properties (map (fn [[label value]] {:label label :value value}) (get-in parsed ["features" 0 "properties"]))
         property-to-row (fn [{:keys [label value]}] (str "<tr><td>" label "</td><td>" value "</td></tr>"))
-        property-rows (str/join "" (map (fn [property] (property-to-row property)) properties))
-        properties []
-        id nil]
+        property-rows (str/join "" (map (fn [property] (property-to-row property)) properties))]
     (if (or id (not-empty properties))
       {:info (str
               "<div class=\"feature-info-json\">"

--- a/frontend/src/cljs/imas_seamap/map/utils.cljs
+++ b/frontend/src/cljs/imas_seamap/map/utils.cljs
@@ -235,6 +235,14 @@
               "</div>")}
       {:status :feature-info/empty})))
 
+(defn feature-info-none
+  []
+  {:info (str
+          "<div>"
+          "<h4>No info available</h4>"
+          "Layer summary not configured"
+          "</div>")})
+
 (def info-format
   {1 "text/html"
    2 "application/json"

--- a/frontend/src/cljs/imas_seamap/map/utils.cljs
+++ b/frontend/src/cljs/imas_seamap/map/utils.cljs
@@ -234,14 +234,16 @@
         id (get-in parsed ["features" 0 "id"])
         properties (map (fn [[label value]] {:label label :value value}) (get-in parsed ["features" 0 "properties"]))
         property-to-row (fn [{:keys [label value]}] (str "<tr><td>" label "</td><td>" value "</td></tr>"))
-        property-rows (str/join "" (map (fn [property] (property-to-row property)) properties))]
+        property-rows (str/join "" (map (fn [property] (property-to-row property)) properties))
+        properties []
+        id nil]
     (if (or id (not-empty properties))
       {:info (str
               "<div class=\"feature-info-json\">"
               "<h4>" id "</h4>"
               "<table>" property-rows "</table>"
               "</div>")}
-      {:status :feature-info/empty})))
+      (feature-info-none))))
 
 (def info-format
   {1 "text/html"


### PR DESCRIPTION
If the info format is "unavailable" for the layers when attempting to get the feature info, then the GetFeatureInfo request is skipped – a popup saying that layer data is currently unavailable is shown instead.

New popup also used in the event that the JSON popup has no data to display.