### PR TITLE
Feature: (ISA-136) Google Maps pills

### DIFF
--- a/frontend/resources/public/css/app.css
+++ b/frontend/resources/public/css/app.css
@@ -860,7 +860,7 @@ input.leaflet-control-layers-selector[type="radio"] {
 }
 /* L.Control.Zoominfo.css end */
 
-.floating-pill-buttons {
+.floating-pills {
     position: absolute;
     z-index: 2000;
     top: -40px;
@@ -870,30 +870,30 @@ input.leaflet-control-layers-selector[type="radio"] {
 }
 
 @media (min-width:768px) {
-	.floating-pill-buttons {
+	.floating-pills {
         top: 10px;
 	}
 }
 
 @media (min-width:768px) and (max-width:991px) {
-	.floating-pill-buttons {
+	.floating-pills {
 		left: calc(305px + 20px);
 	}
 }
 
 @media (min-width:992px) and (max-width:1199px) {
-	.floating-pill-buttons {
+	.floating-pills {
 		left: calc(390px + 20px);
 	}
 }
 
 @media (min-width:1200px) {
-	.floating-pill-buttons {
+	.floating-pills {
 		left: calc(460px + 20px);
 	}
 }
 
-.floating-pill-buttons > *:not(:last-child) {
+.floating-pills > *:not(:last-child) {
     margin-right: 6px; 
 }
 

--- a/frontend/resources/public/css/app.css
+++ b/frontend/resources/public/css/app.css
@@ -860,9 +860,42 @@ input.leaflet-control-layers-selector[type="radio"] {
 }
 /* L.Control.Zoominfo.css end */
 
-.floating-pill-buttons-control > *:not(:last-child) {
+.floating-pill-buttons {
+    position: absolute;
+    z-index: 2000;
+    top: -40px;
+    left: 10px;
+    transition: top .5s, left .5s;
+    white-space: nowrap;
+}
+
+@media (min-width:768px) {
+	.floating-pill-buttons {
+        top: 10px;
+	}
+}
+
+@media (min-width:768px) and (max-width:991px) {
+	.floating-pill-buttons {
+		left: calc(305px + 20px);
+	}
+}
+
+@media (min-width:992px) and (max-width:1199px) {
+	.floating-pill-buttons {
+		left: calc(390px + 20px);
+	}
+}
+
+@media (min-width:1200px) {
+	.floating-pill-buttons {
+		left: calc(460px + 20px);
+	}
+}
+
+.floating-pill-buttons > *:not(:last-child) {
     margin-right: 6px; 
-} 
+}
 
 .floating-pill-button.bp3-button {
     background-color: white;
@@ -876,4 +909,8 @@ input.leaflet-control-layers-selector[type="radio"] {
 .floating-pill-button .bp3-icon {
     color: black;
     font-size: 14px;
+}
+
+.leaflet-top.leaflet-left {
+    top: 46px;
 }

--- a/frontend/resources/public/css/app.css
+++ b/frontend/resources/public/css/app.css
@@ -893,6 +893,10 @@ input.leaflet-control-layers-selector[type="radio"] {
 	}
 }
 
+.floating-pills.collapsed {
+    left: calc(40px + 20px);
+}
+
 .floating-pills > *:not(:last-child) {
     margin-right: 6px; 
 }

--- a/frontend/resources/public/css/app.css
+++ b/frontend/resources/public/css/app.css
@@ -859,3 +859,17 @@ input.leaflet-control-layers-selector[type="radio"] {
     cursor: default;
 }
 /* L.Control.Zoominfo.css end */
+
+.floating-pill-button.bp3-button {
+    background-color: white;
+    padding: 0 14px;
+    height: 36px;
+    border-radius: 14px;
+    border: 1px solid rgba(0,0,0,0.2);
+}
+
+.floating-pill-button .bp3-button-text,
+.floating-pill-button .bp3-icon {
+    color: black;
+    font-size: 14px;
+}

--- a/frontend/resources/public/css/app.css
+++ b/frontend/resources/public/css/app.css
@@ -860,6 +860,10 @@ input.leaflet-control-layers-selector[type="radio"] {
 }
 /* L.Control.Zoominfo.css end */
 
+.floating-pill-buttons-control > *:not(:last-child) {
+    margin-right: 6px; 
+} 
+
 .floating-pill-button.bp3-button {
     background-color: white;
     padding: 0 14px;

--- a/frontend/src/cljs/imas_seamap/components.cljs
+++ b/frontend/src/cljs/imas_seamap/components.cljs
@@ -4,7 +4,8 @@
 (ns imas-seamap.components
   (:require [imas-seamap.interop.ui-controls :as ui-controls]
             [reagent.core :as reagent]
-            [re-frame.core :as re-frame]))
+            [re-frame.core :as re-frame]
+            [imas-seamap.blueprint :as b]))
 
 (defn items-selection-list
   [{:keys [items disabled data-path is-reversed]}]
@@ -33,3 +34,16 @@
      :isOpen      isOpen
      :onClose     onClose
      :hasBackdrop hasBackdrop}]))
+
+(defn floating-pill-button
+  [{:keys [text icon on-click disabled]}]
+  [b/button
+   {:className "floating-pill-button"
+    :text      text
+    :icon
+    (reagent/as-element
+     [b/icon
+      {:icon icon
+       :icon-size 20}])
+    :on-click  on-click
+    :disabled  disabled}])

--- a/frontend/src/cljs/imas_seamap/map/views.cljs
+++ b/frontend/src/cljs/imas_seamap/map/views.cljs
@@ -119,27 +119,6 @@
                   :intent   b/INTENT-PRIMARY
                   :on-click (handler-dispatch [:ui.download/close-dialogue])}]]]]))
 
-(defn floating-pill-buttons-control
-  []
-  [leaflet/custom-control {:position "topleft"}
-   [:div.floating-pill-buttons-control
-    [components/floating-pill-button
-     {:text     "Left Drawer"
-      :icon     "add-column-left"
-      :on-click #(re-frame/dispatch [:left-drawer/toggle])}]
-    [components/floating-pill-button
-     {:text     "Right Drawer"
-      :icon     "add-column-right"
-      :on-click #(re-frame/dispatch [:right-drawer/toggle])}]
-    [components/floating-pill-button
-     {:text     "Draw Transect"
-      :icon     "edit"
-      :on-click #(re-frame/dispatch [:transect.draw/toggle])}]
-    [components/floating-pill-button
-     {:text     "Select Region"
-      :icon     "widget"
-      :on-click #(re-frame/dispatch [:map.layer.selection/toggle])}]]])
-
 (defn share-control [_props]
   [leaflet/custom-control {:position "topleft" :class "leaflet-bar"}
    ;; The copy-text has to be here rather than in a handler, because
@@ -187,6 +166,23 @@
         logic-type                                    @(re-frame/subscribe [:map.layers/logic])]
     [:div.map-wrapper
      sidebar
+     [:div.floating-pill-buttons
+      [components/floating-pill-button
+       {:text     "Left Drawer"
+        :icon     "add-column-left"
+        :on-click #(re-frame/dispatch [:left-drawer/toggle])}]
+      [components/floating-pill-button
+       {:text     "Right Drawer"
+        :icon     "add-column-right"
+        :on-click #(re-frame/dispatch [:right-drawer/toggle])}]
+      [components/floating-pill-button
+       {:text     "Draw Transect"
+        :icon     "edit"
+        :on-click #(re-frame/dispatch [:transect.draw/toggle])}]
+      [components/floating-pill-button
+       {:text     "Select Region"
+        :icon     "widget"
+        :on-click #(re-frame/dispatch [:map.layer.selection/toggle])}]]
      [download-component download-info]
      [leaflet/leaflet-map
       (merge
@@ -293,8 +289,6 @@
       [leaflet/coordinates-control
        {:position "bottomright"
         :style {}}]
-      
-      [floating-pill-buttons-control]
 
       [share-control]
 

--- a/frontend/src/cljs/imas_seamap/map/views.cljs
+++ b/frontend/src/cljs/imas_seamap/map/views.cljs
@@ -9,6 +9,7 @@
             [imas-seamap.utils :refer [copy-text select-values handler-dispatch] :include-macros true]
             [imas-seamap.map.utils :refer [sort-layers bounds->geojson download-type->str]]
             [imas-seamap.interop.leaflet :as leaflet]
+            [imas-seamap.components :as components]
             ["/L.Control.Zoominfo"]
             #_[debux.cs.core :refer [dbg] :include-macros true]))
 
@@ -117,6 +118,27 @@
        [b/button {:text     "Done"
                   :intent   b/INTENT-PRIMARY
                   :on-click (handler-dispatch [:ui.download/close-dialogue])}]]]]))
+
+(defn floating-pill-buttons-control
+  []
+  [leaflet/custom-control {:position "topleft"}
+   [:div.floating-pill-buttons-control
+    [components/floating-pill-button
+     {:text     "Left Drawer"
+      :icon     "add-column-left"
+      :on-click #(re-frame/dispatch [:left-drawer/toggle])}]
+    [components/floating-pill-button
+     {:text     "Right Drawer"
+      :icon     "add-column-right"
+      :on-click #(re-frame/dispatch [:right-drawer/toggle])}]
+    [components/floating-pill-button
+     {:text     "Draw Transect"
+      :icon     "edit"
+      :on-click #(re-frame/dispatch [:transect.draw/toggle])}]
+    [components/floating-pill-button
+     {:text     "Select Region"
+      :icon     "widget"
+      :on-click #(re-frame/dispatch [:map.layer.selection/toggle])}]]])
 
 (defn share-control [_props]
   [leaflet/custom-control {:position "topleft" :class "leaflet-bar"}
@@ -271,6 +293,8 @@
       [leaflet/coordinates-control
        {:position "bottomright"
         :style {}}]
+      
+      [floating-pill-buttons-control]
 
       [share-control]
 

--- a/frontend/src/cljs/imas_seamap/map/views.cljs
+++ b/frontend/src/cljs/imas_seamap/map/views.cljs
@@ -153,7 +153,7 @@
   (when-not (. js-obj listens event-name)
     (. js-obj on event-name handler)))
 
-(defn map-component [sidebar]
+(defn map-component [sidebar floating-pills]
   (let [{:keys [center zoom bounds]}                  @(re-frame/subscribe [:map/props])
         {:keys [layer-opacities visible-layers]}      @(re-frame/subscribe [:map/layers])
         {:keys [grouped-base-layers active-base-layer]} @(re-frame/subscribe [:map/base-layers])
@@ -166,23 +166,7 @@
         logic-type                                    @(re-frame/subscribe [:map.layers/logic])]
     [:div.map-wrapper
      sidebar
-     [:div.floating-pill-buttons
-      [components/floating-pill-button
-       {:text     "Left Drawer"
-        :icon     "add-column-left"
-        :on-click #(re-frame/dispatch [:left-drawer/toggle])}]
-      [components/floating-pill-button
-       {:text     "Right Drawer"
-        :icon     "add-column-right"
-        :on-click #(re-frame/dispatch [:right-drawer/toggle])}]
-      [components/floating-pill-button
-       {:text     "Draw Transect"
-        :icon     "edit"
-        :on-click #(re-frame/dispatch [:transect.draw/toggle])}]
-      [components/floating-pill-button
-       {:text     "Select Region"
-        :icon     "widget"
-        :on-click #(re-frame/dispatch [:map.layer.selection/toggle])}]]
+     floating-pills
      [download-component download-info]
      [leaflet/leaflet-map
       (merge

--- a/frontend/src/cljs/imas_seamap/views.cljs
+++ b/frontend/src/cljs/imas_seamap/views.cljs
@@ -858,23 +858,25 @@
 
 (defn floating-pills
   []
-  [:div.floating-pills
-   [components/floating-pill-button
-    {:text     "Left Drawer"
-     :icon     "add-column-left"
-     :on-click #(re-frame/dispatch [:left-drawer/toggle])}]
-   [components/floating-pill-button
-    {:text     "Right Drawer"
-     :icon     "add-column-right"
-     :on-click #(re-frame/dispatch [:right-drawer/toggle])}]
-   [components/floating-pill-button
-    {:text     "Draw Transect"
-     :icon     "edit"
-     :on-click #(re-frame/dispatch [:transect.draw/toggle])}]
-   [components/floating-pill-button
-    {:text     "Select Region"
-     :icon     "widget"
-     :on-click #(re-frame/dispatch [:map.layer.selection/toggle])}]])
+  (let [collapsed (:collapsed @(re-frame/subscribe [:ui/sidebar]))]
+    [:div
+     {:class (str "floating-pills" (when collapsed " collapsed"))}
+     [components/floating-pill-button
+      {:text     "Left Drawer"
+       :icon     "add-column-left"
+       :on-click #(re-frame/dispatch [:left-drawer/toggle])}]
+     [components/floating-pill-button
+      {:text     "Right Drawer"
+       :icon     "add-column-right"
+       :on-click #(re-frame/dispatch [:right-drawer/toggle])}]
+     [components/floating-pill-button
+      {:text     "Draw Transect"
+       :icon     "edit"
+       :on-click #(re-frame/dispatch [:transect.draw/toggle])}]
+     [components/floating-pill-button
+      {:text     "Select Region"
+       :icon     "widget"
+       :on-click #(re-frame/dispatch [:map.layer.selection/toggle])}]]))
 
 (def hotkeys-combos
   (let [keydown-wrapper

--- a/frontend/src/cljs/imas_seamap/views.cljs
+++ b/frontend/src/cljs/imas_seamap/views.cljs
@@ -856,6 +856,26 @@
                    :id     "tab-settings"}
       [settings-controls]]]))
 
+(defn floating-pills
+  []
+  [:div.floating-pills
+   [components/floating-pill-button
+    {:text     "Left Drawer"
+     :icon     "add-column-left"
+     :on-click #(re-frame/dispatch [:left-drawer/toggle])}]
+   [components/floating-pill-button
+    {:text     "Right Drawer"
+     :icon     "add-column-right"
+     :on-click #(re-frame/dispatch [:right-drawer/toggle])}]
+   [components/floating-pill-button
+    {:text     "Draw Transect"
+     :icon     "edit"
+     :on-click #(re-frame/dispatch [:transect.draw/toggle])}]
+   [components/floating-pill-button
+    {:text     "Select Region"
+     :icon     "widget"
+     :on-click #(re-frame/dispatch [:map.layer.selection/toggle])}]])
+
 (def hotkeys-combos
   (let [keydown-wrapper
         (fn [m keydown-v]
@@ -925,7 +945,7 @@
         _ #_{:keys [handle-keydown handle-keyup]} (use-hotkeys hot-keys)]
     [:div#main-wrapper ;{:on-key-down handle-keydown :on-key-up handle-keyup}
      [:div#content-wrapper
-      [map-component [seamap-sidebar]]
+      [map-component [seamap-sidebar] [floating-pills]]
       [plot-component]]
      [helper-overlay
       :layer-search


### PR DESCRIPTION
Google Saps style pill buttons added over top of map. Placeholder button functionality used until we know what we actually want to use them for.

Quite CSS heavy, but I think I accounted for all the sidebar states accurately. Got to remember to account for the different absolute positioning when we decide we want it to move with the drawer rather than the Leaflet panel.