### PR TITLE
Feature: (ISA-1) transect layer names

### DIFF
--- a/database/Types/HabitatTableType.sql
+++ b/database/Types/HabitatTableType.sql
@@ -1,6 +1,6 @@
-
 CREATE TYPE HabitatTableType AS TABLE (
   id int identity,
+  layer_name VARCHAR(max),
   name VARCHAR(max),
   geom GEOMETRY
 );

--- a/frontend/src/cljs/imas_seamap/plot/views.cljs
+++ b/frontend/src/cljs/imas_seamap/plot/views.cljs
@@ -202,13 +202,13 @@
    [:g#textbox (merge {:transform "translate(0, 0)"} (:textbox @tooltip-content))
     [:defs
      [:clipPath {:id "tooltip-clip"}
-      [:rect {:x 0 :y 0 :width tooltip-width :height (* 3.5 line-height)}]]]
+      [:rect {:x 0 :y 0 :width tooltip-width :height (* 4.5 line-height)}]]]
     [:rect {:x      0
             :y      0
             :rx     5
             :ry     5
             :width  tooltip-width
-            :height (* 3.5 line-height)
+            :height (* 4.5 line-height)
             :style  {:opacity      0.9
                      :fill         "white"
                      :stroke       "black"
@@ -245,21 +245,23 @@
         depth                              (depth-at-percentage (merge props {:percentage percentage}))
         pointx                             (percentage-to-x-pos (merge props {:percentage percentage}))
         pointy                             (if (nil? depth) (+ graph-range m-top) (depth-to-y-pos (merge props {:depth depth})))
-        {:keys [name]}                     (habitat-at-percentage (merge props {:percentage percentage}))
+        {:keys [layer_name name]}                     (habitat-at-percentage (merge props {:percentage percentage}))
         depth-label                        (if (nil? depth) "No data" (str (.toFixed depth) "m"))
         zone-label                         (if (nil? name) "No data" (get zone-legend name name))
+        layer-label                         (if layer_name layer_name "No data")
         distance                           (int (/ (* percentage max-x) 100))
         distance-unit                      (if (seq habitat) "m" "%")]
     (swap! tooltip-content merge {:tooltip   {:style {:visibility "visible"}}
                                   :textbox   {:transform (str "translate("
                                                               (+ m-left ox (* (/ percentage 100) (- graph-domain tooltip-width)))
-                                                              ", " (+ 10 (+ m-top (* graph-range (- 1 offset)))) ")")}
+                                                              ", " (- (+ m-top (* graph-range (- 1 offset))) 10) ")")}
                                   :line      {:x1 pointx
                                               :y1 m-top
                                               :x2 pointx
                                               :y2 (+ m-top graph-range)}
                                   :text      [(str "Depth: " depth-label)
                                               (str "Habitat: " zone-label)
+                                              (str "Layer: " layer-label)
                                               (str "Distance: " distance distance-unit)]
                                   :datapoint {:cx pointx
                                               :cy pointy}})

--- a/frontend/src/cljs/imas_seamap/plot/views.cljs
+++ b/frontend/src/cljs/imas_seamap/plot/views.cljs
@@ -244,11 +244,11 @@
         percentage                         (min (max (* 100 (mouse-pos-to-percentage (merge props {:pagex pagex}))) 0) 100)
         depth                              (depth-at-percentage (merge props {:percentage percentage}))
         pointx                             (percentage-to-x-pos (merge props {:percentage percentage}))
-        pointy                             (if (nil? depth) (+ graph-range m-top) (depth-to-y-pos (merge props {:depth depth})))
-        {:keys [layer_name name]}                     (habitat-at-percentage (merge props {:percentage percentage}))
-        depth-label                        (if (nil? depth) "No data" (str (.toFixed depth) "m"))
-        zone-label                         (if (nil? name) "No data" (get zone-legend name name))
-        layer-label                         (if layer_name layer_name "No data")
+        pointy                             (if depth (depth-to-y-pos (merge props {:depth depth})) (+ graph-range m-top))
+        {:keys [layer_name name]}          (habitat-at-percentage (merge props {:percentage percentage}))
+        depth-label                        (if depth (str (.toFixed depth) "m") "No data")
+        zone-label                         (or (get zone-legend name name) "No data")
+        layer-label                        (or layer_name "No data")
         distance                           (int (/ (* percentage max-x) 100))
         distance-unit                      (if (seq habitat) "m" "%")]
     (swap! tooltip-content merge {:tooltip   {:style {:visibility "visible"}}

--- a/frontend/src/ui/PanelStack/PanelStack.jsx
+++ b/frontend/src/ui/PanelStack/PanelStack.jsx
@@ -2,6 +2,10 @@ import React from 'react';
 import PropTypes from "prop-types";
 import * as BPCore from "@blueprintjs/core";
 
+export function Panel({content}) {
+	return content
+}
+
 export function PanelStack({panels, onClose}) {
 	const stack = panels.map(
 		({content, title}) => {
@@ -9,7 +13,7 @@ export function PanelStack({panels, onClose}) {
 				props: {
 					content: content
 				},
-				component: ({content}) => content,
+				component: Panel, // Using normal function rather than inline function due to way React compares props (https://stackoverflow.com/a/47007354)
 				title: title
 			}
 		}


### PR DESCRIPTION
Updated the transect query to include the layer name of the polygon intersected by each segment. Updates to both `HabitatTableType.sql` and `path_intersections.sql` that have been applied to the dev database.

Transect tooltip now includes layer name for each segment.