### PR TITLE
Feature: (ISA-144) Removed additional sidebar tabs

### DIFF
--- a/frontend/src/cljs/imas_seamap/views.cljs
+++ b/frontend/src/cljs/imas_seamap/views.cljs
@@ -837,7 +837,7 @@
       :hasBackdrop false}
      "With cooler content ;-)"]))
 
-(defn seamap-sidebar []
+(defn active-layers-sidebar []
   (let [{:keys [collapsed selected] :as _sidebar-state}                            @(re-frame/subscribe [:ui/sidebar])
         {:keys [active-layers visible-layers loading-layers error-layers expanded-layers layer-opacities]} @(re-frame/subscribe [:map/layers])]
     [sidebar {:id        "floating-sidebar"
@@ -943,7 +943,7 @@
         _ #_{:keys [handle-keydown handle-keyup]} (use-hotkeys hot-keys)]
     [:div#main-wrapper ;{:on-key-down handle-keydown :on-key-up handle-keyup}
      [:div#content-wrapper
-      [map-component [seamap-sidebar] [floating-pills]]
+      [map-component [active-layers-sidebar] [floating-pills]]
       [plot-component]]
      [helper-overlay
       :layer-search

--- a/frontend/src/cljs/imas_seamap/views.cljs
+++ b/frontend/src/cljs/imas_seamap/views.cljs
@@ -839,8 +839,7 @@
 
 (defn seamap-sidebar []
   (let [{:keys [collapsed selected] :as _sidebar-state}                            @(re-frame/subscribe [:ui/sidebar])
-        {:keys [groups active-layers visible-layers loading-layers error-layers expanded-layers layer-opacities]} @(re-frame/subscribe [:map/layers])
-        {:keys [habitat boundaries bathymetry imagery third-party]}                groups]
+        {:keys [active-layers visible-layers loading-layers error-layers expanded-layers layer-opacities]} @(re-frame/subscribe [:map/layers])]
     [sidebar {:id        "floating-sidebar"
               :selected  selected
               :collapsed collapsed
@@ -851,66 +850,7 @@
                    :icon   (as-icon "eye-open"
                                     (str "Active Layers (" (count active-layers) ")"))
                    :id     "tab-activelayers"}
-      [active-layers-tab active-layers active-layers visible-layers loading-layers error-layers expanded-layers layer-opacities]]
-     [sidebar-tab {:header "Habitats"
-                   :icon   (as-icon "home"
-                                    (str "Habitat Layers (" (count habitat) ")"))
-                   :id     "tab-habitat"}
-      [catalogue-layer-tab habitat active-layers loading-layers error-layers expanded-layers layer-opacities :habitat
-       [{:id         "org"
-         :title      "By Organisation"
-         :categories [:organisation :data_classification]}
-        {:id         "cat"
-         :title      "By Category"
-         :categories [:data_classification]}]]]
-     [sidebar-tab {:header "Bathymetry"
-                   :icon   (as-icon "timeline-area-chart"
-                                    (str "Bathymetry Layers (" (count bathymetry) ")"))
-                   :id     "tab-bathy"}
-      [catalogue-layer-tab bathymetry active-layers loading-layers error-layers expanded-layers layer-opacities :bathymetry
-       [{:id         "org"
-         :title      "By Organisation"
-         :categories [:organisation :data_classification]}
-        {:id         "cat"
-         :title      "By Category"
-         :categories [:data_classification]}]]]
-     [sidebar-tab {:header "Imagery"
-                   :icon   (as-icon "media"
-                                    (str "Imagery Layers (" (count imagery) ")"))
-                   :id     "tab-imagery"}
-      [catalogue-layer-tab imagery active-layers loading-layers error-layers expanded-layers layer-opacities :imagery
-       [{:id         "org"
-         :title      "By Organisation"
-         :categories [:organisation :data_classification]}
-        {:id         "cat"
-         :title      "By Category"
-         :categories [:data_classification]}]]]
-     [sidebar-tab {:header "Management Regions"
-                   :icon   (as-icon "heatmap" "Management Region Layers")
-                   :id     "tab-management"}
-      [catalogue-layer-tab boundaries active-layers loading-layers error-layers expanded-layers layer-opacities :boundaries
-       [{:id         "org"
-         :title      "By Organisation"
-         :categories [:organisation :data_classification]}
-        {:id         "cat"
-         :title      "By Category"
-         :categories [:data_classification]}]]]
-     [sidebar-tab {:header "Third-Party"
-                   :icon   (as-icon "more"
-                                    (str "Third-Party Layers (" (count third-party) ")"))
-                   :id     "tab-thirdparty"}
-      [catalogue-layer-tab third-party active-layers loading-layers error-layers expanded-layers layer-opacities :third-party
-       [{:id         "org"
-         :title      "By Organisation"
-         :categories [:organisation :data_classification]}
-        {:id         "cat"
-         :title      "By Category"
-         :categories [:data_classification]}]]]
-     [sidebar-tab {:header "Settings"
-                   :anchor "bottom"
-                   :icon   (reagent/as-element [:span.bp3-icon-standard.bp3-icon-cog])
-                   :id     "tab-settings"}
-      [settings-controls]]]))
+      [active-layers-tab active-layers active-layers visible-layers loading-layers error-layers expanded-layers layer-opacities]]]))
 
 (defn floating-pills
   []


### PR DESCRIPTION
Simple change: removed all the additional sidebar tabs.

The tab enclosing the active layers tab content hasn't been removed because it would destroy the current styling and also leave the sidebar unable to be collapsed:
![Screen Shot 2022-06-02 at 10 35 34 am](https://user-images.githubusercontent.com/50224230/171523589-7848e106-486e-4432-8023-3f62485fa319.png)

If fixing this is seen as worth it, then I can work on replicating the style, but for now I think what we have will do (especially when we don't even know for certain what we want the sidebar to look like).
![Screen Shot 2022-06-02 at 12 38 09 pm](https://user-images.githubusercontent.com/50224230/171540599-b349c946-1373-4dbd-b332-dcdfc891bc39.png)
