### PR TITLE
Feature: (ISA-135) Remove category-specific logic

### DIFF
--- a/frontend/src/cljs/imas_seamap/core.cljs
+++ b/frontend/src/cljs/imas_seamap/core.cljs
@@ -166,7 +166,8 @@
     :layers-search-omnibar/open           events/layers-search-omnibar-open
     :layers-search-omnibar/close          events/layers-search-omnibar-close
     :drawer-panel-stack/push              events/drawer-panel-stack-push
-    :drawer-panel-stack/pop               events/drawer-panel-stack-pop}})
+    :drawer-panel-stack/pop               events/drawer-panel-stack-pop
+    :drawer-panel-stack/open-catalogue-panel [events/open-catalogue-panel]}})
 
 (def events-for-analytics
   [:help-layer/open

--- a/frontend/src/cljs/imas_seamap/db.cljs
+++ b/frontend/src/cljs/imas_seamap/db.cljs
@@ -49,16 +49,7 @@
                      :right-drawer          false
                      :layers-search-omnibar false
                      :drawer-panel-stack    []
-                     :catalogue             {:habitat     {:tab "org"     ; NOTE: Move away from map to vector to support arbitrary number of tabs/groups?
-                                                           :expanded #{}}
-                                             :boundaries  {:tab "org"
-                                                           :expanded #{}}
-                                             :bathymetry  {:tab "org"
-                                                           :expanded #{}}
-                                             :imagery     {:tab "org"
-                                                           :expanded #{}}
-                                             :third-party {:tab "org"
-                                                           :expanded #{}}}
+                     :catalogue             {}
                      :sidebar               {:collapsed false
                                              :selected  "tab-activelayers"}}
    :config          {:layer-url             (str api-url-base "layers/")

--- a/frontend/src/cljs/imas_seamap/db.cljs
+++ b/frontend/src/cljs/imas_seamap/db.cljs
@@ -62,4 +62,6 @@
                      :region-stats-url      (str api-url-base "habitat/regions/")
                      :descriptor-url        (str api-url-base "descriptors/")
                      :save-state-url        (str api-url-base "savestates")
-                     :category-url          (str api-url-base "categories/")}})
+                     :category-url          (str api-url-base "categories/")
+                     :init-catalogue-state  {:tab      "org"
+                                             :expanded #{}}}})

--- a/frontend/src/cljs/imas_seamap/events.cljs
+++ b/frontend/src/cljs/imas_seamap/events.cljs
@@ -10,7 +10,7 @@
             [goog.dom :as gdom]
             [imas-seamap.blueprint :as b]
             [imas-seamap.db :as db]
-            [imas-seamap.utils :refer [copy-text encode-state geonetwork-force-xml merge-in parse-state append-params-from-map]]
+            [imas-seamap.utils :refer [copy-text encode-state geonetwork-force-xml merge-in parse-state append-params-from-map map-on-key]]
             [imas-seamap.map.utils :as mutils :refer [applicable-layers habitat-layer? download-link]]
             [re-frame.core :as re-frame]
             #_[debux.cs.core :refer [dbg] :include-macros true]))
@@ -608,3 +608,10 @@
 
 (defn drawer-panel-stack-pop [db _]
   (update-in db [:display :drawer-panel-stack] pop))
+
+(defn open-catalogue-panel [{:keys [db]} [_ category]]
+  (let [categories (get-in db [:map :categories])
+        categories (map-on-key categories :name)
+        title      (str (get-in categories [category :display_name]) " Layers")]
+    {:db db
+     :dispatch [:drawer-panel-stack/push :drawer-panel/catalogue-layers {:group category :title title}]}))

--- a/frontend/src/cljs/imas_seamap/map/events.cljs
+++ b/frontend/src/cljs/imas_seamap/map/events.cljs
@@ -516,14 +516,11 @@
 
 (defn add-layer-from-omnibar
   [{:keys [db]} [_ {:keys [category] :as layer}]]
-  (let [categories (get-in db [:map :categories])
-        categories (map-on-key categories :name)
-        title      (str (get-in categories [category :display_name]) " Layers")]
-    {:db       (assoc-in db [:display :layers-search-omnibar] false)
-     :dispatch-n (concat
-                  [[:map/add-layer layer]
-                   [:left-drawer/open]
-                   [:drawer-panel-stack/push :drawer-panel/catalogue-layers {:group category :title title}]
-                   [:ui.catalogue/select-tab category "org"]
-                   [:ui.catalogue/catalogue-add-nodes-to-layer category layer "org" [:organisation :data_classification]]
-                   [:map/pan-to-layer layer]])}))
+  {:db       (assoc-in db [:display :layers-search-omnibar] false)
+   :dispatch-n (concat
+                [[:map/add-layer layer]
+                 [:left-drawer/open]
+                 [:drawer-panel-stack/open-catalogue-panel category]
+                 [:ui.catalogue/select-tab category "org"]
+                 [:ui.catalogue/catalogue-add-nodes-to-layer category layer "org" [:organisation :data_classification]]
+                 [:map/pan-to-layer layer]])})

--- a/frontend/src/cljs/imas_seamap/map/events.cljs
+++ b/frontend/src/cljs/imas_seamap/map/events.cljs
@@ -301,13 +301,26 @@
            :habitat-titles  titles
            :habitat-colours colours)))
 
-(defn update-categories [db [_ categories]]
+(defn update-categories
+  "Adds the categories to the db, as well as setting the initial state of the
+   catalogue (in instances where the catalogue doesn't have a state)."
+  [db [_ categories]]
   (let [categories (map
                     (fn [{:keys [name display_name]}]
                       {:name (keyword (string/lower-case name))
                        :display_name (or display_name (string/capitalize name))})
-                    categories)]
-    (assoc-in db [:map :categories] (set categories))))
+                    categories)
+        catalogue  (reduce
+                    (fn [catalogue {:keys [name]}]
+                      (assoc
+                       catalogue name
+                       {:tab      "org"
+                        :expanded #{}}))
+                    {} categories)
+        catalogue  (merge catalogue (get-in db [:display :catalogue]))] ; Override initial state with states we have
+    (-> db
+        (assoc-in [:map :categories] (set categories))
+        (assoc-in [:display :catalogue] catalogue))))
 
 (defn layer-started-loading [db [_ layer]]
   (update-in db [:layer-state :loading-state] assoc layer :map.layer/loading))

--- a/frontend/src/cljs/imas_seamap/map/events.cljs
+++ b/frontend/src/cljs/imas_seamap/map/events.cljs
@@ -229,9 +229,6 @@
 (defn process-layer [layer]
   (-> layer
       (update :category    (comp keyword string/lower-case))
-      ;; If category is contours, turn it into bathymetry but with a contours attribute set:
-      (as-> lyr (if (= (:category lyr) :contours) (assoc lyr :contours true) lyr))
-      (update :category    #(if (= % :contours) :bathymetry %))
       (update :server_type (comp keyword string/lower-case))))
 
 (defn process-layers [layers]

--- a/frontend/src/cljs/imas_seamap/map/events.cljs
+++ b/frontend/src/cljs/imas_seamap/map/events.cljs
@@ -305,19 +305,19 @@
   "Adds the categories to the db, as well as setting the initial state of the
    catalogue (in instances where the catalogue doesn't have a state)."
   [db [_ categories]]
-  (let [categories (map
-                    (fn [{:keys [name display_name]}]
-                      {:name (keyword (string/lower-case name))
-                       :display_name (or display_name (string/capitalize name))})
-                    categories)
-        catalogue  (reduce
-                    (fn [catalogue {:keys [name]}]
-                      (assoc
-                       catalogue name
-                       {:tab      "org"
-                        :expanded #{}}))
-                    {} categories)
-        catalogue  (merge catalogue (get-in db [:display :catalogue]))] ; Override initial state with states we have
+  (let [categories           (map
+                              (fn [{:keys [name display_name]}]
+                                {:name (keyword (string/lower-case name))
+                                 :display_name (or display_name (string/capitalize name))})
+                              categories)
+        init-catalogue-state (get-in db [:config :init-catalogue-state])
+        catalogue            (reduce
+                              (fn [catalogue {:keys [name]}]
+                                (assoc
+                                 catalogue name
+                                 init-catalogue-state))
+                              {} categories)
+        catalogue            (merge catalogue (get-in db [:display :catalogue]))] ; Override initial state with states we have
     (-> db
         (assoc-in [:map :categories] (set categories))
         (assoc-in [:display :catalogue] catalogue))))

--- a/frontend/src/cljs/imas_seamap/views.cljs
+++ b/frontend/src/cljs/imas_seamap/views.cljs
@@ -527,10 +527,10 @@
               :right-icon "caret-down"}]])
 
 (defn info-card []
-  (let [layer-info       @(re-frame/subscribe [:map.layer/info])
-        layer            (:layer layer-info)
-        title            (or (get-in layer-info [:layer :name]) "Layer Information")
-        {:keys [region]} @(re-frame/subscribe [:map.layer.selection/info])]
+  (let [layer-info                       @(re-frame/subscribe [:map.layer/info])
+        {:keys [metadata_url] :as layer} (:layer layer-info)
+        title                            (or (get-in layer-info [:layer :name]) "Layer Information")
+        {:keys [region]}                 @(re-frame/subscribe [:map.layer.selection/info])]
     [b/dialogue {:title    title
                  :is-open  (and layer-info (not (:hidden? layer-info)))
                  :on-close #(re-frame/dispatch [:map.layer/close-info])}
@@ -550,7 +550,7 @@
         [metadata-record layer-info])]
      [:div.bp3-dialog-footer
       [:div.bp3-dialog-footer-actions
-       (when (#{:habitat :imagery} (:category layer))
+       (when (and metadata_url (re-matches #"^https://metadata\.imas\.utas\.edu\.au/geonetwork/srv/eng/catalog.search#/metadata/[0-9a-f]{8}\-[0-9a-f]{4}\-4[0-9a-f]{3}\-[89ab][0-9a-f]{3}\-[0-9a-f]{12}$" metadata_url))
          [:div
           [download-menu {:title     "Download Selection..."
                           :layer     layer

--- a/frontend/src/cljs/imas_seamap/views.cljs
+++ b/frontend/src/cljs/imas_seamap/views.cljs
@@ -644,7 +644,7 @@
     [b/button
      {:icon     icon
       :text     title
-      :on-click #(re-frame/dispatch [:drawer-panel-stack/push :drawer-panel/catalogue-layers {:group (:name category) :title title}])}]))
+      :on-click #(re-frame/dispatch [:drawer-panel-stack/open-catalogue-panel (:name category)])}]))
 
 (defn base-panel
   []


### PR DESCRIPTION
https://jira.its.utas.edu.au/browse/ISA-135
https://jira.its.utas.edu.au/browse/ISA-32

Just some additional cleanup to remove the last of the category-specific logic that we no longer want. Backend will need to be updated after this merge is made.