### PR TITLE
Feature: (ISA-161) Query statistics for habitat

### DIFF
--- a/backend/habitat/viewsets.py
+++ b/backend/habitat/viewsets.py
@@ -93,6 +93,26 @@ SQL_GET_PARKS = "select name, network from SeamapAus_Parks_View;"
 SQL_GET_ZONES = "select name from SeamapAus_Zones_View;"
 SQL_GET_ZONES_IUCN = "select name from SeamapAus_ZonesIUCN_View;"
 
+SQL_GET_NETWORK_AREA = "select geom.STArea() from SeamapAus_Networks_View where name=%s;"
+SQL_GET_NETWORK_HABITAT_STATS = """
+select habitat, area / 1000000 as area, 100 * area / %s as percentage
+from SeamapAus_Habitat_By_Region
+where
+  region = %s and
+  boundary_layer_id = 260 and
+  habitat_layer_id = 95;
+"""
+
+SQL_GET_PARK_AREA = "select geom.STArea() from SeamapAus_Parks_View where name=%s;"
+SQL_GET_PARK_HABITAT_STATS = """
+select habitat, area / 1000000 as area, 100 * area / %s as percentage
+from SeamapAus_Habitat_By_Region
+where
+  region = %s and
+  boundary_layer_id = 261 and
+  habitat_layer_id = 95;
+"""
+
 def parse_bounds(bounds_str):
     # Note, we want points in x,y order but a boundary string is in y,x order:
     parts = bounds_str.split(',')[:4]  # There may be a trailing SRID URN we ignore for now
@@ -490,3 +510,49 @@ def zones_iucn(request):
                     break
     print(zones_iucn)
     return Response(zones_iucn)
+
+@action(detail=False)
+@api_view()
+def habitat_statistics(request):
+    network   = request.query_params.get('network')
+    park      = request.query_params.get('park')
+    zone      = request.query_params.get('zone')
+    zone_iucn = request.query_params.get('zone-iucn')
+
+    habitat_stats = []
+
+    with connections['transects'].cursor() as cursor:
+        if (park):
+            cursor.execute(SQL_GET_PARK_AREA, [park])
+            area = cursor.fetchone()[0]
+
+            cursor.execute(SQL_GET_PARK_HABITAT_STATS, [area, park])
+
+            while True:
+                try:
+                    for row in cursor.fetchall():
+                        [habitat, area, percentage] = row
+                        habitat_stats.append({'habitat': habitat, 'area': area, 'percentage': percentage})
+                    if not cursor.nextset():
+                        break
+                except ProgrammingError:
+                    if not cursor.nextset():
+                        break
+        elif (network):
+            cursor.execute(SQL_GET_NETWORK_AREA, [network])
+            area = cursor.fetchone()[0]
+
+            cursor.execute(SQL_GET_NETWORK_HABITAT_STATS, [area, network])
+
+            while True:
+                try:
+                    for row in cursor.fetchall():
+                        [habitat, area, percentage] = row
+                        habitat_stats.append({'habitat': habitat, 'area': area, 'percentage': percentage})
+                    if not cursor.nextset():
+                        break
+                except ProgrammingError:
+                    if not cursor.nextset():
+                        break
+
+    return Response(habitat_stats)

--- a/backend/habitat/viewsets.py
+++ b/backend/habitat/viewsets.py
@@ -523,7 +523,7 @@ def habitat_statistics(request):
     total_area = 0
 
     with connections['transects'].cursor() as cursor:
-        if (park):
+        if parks:
             cursor.execute(SQL_GET_PARK_AREA, [park])
             total_area = cursor.fetchone()[0]
 
@@ -539,7 +539,7 @@ def habitat_statistics(request):
                 except ProgrammingError:
                     if not cursor.nextset():
                         break
-        elif (network):
+        elif network:
             cursor.execute(SQL_GET_NETWORK_AREA, [network])
             total_area = cursor.fetchone()[0]
 

--- a/backend/webapp/urls.py
+++ b/backend/webapp/urls.py
@@ -9,7 +9,7 @@ from rest_framework.routers import DefaultRouter
 import catalogue.viewsets as viewsets
 
 from catalogue.views import SaveStateView
-from habitat.viewsets import regions, subset, transect, networks, parks, zones, zones_iucn
+from habitat.viewsets import regions, subset, transect, networks, parks, zones, zones_iucn, habitat_statistics
 
 
 router = DefaultRouter()
@@ -31,6 +31,7 @@ urlpatterns = [
     re_path(r'^api/habitat/parks/?$', parks),
     re_path(r'^api/habitat/zones/?$', zones),
     re_path(r'^api/habitat/zonesiucn/?$', zones_iucn),
+    re_path(r'^api/habitat/habitatstatistics/?$', habitat_statistics),
     re_path(r'^api/savestates', SaveStateView.as_view()),
     re_path(r'^api/', include(router.urls)),
 ]

--- a/database/Views/SeamapAus_Networks_View.sql
+++ b/database/Views/SeamapAus_Networks_View.sql
@@ -1,4 +1,5 @@
 CREATE VIEW [dbo].[SeamapAus_Networks_View] AS
 SELECT
-  [NETNAME] AS [name]
+  [NETNAME] AS [name],
+  [geom]
 FROM [dbo].[SeamapAus_BOUNDARIES_AMP2018_NETWORKS]

--- a/database/Views/SeamapAus_Parks_View.sql
+++ b/database/Views/SeamapAus_Parks_View.sql
@@ -1,5 +1,6 @@
 CREATE VIEW [dbo].[SeamapAus_Parks_View] AS
 SELECT
   [RESNAME] AS [name],
-  [NETNAME] AS [network]
+  [NETNAME] AS [network],
+  [geom]
 FROM [dbo].[SeamapAus_BOUNDARIES_AMP2018_RESERVES]

--- a/frontend/src/cljs/imas_seamap/core.cljs
+++ b/frontend/src/cljs/imas_seamap/core.cljs
@@ -155,10 +155,10 @@
     :map/zoom-out                         mevents/map-zoom-out
     :map/pan-direction                    mevents/map-pan-direction
     :map/view-updated                     [mevents/map-view-updated]
-    :map/update-active-network            mevents/update-active-network
-    :map/update-active-park               mevents/update-active-park
-    :map/update-active-zone               mevents/update-active-zone
-    :map/update-active-zone-iucn          mevents/update-active-zone-iucn
+    :map/update-active-network            [mevents/update-active-network]
+    :map/update-active-park               [mevents/update-active-park]
+    :map/update-active-zone               [mevents/update-active-zone]
+    :map/update-active-zone-iucn          [mevents/update-active-zone-iucn]
     :map/popup-closed                     mevents/destroy-popup
     :map/toggle-ignore-click              mevents/toggle-ignore-click
     :ui/show-loading                      events/loading-screen

--- a/frontend/src/cljs/imas_seamap/core.cljs
+++ b/frontend/src/cljs/imas_seamap/core.cljs
@@ -107,6 +107,8 @@
     :map/clicked                          [mevents/map-click-dispatcher]
     :map/got-featureinfo                  mevents/got-feature-info
     :map/got-featureinfo-err              mevents/got-feature-info-error
+    :map/get-habitat-statistics           [mevents/get-habitat-statistics]
+    :map/got-habitat-statistics           mevents/got-habitat-statistics
     :map/toggle-layer                     [mevents/toggle-layer]
     :map/toggle-layer-visibility          [mevents/toggle-layer-visibility]
     :map/add-layer                        [mevents/add-layer]

--- a/frontend/src/cljs/imas_seamap/core.cljs
+++ b/frontend/src/cljs/imas_seamap/core.cljs
@@ -37,6 +37,7 @@
     :map/active-park                      msubs/active-park
     :map/active-zone                      msubs/active-zone
     :map/active-zone-iucn                 msubs/active-zone-iucn
+    :map/habitat-statistics               msubs/habitat-statistics
     :map.layers/filter                    msubs/map-layers-filter
     :map.layers/others-filter             msubs/map-other-layers-filter
     :map.layers/priorities                msubs/map-layer-priorities

--- a/frontend/src/cljs/imas_seamap/db.cljs
+++ b/frontend/src/cljs/imas_seamap/db.cljs
@@ -36,7 +36,8 @@
                      :zones           []
                      :active-zone     nil
                      :zones-iucn      []
-                     :active-zone-iucn nil}
+                     :active-zone-iucn nil
+                     :habitat-statistics []}
    :layer-state     {:loading-state {}
                      :tile-count    {}
                      :error-count   {}

--- a/frontend/src/cljs/imas_seamap/db.cljs
+++ b/frontend/src/cljs/imas_seamap/db.cljs
@@ -75,5 +75,6 @@
                      :park-url              (str api-url-base "habitat/parks")
                      :zone-url              (str api-url-base "habitat/zones")
                      :zone-iucn-url         (str api-url-base "habitat/zonesiucn")
+                     :habitat-statistics-url (str api-url-base "habitat/habitatstatistics")
                      :init-catalogue-state  {:tab      "cat"
                                              :expanded #{}}}})

--- a/frontend/src/cljs/imas_seamap/map/events.cljs
+++ b/frontend/src/cljs/imas_seamap/map/events.cljs
@@ -587,7 +587,6 @@
      :dispatch [:map/get-habitat-statistics]}))
 
 (defn get-habitat-statistics [{:keys [db]}]
-  (js/console.log "get-habitat-statistics")
   (let [habitat-statistics-url (get-in db [:config :habitat-statistics-url])
         {:keys [active-network active-park active-zone active-zone-iucn]}                    (:map db)]
    {:db db
@@ -602,6 +601,4 @@
                  :on-failure      [:ajax/default-err-handler]}}))
 
 (defn got-habitat-statistics [db [_ habitat-statistics]]
-  (js/console.log "got-habitat-statistics")
-  (js/console.log habitat-statistics)
-  db)
+  (assoc-in db [:map :habitat-statistics] habitat-statistics))

--- a/frontend/src/cljs/imas_seamap/map/events.cljs
+++ b/frontend/src/cljs/imas_seamap/map/events.cljs
@@ -556,27 +556,35 @@
                  [:ui.catalogue/catalogue-add-nodes-to-layer category layer "cat" [:data_classification]]
                  [:map/pan-to-layer layer]])})
 
-(defn update-active-network [db [_ network]]
-  (if-not (= network (get-in db [:map :active-network]))
-    (-> db
-        (assoc-in [:map :active-park] nil)
-        (assoc-in [:map :active-network] network))
-    db))
+(defn update-active-network [{:keys [db]} [_ network]]
+  (let [db (if-not (= network (get-in db [:map :active-network]))
+             (-> db
+                 (assoc-in [:map :active-park] nil)
+                 (assoc-in [:map :active-network] network))
+             db)]
+    {:db db
+     :dispatch [:map/get-habitat-statistics]}))
 
-(defn update-active-park [{:keys [map] :as db} [_ {:keys [network] :as park}]]
-  (-> db
-      (assoc-in [:map :active-network] (first-where #(= (:name %) network) (:networks map)))
-      (assoc-in [:map :active-park] park)))
+(defn update-active-park [{:keys [db]} [_ {:keys [network] :as park}]]
+  (let [db (-> db
+               (assoc-in [:map :active-network] (first-where #(= (:name %) network) (get-in db [:map :networks])))
+               (assoc-in [:map :active-park] park))]
+    {:db db
+     :dispatch [:map/get-habitat-statistics]}))
 
-(defn update-active-zone [db [_ zone]]
-  (-> db
-      (assoc-in [:map :active-zone] zone)
-      (assoc-in [:map :active-zone-iucn] nil)))
+(defn update-active-zone [{:keys [db]} [_ zone]]
+  (let [db (-> db
+               (assoc-in [:map :active-zone] zone)
+               (assoc-in [:map :active-zone-iucn] nil))]
+    {:db db
+     :dispatch [:map/get-habitat-statistics]}))
 
-(defn update-active-zone-iucn [db [_ zone-iucn]]
-  (-> db
-      (assoc-in [:map :active-zone-iucn] zone-iucn)
-      (assoc-in [:map :active-zone] nil)))
+(defn update-active-zone-iucn [{:keys [db]} [_ zone-iucn]]
+  (let [db (-> db
+               (assoc-in [:map :active-zone-iucn] zone-iucn)
+               (assoc-in [:map :active-zone] nil))]
+    {:db db
+     :dispatch [:map/get-habitat-statistics]}))
 
 (defn get-habitat-statistics [{:keys [db]}]
   (js/console.log "get-habitat-statistics")

--- a/frontend/src/cljs/imas_seamap/map/events.cljs
+++ b/frontend/src/cljs/imas_seamap/map/events.cljs
@@ -577,3 +577,23 @@
   (-> db
       (assoc-in [:map :active-zone-iucn] zone-iucn)
       (assoc-in [:map :active-zone] nil)))
+
+(defn get-habitat-statistics [{:keys [db]}]
+  (js/console.log "get-habitat-statistics")
+  (let [habitat-statistics-url (get-in db [:config :habitat-statistics-url])
+        {:keys [active-network active-park active-zone active-zone-iucn]}                    (:map db)]
+   {:db db
+    :http-xhrio {:method          :get
+                 :uri             habitat-statistics-url
+                 :params          {:network   (:name active-network)
+                                   :park      (:name active-park)
+                                   :zone      (:name active-zone)
+                                   :zone-iucn (:name active-zone-iucn)}
+                 :response-format (ajax/json-response-format {:keywords? true})
+                 :on-success      [:map/got-habitat-statistics]
+                 :on-failure      [:ajax/default-err-handler]}}))
+
+(defn got-habitat-statistics [db [_ habitat-statistics]]
+  (js/console.log "got-habitat-statistics")
+  (js/console.log habitat-statistics)
+  db)

--- a/frontend/src/cljs/imas_seamap/map/events.cljs
+++ b/frontend/src/cljs/imas_seamap/map/events.cljs
@@ -557,11 +557,11 @@
                  [:map/pan-to-layer layer]])})
 
 (defn update-active-network [{:keys [db]} [_ network]]
-  (let [db (if-not (= network (get-in db [:map :active-network]))
-             (-> db
-                 (assoc-in [:map :active-park] nil)
-                 (assoc-in [:map :active-network] network))
-             db)]
+  (let [db (cond-> db
+             (not= network (get-in db [:map :active-network]))
+             (->
+              (assoc-in [:map :active-park] nil)
+              (assoc-in [:map :active-network] network)))]
     {:db db
      :dispatch [:map/get-habitat-statistics]}))
 
@@ -589,8 +589,7 @@
 (defn get-habitat-statistics [{:keys [db]}]
   (let [habitat-statistics-url (get-in db [:config :habitat-statistics-url])
         {:keys [active-network active-park active-zone active-zone-iucn]}                    (:map db)]
-   {:db db
-    :http-xhrio {:method          :get
+   {:http-xhrio {:method          :get
                  :uri             habitat-statistics-url
                  :params          {:network   (:name active-network)
                                    :park      (:name active-park)

--- a/frontend/src/cljs/imas_seamap/map/subs.cljs
+++ b/frontend/src/cljs/imas_seamap/map/subs.cljs
@@ -178,3 +178,6 @@
 
 (defn active-zone-iucn [{:keys [map]}]
   (:active-zone-iucn map))
+
+(defn habitat-statistics [{:keys [map]}]
+  (:habitat-statistics map))

--- a/frontend/src/cljs/imas_seamap/specs/app_state.cljs
+++ b/frontend/src/cljs/imas_seamap/specs/app_state.cljs
@@ -196,6 +196,16 @@
                                   :kind vector?))
 (s/def :map/active-zone-iucn :map/zone-iucn)
 
+(s/def :map.habitat-statistic/habitat (s/nilable string?))
+(s/def :map.habitat-statistic/area number?)
+(s/def :map.habitat-statistic/percentage number?)
+(s/def :map/habitat-statistic
+  (s/keys :req-un [:map.habitat-statistic/habitat
+                   :map.habitat-statistic/area
+                   :map.habitat-statistic/percentage]))
+(s/def :map/habitat-statistics (s/coll-of :map/habitat-statistic
+                                          :kind vector?))
+
 (s/def ::habitat-titles  (s/map-of string? (s/nilable string?)))
 (s/def ::habitat-colours (s/map-of string? string?))
 

--- a/frontend/src/cljs/imas_seamap/views.cljs
+++ b/frontend/src/cljs/imas_seamap/views.cljs
@@ -815,12 +815,17 @@
      [:th "Area"]
      [:th "Percentage"]]]
    [:tbody
-    (for [{:keys [habitat area percentage]} habitat-statistics]
+    (if (seq habitat-statistics)
+     (for [{:keys [habitat area percentage]} habitat-statistics]
       [:tr
        {:key habitat}
        [:td habitat]
        [:td area]
-       [:td percentage]])]])
+       [:td percentage]])
+      [:tr
+       [:td
+        {:colspan 3}
+        "No habitat information"]])]])
 
 (defn right-drawer
   []

--- a/frontend/src/cljs/imas_seamap/views.cljs
+++ b/frontend/src/cljs/imas_seamap/views.cljs
@@ -13,6 +13,8 @@
             [imas-seamap.utils :refer [handler-fn handler-dispatch first-where] :include-macros true]
             [imas-seamap.components :as components]
             [imas-seamap.map.utils :refer [layer-search-keywords]]
+            [goog.string :as gstring]
+            [goog.string.format]
             #_[debux.cs.core :refer [dbg] :include-macros true]))
 
 (defn with-params [url params]
@@ -812,16 +814,16 @@
    [:thead
     [:tr
      [:th "Habitat"]
-     [:th "Area"]
-     [:th "Percentage"]]]
+     [:th "Area (km^2)"]
+     [:th "Percentage (%)"]]]
    [:tbody
     (if (seq habitat-statistics)
      (for [{:keys [habitat area percentage]} habitat-statistics]
       [:tr
        {:key habitat}
-       [:td habitat]
-       [:td area]
-       [:td percentage]])
+       [:td (or habitat "Unmapped")]
+       [:td (gstring/format "%.2f" area)]
+       [:td (gstring/format "%.2f" percentage)]])
       [:tr
        [:td
         {:colspan 3}

--- a/frontend/src/cljs/imas_seamap/views.cljs
+++ b/frontend/src/cljs/imas_seamap/views.cljs
@@ -806,6 +806,22 @@
       :hasBackdrop false}
      [drawer-panel-stack]]))
 
+(defn habitat-statistics-table
+  [{:keys [habitat-statistics]}]
+  [:table
+   [:thead
+    [:tr
+     [:th "Habitat"]
+     [:th "Area"]
+     [:th "Percentage"]]]
+   [:tbody
+    (for [{:keys [habitat area percentage]} habitat-statistics]
+      [:tr
+       {:key habitat}
+       [:td habitat]
+       [:td area]
+       [:td percentage]])]])
+
 (defn right-drawer
   []
   [components/drawer
@@ -851,7 +867,9 @@
       :onChange #(re-frame/dispatch [:map/update-active-zone-iucn %])
       :keyfns
       {:id   :name
-       :text :name}}]]])
+       :text :name}}]]
+   [habitat-statistics-table
+    {:habitat-statistics @(re-frame/subscribe [:map/habitat-statistics])}]])
 
 (defn active-layers-sidebar []
   (let [{:keys [collapsed selected] :as _sidebar-state}                            @(re-frame/subscribe [:ui/sidebar])


### PR DESCRIPTION
[ISA-161](https://jira.its.utas.edu.au/browse/ISA-161)

Can now get and display the habitat statistics for a network or park. Statistics are displayed in a table on the state of knowledge sidebar, like so:
![Screen Shot 2022-06-15 at 11 42 52 am](https://user-images.githubusercontent.com/50224230/173718928-083f48d6-fd6b-4978-8b60-44e180aefafb.png)

Currently does not work for zones. Does not display bathymetry or habitat observations information.