### PR TITLE
Bugfix: (ISA-187) GetFeatureInfo info format request priorities

### DIFF
--- a/frontend/src/cljs/imas_seamap/map/events.cljs
+++ b/frontend/src/cljs/imas_seamap/map/events.cljs
@@ -201,7 +201,7 @@
                  (update-in [:feature-query :response-remain] dec)
                  (update-in [:feature-query :responses] conj {:response response :info-format info-format}))]
 
-      (if (>= 0 (get-in db [:feature-query :response-remain]))
+      (if-not (pos? (get-in db [:feature-query :response-remain]))
         (assoc db :feature (responses-feature-info db point)) ;; If this is the last response expected, update the displayed feature
         db))))
 
@@ -212,7 +212,7 @@
                  (update-in [:feature-query :response-remain] dec)
                  (update-in [:feature-query :responses] conj nil))]
       
-      (if (>= 0 (get-in db [:feature-query :response-remain]))
+      (if-not (pos? (get-in db [:feature-query :response-remain]))
         (assoc db :feature (responses-feature-info db point)) ;; If this is the last response expected, update the displayed feature
         db))))  
 

--- a/frontend/src/cljs/imas_seamap/map/events.cljs
+++ b/frontend/src/cljs/imas_seamap/map/events.cljs
@@ -95,14 +95,14 @@
   (let [{:keys [hidden-layers active-layers]} (:map db)
         visible-layers (remove #((set hidden-layers) %) active-layers)
         secure-layers  (remove #(is-insecure? (:server_url %)) visible-layers)
-        by-server      (group-by :server_url secure-layers)
+        {:keys [valid-layers info-format]} (get-layers-info-format secure-layers)
+        by-server      (group-by :server_url valid-layers)
         ;; Note, we don't use the entire viewport for the pixel bounds because of inaccuracies when zoomed out.
         img-size       {:width 101 :height 101}
         img-bounds     (bounds-for-zoom point size bounds img-size)
         ;; Note, top layer, last in the list, must be first in our search string:
         request-id     (gensym)
         had-insecure?  (some #(is-insecure? (:server_url %)) visible-layers)
-        info-format    (get-layers-info-format secure-layers)
         db             (if had-insecure?
                          (assoc db :feature {:status :feature-info/none-queryable :location point}) ;; This is the fall-through case for "layers are visible, but they're http so we can't query them":
                          (assoc ;; Initialise marshalling-pen of data: how many in flight, and current best-priority response
@@ -119,7 +119,7 @@
         db             (assoc-in db [:feature :status] :feature-info/waiting)]
     (merge
      {:db db}
-     (if info-format
+     (if (seq valid-layers)
        {:http-xhrio (get-feature-info-request info-format request-id by-server img-size img-bounds point)}
        {:dispatch [:map/got-featureinfo request-id point nil nil]}))))
 
@@ -201,7 +201,7 @@
                  (update-in [:feature-query :response-remain] dec)
                  (update-in [:feature-query :responses] conj {:response response :info-format info-format}))]
 
-      (if (zero? (get-in db [:feature-query :response-remain]))
+      (if (>= 0 (get-in db [:feature-query :response-remain]))
         (assoc db :feature (responses-feature-info db point)) ;; If this is the last response expected, update the displayed feature
         db))))
 
@@ -212,7 +212,7 @@
                  (update-in [:feature-query :response-remain] dec)
                  (update-in [:feature-query :responses] conj nil))]
       
-      (if (zero? (get-in db [:feature-query :response-remain]))
+      (if (>= 0 (get-in db [:feature-query :response-remain]))
         (assoc db :feature (responses-feature-info db point)) ;; If this is the last response expected, update the displayed feature
         db))))  
 

--- a/frontend/src/cljs/imas_seamap/map/utils.cljs
+++ b/frontend/src/cljs/imas_seamap/map/utils.cljs
@@ -258,9 +258,10 @@
 
 (defn get-layers-info-format
   [layers]
-  (let [info-formats (map (fn [layer] (:info_format_type layer)) layers)
-        info-format (get info-format (apply max info-formats))]
-    info-format))
+  (let [valid-layers (filter #(get info-format (:info_format_type %)) layers)
+        info-format (get info-format (apply max (map :info_format_type valid-layers)))]
+    {:valid-layers valid-layers
+     :info-format  info-format}))
 
 (defn sort-by-sort-key
   "Sorts a collection by its sort-key first and its id second."


### PR DESCRIPTION
[ISA-187](https://jira.its.utas.edu.au/browse/ISA-187)

Simple fix by filtering out layers without a valid info format from the request (strangely, I thought we'd already done that :-/ ).
Fixed now – sorry about the whole pull request, I thought it'd be bigger than one commit.

I believe this solution also fixes [ISA-188](https://jira.its.utas.edu.au/browse/ISA-188), by skipping those buggy requests.