### PR TITLE
Feature: (ISA-195) State of knowledge floating pills tweaks

### DIFF
--- a/frontend/src/cljs/imas_seamap/components.cljs
+++ b/frontend/src/cljs/imas_seamap/components.cljs
@@ -132,7 +132,7 @@
         :onItemSelect (fn [id] (onItemSelect (:item (first-where #(= (:id %) id) items))))}])))
 
 (defn select
-  [{:keys [value options onChange isSearchable isClearable keyfns]}]
+  [{:keys [value options onChange isSearchable isClearable isDisabled keyfns]}]
   (letfn [(option->select-option
             [option]
             (if-let [{:keys [id text breadcrumbs]} keyfns]
@@ -149,7 +149,8 @@
         :options      options
         :onChange     (fn [id] (onChange (:option (first-where #(= (:id %) id) options))))
         :isSearchable isSearchable
-        :isClearable  isClearable}])))
+        :isClearable  isClearable
+        :isDisabled   isDisabled}])))
 
 (defn form-group
   [{:keys [label]} & children]

--- a/frontend/src/cljs/imas_seamap/components.cljs
+++ b/frontend/src/cljs/imas_seamap/components.cljs
@@ -189,3 +189,9 @@
        {:icon (if collapsed? "plus" "minus")
         :icon-size 20}])]
    (into [:div.drawer-group-content] children)])
+
+(defn breadcrumbs
+  [{:keys [content]}]
+  (let [content (map #(vector :span %) content)
+        content (interpose [b/icon {:icon "caret-right"}] content)]
+    (into [:div.breadcrumbs] content)))

--- a/frontend/src/cljs/imas_seamap/components.cljs
+++ b/frontend/src/cljs/imas_seamap/components.cljs
@@ -132,7 +132,7 @@
         :onItemSelect (fn [id] (onItemSelect (:item (first-where #(= (:id %) id) items))))}])))
 
 (defn select
-  [{:keys [value options onChange keyfns]}]
+  [{:keys [value options onChange isSearchable isClearable keyfns]}]
   (letfn [(option->select-option
             [option]
             (if-let [{:keys [id text breadcrumbs]} keyfns]
@@ -145,9 +145,11 @@
     (let [options (map option->select-option options)
           value   (:id (option->select-option value))]
       [ui-controls/Select
-       {:value    value
-        :options  options
-        :onChange (fn [id] (onChange (:option (first-where #(= (:id %) id) options))))}])))
+       {:value        value
+        :options      options
+        :onChange     (fn [id] (onChange (:option (first-where #(= (:id %) id) options))))
+        :isSearchable isSearchable
+        :isClearable  isClearable}])))
 
 (defn form-group
   [{:keys [label]} & children]

--- a/frontend/src/cljs/imas_seamap/core.cljs
+++ b/frontend/src/cljs/imas_seamap/core.cljs
@@ -186,8 +186,6 @@
     :sok/got-bathymetry-statistics        sokevents/got-bathymetry-statistics
     :sok/get-habitat-observations         [sokevents/get-habitat-observations]
     :sok/got-habitat-observations         sokevents/got-habitat-observations
-    :sok/toggle                           [sokevents/toggle]
-    :sok/open                             sokevents/open
     :sok/close                            [sokevents/close]
     :sok/open-pill                        sokevents/open-pill
     :ui/show-loading                      events/loading-screen

--- a/frontend/src/cljs/imas_seamap/db.cljs
+++ b/frontend/src/cljs/imas_seamap/db.cljs
@@ -58,7 +58,6 @@
                                                             :sediment       nil
                                                             :squidle        nil
                                                             :loading?       false}}
-                        :open?      false
                         :open-pill  nil}
    :layer-state     {:loading-state {}
                      :tile-count    {}

--- a/frontend/src/cljs/imas_seamap/state_of_knowledge/events.cljs
+++ b/frontend/src/cljs/imas_seamap/state_of_knowledge/events.cljs
@@ -65,22 +65,30 @@
              (not= network (get-in db [:state-of-knowledge :boundaries :amp :active-network]))
              (->
               (assoc-in [:state-of-knowledge :boundaries :amp :active-park] nil)
-              (assoc-in [:state-of-knowledge :boundaries :amp :active-network] network)))]
+              (assoc-in [:state-of-knowledge :boundaries :amp :active-network] network)))
+        park? (get-in db [:state-of-knowledge :boundaries :amp :active-park])]
     {:db db
-     :dispatch-n [[:sok/get-habitat-statistics]
-                  [:sok/get-bathymetry-statistics]
-                  [:sok/get-habitat-observations]]}))
+     :dispatch-n (vec
+                  (concat
+                   [[:sok/get-habitat-statistics]
+                    [:sok/get-bathymetry-statistics]
+                    [:sok/get-habitat-observations]]
+                   (when park? [[:sok/open-pill nil]])))}))
 
 (defn update-active-park [{:keys [db]} [_ {:keys [network] :as park}]]
   (let [networks (get-in db [:state-of-knowledge :boundaries :amp :networks])
         network (first-where #(= (:name %) network) networks)
+        old-network? (get-in db [:state-of-knowledge :boundaries :amp :active-network])
         db (-> db
                (assoc-in [:state-of-knowledge :boundaries :amp :active-network] network)
                (assoc-in [:state-of-knowledge :boundaries :amp :active-park] park))]
     {:db db
-     :dispatch-n [[:sok/get-habitat-statistics]
-                  [:sok/get-bathymetry-statistics]
-                  [:sok/get-habitat-observations]]}))
+     :dispatch-n (vec
+                  (concat
+                   [[:sok/get-habitat-statistics]
+                    [:sok/get-bathymetry-statistics]
+                    [:sok/get-habitat-observations]]
+                   (when old-network? [[:sok/open-pill nil]])))}))
 
 (defn update-active-zone [{:keys [db]} [_ zone]]
   (let [db (-> db
@@ -107,22 +115,30 @@
              (not= provincial-bioregion (get-in db [:state-of-knowledge :boundaries :imcra :active-provincial-bioregion]))
              (->
               (assoc-in [:state-of-knowledge :boundaries :imcra :active-mesoscale-bioregion] nil)
-              (assoc-in [:state-of-knowledge :boundaries :imcra :active-provincial-bioregion] provincial-bioregion)))]
+              (assoc-in [:state-of-knowledge :boundaries :imcra :active-provincial-bioregion] provincial-bioregion)))
+        mesoscale-bioregion? (get-in db [:state-of-knowledge :boundaries :imcra :active-mesoscale-bioregion])]
     {:db db
-     :dispatch-n [[:sok/get-habitat-statistics]
-                  [:sok/get-bathymetry-statistics]
-                  [:sok/get-habitat-observations]]}))
+     :dispatch-n (vec
+                  (concat
+                   [[:sok/get-habitat-statistics]
+                    [:sok/get-bathymetry-statistics]
+                    [:sok/get-habitat-observations]]
+                   (when mesoscale-bioregion? [[:sok/open-pill nil]])))}))
 
 (defn update-active-mesoscale-bioregion [{:keys [db]} [_ {:keys [provincial-bioregion] :as mesoscale-bioregion}]]
   (let [provincial-bioregions (get-in db [:state-of-knowledge :boundaries :imcra :provincial-bioregions])
-        provincial-bioregion2 (first-where #(= (:name %) provincial-bioregion) provincial-bioregions)
+        provincial-bioregion (first-where #(= (:name %) provincial-bioregion) provincial-bioregions)
+        old-provincial-bioregion? (get-in db [:state-of-knowledge :boundaries :imcra :active-provincial-bioregion])
         db (-> db
-               (assoc-in [:state-of-knowledge :boundaries :imcra :active-provincial-bioregion] provincial-bioregion2)
+               (assoc-in [:state-of-knowledge :boundaries :imcra :active-provincial-bioregion] provincial-bioregion)
                (assoc-in [:state-of-knowledge :boundaries :imcra :active-mesoscale-bioregion] mesoscale-bioregion))]
     {:db db
-     :dispatch-n [[:sok/get-habitat-statistics]
-                  [:sok/get-bathymetry-statistics]
-                  [:sok/get-habitat-observations]]}))
+     :dispatch-n (vec
+                  (concat
+                   [[:sok/get-habitat-statistics]
+                    [:sok/get-bathymetry-statistics]
+                    [:sok/get-habitat-observations]]
+                   (when old-provincial-bioregion? [[:sok/open-pill nil]])))}))
 
 (defn update-active-realm [{:keys [db]} [_ realm]]
   (let [db (cond-> db
@@ -130,11 +146,15 @@
              (->
               (assoc-in [:state-of-knowledge :boundaries :meow :active-realm] realm)
               (assoc-in [:state-of-knowledge :boundaries :meow :active-province] nil)
-              (assoc-in [:state-of-knowledge :boundaries :meow :active-ecoregion] nil)))]
+              (assoc-in [:state-of-knowledge :boundaries :meow :active-ecoregion] nil)))
+        ecoregion? (get-in db [:state-of-knowledge :boundaries :meow :active-ecoregion])]
     {:db db
-     :dispatch-n [[:sok/get-habitat-statistics]
-                  [:sok/get-bathymetry-statistics]
-                  [:sok/get-habitat-observations]]}))
+     :dispatch-n (vec
+                  (concat
+                   [[:sok/get-habitat-statistics]
+                    [:sok/get-bathymetry-statistics]
+                    [:sok/get-habitat-observations]]
+                   (when ecoregion? [[:sok/open-pill nil]])))}))
 
 (defn update-active-province [{:keys [db]} [_ {:keys [realm] :as province}]]
   (let [realms (get-in db [:state-of-knowledge :boundaries :meow :realms])
@@ -144,24 +164,32 @@
              (->
               (assoc-in [:state-of-knowledge :boundaries :meow :active-realm] realm)
               (assoc-in [:state-of-knowledge :boundaries :meow :active-province] province)
-              (assoc-in [:state-of-knowledge :boundaries :meow :active-ecoregion] nil)))]
+              (assoc-in [:state-of-knowledge :boundaries :meow :active-ecoregion] nil)))
+        ecoregion? (get-in db [:state-of-knowledge :boundaries :meow :active-ecoregion])]
     {:db db
-     :dispatch-n [[:sok/get-habitat-statistics]
-                  [:sok/get-bathymetry-statistics]
-                  [:sok/get-habitat-observations]]}))
+     :dispatch-n (vec
+                  (concat
+                   [[:sok/get-habitat-statistics]
+                    [:sok/get-bathymetry-statistics]
+                    [:sok/get-habitat-observations]]
+                   (when ecoregion? [[:sok/open-pill nil]])))}))
 
 (defn update-active-ecoregion [{:keys [db]} [_ {:keys [realm province] :as ecoregion}]]
   (let [{:keys [realms provinces]} (get-in db [:state-of-knowledge :boundaries :meow])
         realm (first-where #(= (:name %) realm) realms)
         province (first-where #(= (:name %) province) provinces)
+        old-province? (get-in db [:state-of-knowledge :boundaries :meow :active-province])
         db (-> db
                (assoc-in [:state-of-knowledge :boundaries :meow :active-realm] realm)
                (assoc-in [:state-of-knowledge :boundaries :meow :active-province] province)
                (assoc-in [:state-of-knowledge :boundaries :meow :active-ecoregion] ecoregion))]
     {:db db
-     :dispatch-n [[:sok/get-habitat-statistics]
-                  [:sok/get-bathymetry-statistics]
-                  [:sok/get-habitat-observations]]}))
+     :dispatch-n (vec
+                  (concat
+                   [[:sok/get-habitat-statistics]
+                    [:sok/get-bathymetry-statistics]
+                    [:sok/get-habitat-observations]]
+                   (when old-province? [[:sok/open-pill nil]])))}))
 
 (defn reset-active-boundaries [{:keys [db]} _]
   (let [db (-> db

--- a/frontend/src/cljs/imas_seamap/state_of_knowledge/events.cljs
+++ b/frontend/src/cljs/imas_seamap/state_of_knowledge/events.cljs
@@ -199,10 +199,7 @@
           active-provincial-bioregion active-mesoscale-bioregion active-realm
           active-province active-ecoregion])]
     (if
-     (or
-      active-network active-park active-zone active-zone-iucn
-      active-provincial-bioregion active-mesoscale-bioregion active-realm
-      active-province active-ecoregion)
+     active-boundary
       {:db (assoc-in db [:state-of-knowledge :statistics :habitat :loading?] true)
        :http-xhrio {:method          :get
                     :uri             habitat-statistics-url
@@ -219,7 +216,7 @@
                     :response-format (ajax/json-response-format {:keywords? true})
                     :on-success      [:sok/got-habitat-statistics]
                     :on-failure      [:ajax/default-err-handler]}}
-     {:db (assoc-in db [:state-of-knowledge :statistics :habitat :results] [])})))
+      {:db (assoc-in db [:state-of-knowledge :statistics :habitat :results] [])})))
 
 (defn got-habitat-statistics [db [_ habitat-statistics]]
   (-> db
@@ -242,10 +239,7 @@
           active-provincial-bioregion active-mesoscale-bioregion active-realm
           active-province active-ecoregion])]
     (if
-     (or
-      active-network active-park active-zone active-zone-iucn
-      active-provincial-bioregion active-mesoscale-bioregion active-realm
-      active-province active-ecoregion)
+     active-boundary
       {:db (assoc-in db [:state-of-knowledge :statistics :bathymetry :loading?] true)
        :http-xhrio {:method          :get
                     :uri             bathymetry-statistics-url
@@ -285,10 +279,7 @@
           active-provincial-bioregion active-mesoscale-bioregion active-realm
           active-province active-ecoregion])]
     (if
-     (or
-      active-network active-park active-zone active-zone-iucn
-      active-provincial-bioregion active-mesoscale-bioregion active-realm
-      active-province active-ecoregion)
+     active-boundary
       {:db (assoc-in db [:state-of-knowledge :statistics :habitat-observations :loading?] true)
        :http-xhrio {:method          :get
                     :uri             habitat-observations-url

--- a/frontend/src/cljs/imas_seamap/state_of_knowledge/events.cljs
+++ b/frontend/src/cljs/imas_seamap/state_of_knowledge/events.cljs
@@ -317,25 +317,13 @@
       (assoc-in [:state-of-knowledge :statistics :habitat-observations :squidle] squidle)
       (assoc-in [:state-of-knowledge :statistics :habitat-observations :loading?] false)))
 
-(defn open [db _]
-  (-> db
-      (assoc-in [:state-of-knowledge :open?] true)
-      (assoc-in [:state-of-knowledge :open-pill] "state-of-knowledge")))
-
 (defn close [{:keys [db]} _]
-  (let [db (-> db
-               (assoc-in [:state-of-knowledge :open?] false)
-               (assoc-in [:state-of-knowledge :open-pill] nil))]
-    {:db db
-     :dispatch-n [[:sok/update-active-boundary nil]
-                  [:sok/got-habitat-statistics nil]
-                  [:sok/got-bathymetry-statistics nil]
-                  [:sok/got-habitat-observations nil]]}))
-
-(defn toggle [{:keys [db]} _]
-  {:dispatch (if (get-in db [:state-of-knowledge :open?])
-               [:sok/close]
-               [:sok/open])})
+  {:db db
+   :dispatch-n [[:sok/open-pill nil]
+                [:sok/update-active-boundary nil]
+                [:sok/got-habitat-statistics nil]
+                [:sok/got-bathymetry-statistics nil]
+                [:sok/got-habitat-observations nil]]})
 
 (defn open-pill [db [_ pill-id]]
   (assoc-in db [:state-of-knowledge :open-pill] pill-id))

--- a/frontend/src/cljs/imas_seamap/state_of_knowledge/events.cljs
+++ b/frontend/src/cljs/imas_seamap/state_of_knowledge/events.cljs
@@ -55,7 +55,8 @@
                   (concat
                    [[:sok/get-habitat-statistics]
                     [:sok/get-bathymetry-statistics]
-                    [:sok/get-habitat-observations]]
+                    [:sok/get-habitat-observations]
+                    [:sok/open-pill nil]]
                    (when previous-layer [[:map/remove-layer previous-layer]])
                    (when current-layer [[:map/pan-to-layer current-layer]])))}))
 
@@ -88,7 +89,8 @@
     {:db db
      :dispatch-n [[:sok/get-habitat-statistics]
                   [:sok/get-bathymetry-statistics]
-                  [:sok/get-habitat-observations]]}))
+                  [:sok/get-habitat-observations]
+                  [:sok/open-pill nil]]}))
 
 (defn update-active-zone-iucn [{:keys [db]} [_ zone-iucn]]
   (let [db (-> db
@@ -97,7 +99,8 @@
     {:db db
      :dispatch-n [[:sok/get-habitat-statistics]
                   [:sok/get-bathymetry-statistics]
-                  [:sok/get-habitat-observations]]}))
+                  [:sok/get-habitat-observations]
+                  [:sok/open-pill nil]]}))
 
 (defn update-active-provincial-bioregion [{:keys [db]} [_ provincial-bioregion]]
   (let [db (cond-> db

--- a/frontend/src/cljs/imas_seamap/state_of_knowledge/subs.cljs
+++ b/frontend/src/cljs/imas_seamap/state_of_knowledge/subs.cljs
@@ -137,7 +137,7 @@
     (boolean (or active-zone active-zone-iucn)))) ; coerce to boolean to hide implementation
 
 (defn open? [db _]
-  (get-in db [:state-of-knowledge :open?]))
+  (boolean (get-in db [:state-of-knowledge :boundaries :active-boundary])))
 
 (defn open-pill [db _]
   (get-in db [:state-of-knowledge :open-pill]))

--- a/frontend/src/cljs/imas_seamap/state_of_knowledge/views.cljs
+++ b/frontend/src/cljs/imas_seamap/state_of_knowledge/views.cljs
@@ -262,7 +262,7 @@
   [{:keys [expanded? boundaries active-boundary]}]
   [components/floating-pill-control-menu
    (merge
-    {:text           "State of Knowledge"
+    {:text           (or (:name active-boundary) "State of Knowledge")
      :icon           "add-column-right"
      :expanded?      expanded?
      :on-open-click  #(re-frame/dispatch [:sok/open-pill "state-of-knowledge"])
@@ -294,10 +294,25 @@
   (let [amp?   (= (:id active-boundary) "amp")
         imcra? (= (:id active-boundary) "imcra")
         meow?  (= (:id active-boundary) "meow")
-        active-boundaries? @(re-frame/subscribe [:sok/active-boundaries?])]
+        active-boundaries? @(re-frame/subscribe [:sok/active-boundaries?])
+        text (case (:id active-boundary)
+               "amp" (str
+                      (or (:name active-network) "All networks")
+                      " / "
+                      (or (:name active-park) "All parks"))
+               "imcra" (str
+                        (or (:name active-provincial-bioregion) "All provincial bioregions")
+                        " / "
+                        (or (:name active-mesoscale-bioregion) "All mesoscale bioregions"))
+               "meow" (str
+                       (or (:name active-realm) "All realms")
+                       " / "
+                       (or (:name active-province) "All provinces")
+                       " / "
+                       (or (:name active-ecoregion) "All ecoregions")))]
     [components/floating-pill-control-menu
      (merge
-      {:text           "Boundaries"
+      {:text           text
        :icon           "heatmap"
        :expanded?      expanded?
        :on-open-click  #(re-frame/dispatch [:sok/open-pill "boundaries"])
@@ -388,10 +403,11 @@
 
 (defn floating-zones-pill
   [{:keys [expanded? zones zones-iucn active-zone active-zone-iucn]}]
-  (let [active-zones? @(re-frame/subscribe [:sok/active-zones?])]
+  (let [active-zones? @(re-frame/subscribe [:sok/active-zones?])
+        text (or (:name active-zone) (:name active-zone-iucn) "All zones")]
     [components/floating-pill-control-menu
      (merge
-      {:text           "Zones"
+      {:text           text
        :icon           "polygon-filter"
        :expanded?      expanded?
        :on-open-click  #(re-frame/dispatch [:sok/open-pill "zones"])

--- a/frontend/src/cljs/imas_seamap/state_of_knowledge/views.cljs
+++ b/frontend/src/cljs/imas_seamap/state_of_knowledge/views.cljs
@@ -426,7 +426,7 @@
           :text :name}}]]
 
       [components/form-group
-       {:label "IUCN Category (Zone)"}
+       {:label "IUCN Category"}
        [components/select
         {:value    active-zone-iucn
          :options  zones-iucn

--- a/frontend/src/cljs/imas_seamap/state_of_knowledge/views.cljs
+++ b/frontend/src/cljs/imas_seamap/state_of_knowledge/views.cljs
@@ -309,9 +309,11 @@
     [components/form-group
      {:label "Management Region"}
      [components/select
-      {:value    active-boundary
-       :options  boundaries
-       :onChange #(re-frame/dispatch [:sok/update-active-boundary %])
+      {:value        active-boundary
+       :options      boundaries
+       :onChange     #(re-frame/dispatch [:sok/update-active-boundary %])
+       :isSearchable true
+       :isClearable  true
        :keyfns
        {:id   :id
         :text :name}}]]]])
@@ -355,9 +357,11 @@
         [components/form-group
          {:label "Network"}
          [components/select
-          {:value    active-network
-           :options  networks
-           :onChange #(re-frame/dispatch [:sok/update-active-network %])
+          {:value        active-network
+           :options      networks
+           :onChange     #(re-frame/dispatch [:sok/update-active-network %])
+           :isSearchable true
+           :isClearable  true
            :keyfns
            {:id   :name
             :text :name}}]])
@@ -366,9 +370,11 @@
         [components/form-group
          {:label "Park"}
          [components/select
-          {:value    active-park
-           :options  parks
-           :onChange #(re-frame/dispatch [:sok/update-active-park %])
+          {:value        active-park
+           :options      parks
+           :onChange     #(re-frame/dispatch [:sok/update-active-park %])
+           :isSearchable true
+           :isClearable  true
            :keyfns
            {:id          :name
             :text        :name
@@ -378,9 +384,11 @@
         [components/form-group
          {:label "Provincial Bioregion"}
          [components/select
-          {:value    active-provincial-bioregion
-           :options  provincial-bioregions
-           :onChange #(re-frame/dispatch [:sok/update-active-provincial-bioregion %])
+          {:value        active-provincial-bioregion
+           :options      provincial-bioregions
+           :onChange     #(re-frame/dispatch [:sok/update-active-provincial-bioregion %])
+           :isSearchable true
+           :isClearable  true
            :keyfns
            {:id   :name
             :text :name}}]])
@@ -389,9 +397,11 @@
         [components/form-group
          {:label "Mesoscale Bioregion"}
          [components/select
-          {:value    active-mesoscale-bioregion
-           :options  mesoscale-bioregions
-           :onChange #(re-frame/dispatch [:sok/update-active-mesoscale-bioregion %])
+          {:value        active-mesoscale-bioregion
+           :options      mesoscale-bioregions
+           :onChange     #(re-frame/dispatch [:sok/update-active-mesoscale-bioregion %])
+           :isSearchable true
+           :isClearable  true
            :keyfns
            {:id          :name
             :text        :name
@@ -401,9 +411,11 @@
         [components/form-group
          {:label "Realms"}
          [components/select
-          {:value    active-realm
-           :options  realms
-           :onChange #(re-frame/dispatch [:sok/update-active-realm %])
+          {:value        active-realm
+           :options      realms
+           :onChange     #(re-frame/dispatch [:sok/update-active-realm %])
+           :isSearchable true
+           :isClearable  true
            :keyfns
            {:id   :name
             :text :name}}]])
@@ -412,9 +424,11 @@
         [components/form-group
          {:label "Provinces"}
          [components/select
-          {:value    active-province
-           :options  provinces
-           :onChange #(re-frame/dispatch [:sok/update-active-province %])
+          {:value        active-province
+           :options      provinces
+           :onChange     #(re-frame/dispatch [:sok/update-active-province %])
+           :isSearchable true
+           :isClearable  true
            :keyfns
            {:id          :name
             :text        :name
@@ -424,9 +438,11 @@
         [components/form-group
          {:label "Ecoregions"}
          [components/select
-          {:value    active-ecoregion
-           :options  ecoregions
-           :onChange #(re-frame/dispatch [:sok/update-active-ecoregion %])
+          {:value        active-ecoregion
+           :options      ecoregions
+           :onChange     #(re-frame/dispatch [:sok/update-active-ecoregion %])
+           :isSearchable true
+           :isClearable  true
            :keyfns
            {:id          :name
             :text        :name
@@ -449,9 +465,11 @@
       [components/form-group
        {:label "Zone Category"}
        [components/select
-        {:value    active-zone
-         :options  zones
-         :onChange #(re-frame/dispatch [:sok/update-active-zone %])
+        {:value        active-zone
+         :options      zones
+         :onChange     #(re-frame/dispatch [:sok/update-active-zone %])
+         :isSearchable true
+         :isClearable  true
          :keyfns
          {:id   :name
           :text :name}}]]
@@ -459,9 +477,11 @@
       [components/form-group
        {:label "IUCN Category"}
        [components/select
-        {:value    active-zone-iucn
-         :options  zones-iucn
-         :onChange #(re-frame/dispatch [:sok/update-active-zone-iucn %])
+        {:value        active-zone-iucn
+         :options      zones-iucn
+         :onChange     #(re-frame/dispatch [:sok/update-active-zone-iucn %])
+         :isSearchable true
+         :isClearable  true
          :keyfns
          {:id   :name
           :text :name}}]]]]))

--- a/frontend/src/cljs/imas_seamap/state_of_knowledge/views.cljs
+++ b/frontend/src/cljs/imas_seamap/state_of_knowledge/views.cljs
@@ -470,6 +470,7 @@
          :onChange     #(re-frame/dispatch [:sok/update-active-zone %])
          :isSearchable true
          :isClearable  true
+         :isDisabled   active-zone-iucn
          :keyfns
          {:id   :name
           :text :name}}]]
@@ -482,6 +483,7 @@
          :onChange     #(re-frame/dispatch [:sok/update-active-zone-iucn %])
          :isSearchable true
          :isClearable  true
+         :isDisabled   active-zone
          :keyfns
          {:id   :name
           :text :name}}]]]]))

--- a/frontend/src/cljs/imas_seamap/state_of_knowledge/views.cljs
+++ b/frontend/src/cljs/imas_seamap/state_of_knowledge/views.cljs
@@ -263,15 +263,9 @@
                                     :target "_blank"}
                                    (:name active-park)]])
                                (when active-zone
-                                 [[:a
-                                   {:href   "https://blueprintjs.com/" ; Placeholder URL
-                                    :target "_blank"}
-                                   (:name active-zone)]])
+                                 [(:name active-zone)])
                                (when active-zone-iucn
-                                 [[:a
-                                   {:href   "https://blueprintjs.com/" ; Placeholder URL
-                                    :target "_blank"}
-                                   (:name active-zone-iucn)]]))
+                                 [(:name active-zone-iucn)]))
                       "imcra" (concat
                                (when active-provincial-bioregion [(:name active-provincial-bioregion)])
                                (when active-mesoscale-bioregion [(:name active-mesoscale-bioregion)]))
@@ -281,7 +275,7 @@
                                (when active-ecoregion [(:name active-ecoregion)]))
                       nil)]
     [:div.selected-boundaries
-     [:h1.bp3-heading (:name active-boundary)]
+     [:h2.bp3-heading (:name active-boundary)]
      (when (seq breadcrumbs)
        [components/breadcrumbs
         {:content breadcrumbs}])]))

--- a/frontend/src/cljs/imas_seamap/state_of_knowledge/views.cljs
+++ b/frontend/src/cljs/imas_seamap/state_of_knowledge/views.cljs
@@ -245,6 +245,31 @@
             [global-archive-stats global-archive]
             [sediment-stats sediment]])]))))
 
+(defn selected-boundaries []
+  (let [active-boundary @(re-frame/subscribe [:sok/active-boundary])
+        {:keys [active-network active-park active-zone active-zone-iucn]} @(re-frame/subscribe [:sok/valid-amp-boundaries])
+        {:keys [active-provincial-bioregion active-mesoscale-bioregion]}  @(re-frame/subscribe [:sok/valid-imcra-boundaries])
+        {:keys [active-realm active-province active-ecoregion]}           @(re-frame/subscribe [:sok/valid-meow-boundaries])
+        breadcrumbs (case (:id active-boundary)
+                      "amp"   (concat
+                               (when active-network [(:name active-network)])
+                               (when active-park [(:name active-park)])
+                               (when active-zone [(:name active-zone)])
+                               (when active-zone-iucn [(:name active-zone-iucn)]))
+                      "imcra" (concat
+                               (when active-provincial-bioregion [(:name active-provincial-bioregion)])
+                               (when active-mesoscale-bioregion [(:name active-mesoscale-bioregion)]))
+                      "meow"  (concat
+                               (when active-realm [(:name active-realm)])
+                               (when active-province [(:name active-province)])
+                               (when active-ecoregion [(:name active-ecoregion)]))
+                      nil)]
+    [:div.selected-boundaries
+     [:h1.bp3-heading (:name active-boundary)]
+     (when (seq breadcrumbs)
+       [components/breadcrumbs
+        {:content breadcrumbs}])]))
+
 (defn state-of-knowledge []
   [components/drawer
    {:title       "State of Knowledge"
@@ -254,6 +279,7 @@
     :onClose     #(re-frame/dispatch [:sok/close])
     :hasBackdrop false
     :className   "state-of-knowledge-drawer"}
+   [selected-boundaries]
    [habitat-statistics]
    [bathymetry-statistics]
    [habitat-observations]])

--- a/frontend/src/cljs/imas_seamap/state_of_knowledge/views.cljs
+++ b/frontend/src/cljs/imas_seamap/state_of_knowledge/views.cljs
@@ -265,7 +265,7 @@
     {:text           "State of Knowledge"
      :icon           "add-column-right"
      :expanded?      expanded?
-     :on-open-click  #(re-frame/dispatch [:sok/open])
+     :on-open-click  #(re-frame/dispatch [:sok/open-pill "state-of-knowledge"])
      :on-close-click #(re-frame/dispatch [:sok/open-pill nil])}
     (when active-boundary {:reset-click #(re-frame/dispatch [:sok/update-active-boundary nil])}))
    [:div.state-of-knowledge-pill-content

--- a/frontend/src/cljs/imas_seamap/state_of_knowledge/views.cljs
+++ b/frontend/src/cljs/imas_seamap/state_of_knowledge/views.cljs
@@ -252,10 +252,26 @@
         {:keys [active-realm active-province active-ecoregion]}           @(re-frame/subscribe [:sok/valid-meow-boundaries])
         breadcrumbs (case (:id active-boundary)
                       "amp"   (concat
-                               (when active-network [(:name active-network)])
-                               (when active-park [(:name active-park)])
-                               (when active-zone [(:name active-zone)])
-                               (when active-zone-iucn [(:name active-zone-iucn)]))
+                               (when active-network
+                                 [[:a
+                                   {:href   "https://blueprintjs.com/" ; Placeholder URL
+                                    :target "_blank"}
+                                   (:name active-network)]])
+                               (when active-park
+                                 [[:a
+                                   {:href   "https://blueprintjs.com/" ; Placeholder URL
+                                    :target "_blank"}
+                                   (:name active-park)]])
+                               (when active-zone
+                                 [[:a
+                                   {:href   "https://blueprintjs.com/" ; Placeholder URL
+                                    :target "_blank"}
+                                   (:name active-zone)]])
+                               (when active-zone-iucn
+                                 [[:a
+                                   {:href   "https://blueprintjs.com/" ; Placeholder URL
+                                    :target "_blank"}
+                                   (:name active-zone-iucn)]]))
                       "imcra" (concat
                                (when active-provincial-bioregion [(:name active-provincial-bioregion)])
                                (when active-mesoscale-bioregion [(:name active-mesoscale-bioregion)]))
@@ -304,12 +320,7 @@
        :onChange #(re-frame/dispatch [:sok/update-active-boundary %])
        :keyfns
        {:id   :id
-        :text :name}}]]
-    
-    [:a.data-coverage-report-link
-     {:href   "https://blueprintjs.com/" ; Placeholder URL
-      :target "_blank"}
-     "View data coverage report"]]])
+        :text :name}}]]]])
 
 (defn floating-boundaries-pill
   [{:keys

--- a/frontend/src/cljs/imas_seamap/views.cljs
+++ b/frontend/src/cljs/imas_seamap/views.cljs
@@ -869,9 +869,6 @@
        {:label "Toggle Left Drawer"     :combo "a"}
        [:left-drawer/toggle])
       (keydown-wrapper
-       {:label "Toggle State of Knowledge"    :combo "d"}
-       [:sok/toggle])
-      (keydown-wrapper
        {:label "Toggle Layers Search"   :combo "shift + s"}
        [:layers-search-omnibar/toggle])
       (keydown-wrapper

--- a/frontend/src/ui/Select/Select.jsx
+++ b/frontend/src/ui/Select/Select.jsx
@@ -40,10 +40,15 @@ export function Select({value, options, onChange, isSearchable, isClearable}) {
 			isClearable={isClearable}
 			filterOption={(option, inputValue) => {
 				inputValue = inputValue.toLowerCase();
-				const breadcrumbContains = option.data.breadcrumbs.map(e => e.toLowerCase().includes(inputValue)).reduce(
-					(e1, e2) => e1 || e2
-				);
-				return option.data.text.toLowerCase().includes(inputValue) || breadcrumbContains;
+
+				if (breadcrumbs) {
+					const breadcrumbContains = option.data.breadcrumbs.map(e => e.toLowerCase().includes(inputValue)).reduce(
+						(e1, e2) => e1 || e2
+					);
+					return option.data.text.toLowerCase().includes(inputValue) || breadcrumbContains;
+				} else {
+					return option.data.text.toLowerCase().includes(inputValue);
+				}
 			}}
 			formatOptionLabel={ItemRenderer}
 			onChange={e => onChange(e ? e.id : e)}

--- a/frontend/src/ui/Select/Select.jsx
+++ b/frontend/src/ui/Select/Select.jsx
@@ -58,5 +58,7 @@ Select.propTypes = {
 		text: PropTypes.string.isRequired,
 		breadcrumbs: PropTypes.arrayOf(PropTypes.string)
 	})).isRequired,
-	onChange: PropTypes.func.isRequired
+	onChange: PropTypes.func.isRequired,
+	isSearchable: PropTypes.bool,
+	isClearable: PropTypes.bool
 }

--- a/frontend/src/ui/Select/Select.jsx
+++ b/frontend/src/ui/Select/Select.jsx
@@ -30,15 +30,23 @@ function ItemRenderer({id, text, breadcrumbs}, {selectValue}) {
 	);
 }
 
-export function Select({value, options, onChange}) {
+export function Select({value, options, onChange, isSearchable, isClearable}) {
 	return (
 		<ReactSelect
 			value={options.filter(({id}) => id == value)}
 			options={options}
 			getOptionValue={({id})=> id}
-			isSearchable={false}
+			isSearchable={isSearchable}
+			isClearable={isClearable}
+			filterOption={(option, inputValue) => {
+				inputValue = inputValue.toLowerCase();
+				const breadcrumbContains = option.data.breadcrumbs.map(e => e.toLowerCase().includes(inputValue)).reduce(
+					(e1, e2) => e1 || e2
+				);
+				return option.data.text.toLowerCase().includes(inputValue) || breadcrumbContains;
+			}}
 			formatOptionLabel={ItemRenderer}
-			onChange={({id}) => onChange(id)}
+			onChange={e => onChange(e ? e.id : e)}
 		/>
 	);
 }

--- a/frontend/src/ui/Select/Select.jsx
+++ b/frontend/src/ui/Select/Select.jsx
@@ -41,7 +41,7 @@ export function Select({value, options, onChange, isSearchable, isClearable}) {
 			filterOption={(option, inputValue) => {
 				inputValue = inputValue.toLowerCase();
 
-				if (breadcrumbs) {
+				if (option.data.breadcrumbs) {
 					const breadcrumbContains = option.data.breadcrumbs.map(e => e.toLowerCase().includes(inputValue)).reduce(
 						(e1, e2) => e1 || e2
 					);

--- a/frontend/src/ui/Select/Select.jsx
+++ b/frontend/src/ui/Select/Select.jsx
@@ -30,7 +30,7 @@ function ItemRenderer({id, text, breadcrumbs}, {selectValue}) {
 	);
 }
 
-export function Select({value, options, onChange, isSearchable, isClearable}) {
+export function Select({value, options, onChange, isSearchable, isClearable, isDisabled}) {
 	return (
 		<ReactSelect
 			value={options.filter(({id}) => id == value)}
@@ -38,6 +38,7 @@ export function Select({value, options, onChange, isSearchable, isClearable}) {
 			getOptionValue={({id})=> id}
 			isSearchable={isSearchable}
 			isClearable={isClearable}
+			isDisabled={isDisabled}
 			filterOption={(option, inputValue) => {
 				inputValue = inputValue.toLowerCase();
 
@@ -65,5 +66,6 @@ Select.propTypes = {
 	})).isRequired,
 	onChange: PropTypes.func.isRequired,
 	isSearchable: PropTypes.bool,
-	isClearable: PropTypes.bool
+	isClearable: PropTypes.bool,
+	isDisabled: PropTypes.bool
 }

--- a/frontend/src/ui/Select/Select.stories.jsx
+++ b/frontend/src/ui/Select/Select.stories.jsx
@@ -39,6 +39,7 @@ const FieldTemplate = (args) => {
 			onChange={setValue}
 			isSearchable={true}
 			isClearable={true}
+			isDisabled={false}
 		/>
 	);
 }

--- a/frontend/src/ui/Select/Select.stories.jsx
+++ b/frontend/src/ui/Select/Select.stories.jsx
@@ -37,6 +37,8 @@ const FieldTemplate = (args) => {
 			value={value}
 			options={options}
 			onChange={setValue}
+			isSearchable={true}
+			isClearable={true}
 		/>
 	);
 }

--- a/frontend/src/ui/css/app.scss
+++ b/frontend/src/ui/css/app.scss
@@ -700,7 +700,6 @@ input.leaflet-control-layers-selector[type="radio"] {
     margin-top: 8px;
 }
 
-.data-coverage-report-link,
 .drawer-group .download {
     font-weight: bold;
     color: #0078A8;

--- a/frontend/src/ui/css/floating-pills.scss
+++ b/frontend/src/ui/css/floating-pills.scss
@@ -58,6 +58,10 @@ $floating-pill-height: 36px;
 	background-color: #eff4ff;
 }
 
+.floating-pill-control-menu-button.reset-click:hover {
+	background-color: #e9eef8;
+}
+
 .floating-pill-control-menu-button.reset-click > button:last-child {
 	margin-right: -5px;
 }

--- a/frontend/src/ui/css/state-of-knowledge.scss
+++ b/frontend/src/ui/css/state-of-knowledge.scss
@@ -74,3 +74,25 @@
 .bp3-overlay-start-focus-trap.bp3-overlay-enter-done {
     display: none;
 }
+
+.selected-boundaries {
+    margin-bottom: 20px;
+}
+
+.selected-boundaries h2.bp3-heading {
+    font-size: 16px;
+    margin: 0 0 0 12px;
+}
+
+.selected-boundaries .breadcrumbs {
+    margin: 0 12px;
+}
+
+.selected-boundaries .breadcrumbs {
+    margin: 0 12px;
+}
+
+.selected-boundaries .breadcrumbs a {
+    color: #106ba3;
+    text-decoration: underline;
+}


### PR DESCRIPTION
Several usability tweaks to the state of knowledge floating pills:
 • State of knowledge panel now only opens when a boundary type has been selected
 • State of knowledge statistics are shown for the entire region (all boundaries), when no filters are selected
 • Floating pill titles show the filters selected in that pill
 • Pills automatically close on special logic, specific to each pill (pills 1 and 3 close when a single selection is made, and pill 2 closes when all selections are made).
 • "IUCN Category (Zone)" -> "IUCN Category"
 • Currently selected boundaries are shown in the state of knowledge panel
     ◦ New breadcrumbs component to accomplish this
     ◦ Network and park breadcrumbs have placeholder hyperlinks for their data coverage report pages
 • The select fields for selecting the boundary type and boundaries now have several new usability features
     ◦ Ability to clear selected item
     ◦ Type search text to filter items from list
 • Zone select fields are now disabled when other zone type has a value

![Screen Shot 2022-07-26 at 12 53 35 pm](https://user-images.githubusercontent.com/50224230/180913496-5aebcb23-eca4-4f0d-b784-f7ae10ecf846.png)
