### PR TITLE
Feature: (ISA-205) State of knowledge boundary CQL filters

### DIFF
--- a/frontend/src/cljs/imas_seamap/core.cljs
+++ b/frontend/src/cljs/imas_seamap/core.cljs
@@ -169,6 +169,7 @@
     :sok/update-amp-boundaries            sokevents/update-amp-boundaries
     :sok/update-imcra-boundaries          sokevents/update-imcra-boundaries
     :sok/update-meow-boundaries           sokevents/update-meow-boundaries
+    :sok/update-active-boundary-layer     [sokevents/update-active-boundary-layer]
     :sok/update-active-boundary           [sokevents/update-active-boundary]
     :sok/update-active-network            [sokevents/update-active-network]
     :sok/update-active-park               [sokevents/update-active-park]

--- a/frontend/src/cljs/imas_seamap/core.cljs
+++ b/frontend/src/cljs/imas_seamap/core.cljs
@@ -59,6 +59,7 @@
     :sok/active-zones?                    soksubs/active-zones?
     :sok/open?                            soksubs/open?
     :sok/open-pill                        soksubs/open-pill
+    :sok/boundary-layer-filter            soksubs/boundary-layer-filter-fn
     :sorting/info                         subs/sorting-info
     :download/info                        subs/download-info
     :transect/info                        subs/transect-info

--- a/frontend/src/cljs/imas_seamap/db.cljs
+++ b/frontend/src/cljs/imas_seamap/db.cljs
@@ -32,6 +32,7 @@
                      :controls        {:transect false
                                        :download nil}}
    :state-of-knowledge {:boundaries {:active-boundary nil
+                                     :active-boundary-layer nil
                                      :amp             {:networks         []
                                                        :parks            []
                                                        :zones            []

--- a/frontend/src/cljs/imas_seamap/map/views.cljs
+++ b/frontend/src/cljs/imas_seamap/map/views.cljs
@@ -164,6 +164,7 @@
         download-info                                 @(re-frame/subscribe [:download/info])
         layer-priorities                              @(re-frame/subscribe [:map.layers/priorities])
         ;layer-params                                  @(re-frame/subscribe [:map.layers/params])
+        boundary-filter                               @(re-frame/subscribe [:sok/boundary-layer-filter])
         logic-type                                    @(re-frame/subscribe [:map.layers/logic])
         loading?                                      @(re-frame/subscribe [:app/loading?])]
     (into
@@ -231,7 +232,8 @@
              :opacity          (/ (layer-opacities layer) 100)
              :tiled            true
              :format           "image/png"}
-            (when style {:styles style}))])
+            (when style {:styles style})
+            (boundary-filter layer))])
         (concat (:layers active-base-layer) visible-layers))
        (when query
          [leaflet/geojson-layer {:data (clj->js query)}])

--- a/frontend/src/cljs/imas_seamap/map/views.cljs
+++ b/frontend/src/cljs/imas_seamap/map/views.cljs
@@ -218,7 +218,7 @@
       ;; then orders in the map by update not by list):
        (map-indexed
         (fn [i {:keys [server_url layer_name style id] :as layer}]
-          ^{:key (str id)}
+          ^{:key (str id (boundary-filter layer))}
           [leaflet/wms-layer
            (merge
             {:url              server_url

--- a/frontend/src/cljs/imas_seamap/specs/app_state.cljs
+++ b/frontend/src/cljs/imas_seamap/specs/app_state.cljs
@@ -256,6 +256,8 @@
    (s/keys :req-un [:state-of-knowledge.boundaries.active-boundary/id
                     :state-of-knowledge.boundaries.active-boundary/name])))
 
+(s/def :state-of-knowledge.boundaries/active-boundary-layer (s/nilable :map/layer))
+
 (s/def :state-of-knowledge.boundaries.amp.network/name string?)
 (s/def :state-of-knowledge.boundaries.amp.park/name string?)
 (s/def :state-of-knowledge.boundaries.amp.park/network :state-of-knowledge.boundaries.amp.network/name)
@@ -352,6 +354,7 @@
 
 (s/def :state-of-knowledge/boundaries
   (s/keys :req-un [:state-of-knowledge.boundaries/active-boundary
+                   :state-of-knowledge.boundaries/active-boundary-layer
                    :state-of-knowledge.boundaries/amp
                    :state-of-knowledge.boundaries/imcra
                    :state-of-knowledge.boundaries/meow]))

--- a/frontend/src/cljs/imas_seamap/state_of_knowledge/events.cljs
+++ b/frontend/src/cljs/imas_seamap/state_of_knowledge/events.cljs
@@ -60,7 +60,6 @@
         current-boundary-layer  (select-boundary-layer layers active-boundary (get-in db [:state-of-knowledge :boundaries]))
 
         db                      (assoc-in db [:state-of-knowledge :boundaries :active-boundary-layer] current-boundary-layer)]
-    (js/console.warn pan?)
     {:db db
      :dispatch-n [(when previous-boundary-layer [:map/remove-layer previous-boundary-layer])
                   (when current-boundary-layer

--- a/frontend/src/cljs/imas_seamap/state_of_knowledge/events.cljs
+++ b/frontend/src/cljs/imas_seamap/state_of_knowledge/events.cljs
@@ -99,7 +99,8 @@
               (assoc-in [:state-of-knowledge :boundaries :amp :active-network] network)))
         park (get-in db [:state-of-knowledge :boundaries :amp :active-park])]
     {:db db
-     :dispatch-n [[:sok/get-habitat-statistics]
+     :dispatch-n [[:sok/update-active-boundary-layer]
+                  [:sok/get-habitat-statistics]
                   [:sok/get-bathymetry-statistics]
                   [:sok/get-habitat-observations]
                   (when (and network park) [:sok/open-pill nil])]}))
@@ -114,7 +115,8 @@
                (assoc-in [:state-of-knowledge :boundaries :amp :active-network] network)
                (assoc-in [:state-of-knowledge :boundaries :amp :active-park] park))]
     {:db db
-     :dispatch-n [[:sok/get-habitat-statistics]
+     :dispatch-n [[:sok/update-active-boundary-layer]
+                  [:sok/get-habitat-statistics]
                   [:sok/get-bathymetry-statistics]
                   [:sok/get-habitat-observations]
                   (when (and park old-network) [:sok/open-pill nil])]}))
@@ -124,7 +126,8 @@
                (assoc-in [:state-of-knowledge :boundaries :amp :active-zone] zone)
                (assoc-in [:state-of-knowledge :boundaries :amp :active-zone-iucn] nil))]
     {:db db
-     :dispatch-n [[:sok/get-habitat-statistics]
+     :dispatch-n [[:sok/update-active-boundary-layer]
+                  [:sok/get-habitat-statistics]
                   [:sok/get-bathymetry-statistics]
                   [:sok/get-habitat-observations]
                   (when zone [:sok/open-pill nil])]}))
@@ -134,7 +137,8 @@
                (assoc-in [:state-of-knowledge :boundaries :amp :active-zone-iucn] zone-iucn)
                (assoc-in [:state-of-knowledge :boundaries :amp :active-zone] nil))]
     {:db db
-     :dispatch-n [[:sok/get-habitat-statistics]
+     :dispatch-n [[:sok/update-active-boundary-layer]
+                  [:sok/get-habitat-statistics]
                   [:sok/get-bathymetry-statistics]
                   [:sok/get-habitat-observations]
                   (when zone-iucn [:sok/open-pill nil])]}))
@@ -147,7 +151,8 @@
               (assoc-in [:state-of-knowledge :boundaries :imcra :active-provincial-bioregion] provincial-bioregion)))
         mesoscale-bioregion (get-in db [:state-of-knowledge :boundaries :imcra :active-mesoscale-bioregion])]
     {:db db
-     :dispatch-n [[:sok/get-habitat-statistics]
+     :dispatch-n [[:sok/update-active-boundary-layer]
+                  [:sok/get-habitat-statistics]
                   [:sok/get-bathymetry-statistics]
                   [:sok/get-habitat-observations]
                   (when (and provincial-bioregion mesoscale-bioregion) [:sok/open-pill nil])]}))
@@ -162,7 +167,8 @@
                (assoc-in [:state-of-knowledge :boundaries :imcra :active-provincial-bioregion] provincial-bioregion)
                (assoc-in [:state-of-knowledge :boundaries :imcra :active-mesoscale-bioregion] mesoscale-bioregion))]
     {:db db
-     :dispatch-n [[:sok/get-habitat-statistics]
+     :dispatch-n [[:sok/update-active-boundary-layer]
+                  [:sok/get-habitat-statistics]
                   [:sok/get-bathymetry-statistics]
                   [:sok/get-habitat-observations]
                   (when (and mesoscale-bioregion old-provincial-bioregion) [:sok/open-pill nil])]}))
@@ -176,7 +182,8 @@
               (assoc-in [:state-of-knowledge :boundaries :meow :active-ecoregion] nil)))
         ecoregion (get-in db [:state-of-knowledge :boundaries :meow :active-ecoregion])]
     {:db db
-     :dispatch-n [[:sok/get-habitat-statistics]
+     :dispatch-n [[:sok/update-active-boundary-layer]
+                  [:sok/get-habitat-statistics]
                   [:sok/get-bathymetry-statistics]
                   [:sok/get-habitat-observations]
                   (when (and realm ecoregion) [:sok/open-pill nil])]}))
@@ -195,7 +202,8 @@
               (assoc-in [:state-of-knowledge :boundaries :meow :active-ecoregion] nil)))
         ecoregion (get-in db [:state-of-knowledge :boundaries :meow :active-ecoregion])]
     {:db db
-     :dispatch-n [[:sok/get-habitat-statistics]
+     :dispatch-n [[:sok/update-active-boundary-layer]
+                  [:sok/get-habitat-statistics]
                   [:sok/get-bathymetry-statistics]
                   [:sok/get-habitat-observations]
                   (when (and province ecoregion) [:sok/open-pill nil])]}))
@@ -215,7 +223,8 @@
                (assoc-in [:state-of-knowledge :boundaries :meow :active-province] province)
                (assoc-in [:state-of-knowledge :boundaries :meow :active-ecoregion] ecoregion))]
     {:db db
-     :dispatch-n [[:sok/get-habitat-statistics]
+     :dispatch-n [[:sok/update-active-boundary-layer]
+                  [:sok/get-habitat-statistics]
                   [:sok/get-bathymetry-statistics]
                   [:sok/get-habitat-observations]
                   (when (and ecoregion old-province) [:sok/open-pill nil])]}))
@@ -230,7 +239,8 @@
                (assoc-in [:state-of-knowledge :boundaries :meow :active-province] nil)
                (assoc-in [:state-of-knowledge :boundaries :meow :active-ecoregion] nil))]
     {:db db
-     :dispatch-n [[:sok/get-habitat-statistics]
+     :dispatch-n [[:sok/update-active-boundary-layer]
+                  [:sok/get-habitat-statistics]
                   [:sok/get-bathymetry-statistics]
                   [:sok/get-habitat-observations]]}))
 
@@ -239,7 +249,8 @@
                (assoc-in [:state-of-knowledge :boundaries :amp :active-zone] nil)
                (assoc-in [:state-of-knowledge :boundaries :amp :active-zone-iucn] nil))]
     {:db db
-     :dispatch-n [[:sok/get-habitat-statistics]
+     :dispatch-n [[:sok/update-active-boundary-layer]
+                  [:sok/get-habitat-statistics]
                   [:sok/get-bathymetry-statistics]
                   [:sok/get-habitat-observations]]}))
 

--- a/frontend/src/cljs/imas_seamap/state_of_knowledge/events.cljs
+++ b/frontend/src/cljs/imas_seamap/state_of_knowledge/events.cljs
@@ -25,6 +25,32 @@
       (assoc-in [:state-of-knowledge :boundaries :meow :provinces] provinces)
       (assoc-in [:state-of-knowledge :boundaries :meow :ecoregions] ecoregions)))
 
+(defn- select-boundary-layer
+  "Based on the currently active boundary and boundary filters, select an
+   appropriate boundary layer."
+  [layers {boundary-id :id} {:keys [amp imcra meow] :as _boundaries}]
+  (let [{:keys [active-park active-zone active-zone-iucn]} amp
+        {:keys [active-mesoscale-bioregion]} imcra
+        {:keys [active-province active-ecoregion]} meow
+
+        layer-id (case boundary-id
+                   
+                   "amp"   (cond
+                             (or active-zone active-zone-iucn) 1520
+                             active-park                       1569
+                             :else                             1567)
+
+                   "imcra" (cond
+                             active-mesoscale-bioregion 1500
+                             :else                      182)
+
+                   "meow"  (cond
+                             (or active-province active-ecoregion) 189
+                             :else                                 181)
+
+                   nil)]
+    (first-where #(= (:id %) layer-id) layers)))
+
 (defn update-active-boundary [{:keys [db]} [_ active-boundary]]
   (let [previous-boundary (get-in db [:state-of-knowledge :boundaries :active-boundary])
         db (-> db

--- a/frontend/src/cljs/imas_seamap/state_of_knowledge/events.cljs
+++ b/frontend/src/cljs/imas_seamap/state_of_knowledge/events.cljs
@@ -4,7 +4,8 @@
 (ns imas-seamap.state-of-knowledge.events
   (:require [clojure.set :refer [rename-keys]]
             [ajax.core :as ajax]
-            [imas-seamap.utils :refer [first-where]]))
+            [imas-seamap.utils :refer [first-where]]
+            [imas-seamap.state-of-knowledge.utils :refer [boundary-filter-names]]))
 
 (defn update-amp-boundaries [db [_ {:keys [networks parks zones zones_iucn]}]]
   (-> db
@@ -256,34 +257,16 @@
 
 (defn get-habitat-statistics [{:keys [db]}]
   (let [habitat-statistics-url (get-in db [:config :habitat-statistics-url])
-        {:keys [active-boundary amp imcra meow]} (get-in db [:state-of-knowledge :boundaries])
-        {:keys [active-network active-park active-zone active-zone-iucn]} amp
-        {:keys [active-provincial-bioregion active-mesoscale-bioregion]} imcra
-        {:keys [active-realm active-province active-ecoregion]} meow
-        active-boundary (:id active-boundary)
-        [active-network active-park active-zone active-zone-iucn
-         active-provincial-bioregion active-mesoscale-bioregion active-realm
-         active-province active-ecoregion]
-        (map
-         :name
-         [active-network active-park active-zone active-zone-iucn
-          active-provincial-bioregion active-mesoscale-bioregion active-realm
-          active-province active-ecoregion])]
+        {:keys [active-boundary] :as boundaries} (get-in db [:state-of-knowledge :boundaries])
+        active-boundary (:id active-boundary)]
     (if
      active-boundary
       {:db (assoc-in db [:state-of-knowledge :statistics :habitat :loading?] true)
        :http-xhrio {:method          :get
                     :uri             habitat-statistics-url
-                    :params          {:boundary-type        active-boundary
-                                      :network              active-network
-                                      :park                 active-park
-                                      :zone                 active-zone
-                                      :zone-iucn            active-zone-iucn
-                                      :provincial-bioregion active-provincial-bioregion
-                                      :mesoscale-bioregion  active-mesoscale-bioregion
-                                      :realm                active-realm
-                                      :province             active-province
-                                      :ecoregion            active-ecoregion}
+                    :params          (merge
+                                      {:boundary-type        active-boundary}
+                                      (boundary-filter-names boundaries))
                     :response-format (ajax/json-response-format {:keywords? true})
                     :on-success      [:sok/got-habitat-statistics]
                     :on-failure      [:ajax/default-err-handler]}}
@@ -296,34 +279,16 @@
 
 (defn get-bathymetry-statistics [{:keys [db]}]
   (let [bathymetry-statistics-url (get-in db [:config :bathymetry-statistics-url])
-        {:keys [active-boundary amp imcra meow]} (get-in db [:state-of-knowledge :boundaries])
-        {:keys [active-network active-park active-zone active-zone-iucn]} amp
-        {:keys [active-provincial-bioregion active-mesoscale-bioregion]} imcra
-        {:keys [active-realm active-province active-ecoregion]} meow
-        active-boundary (:id active-boundary)
-        [active-network active-park active-zone active-zone-iucn
-         active-provincial-bioregion active-mesoscale-bioregion active-realm
-         active-province active-ecoregion]
-        (map
-         :name
-         [active-network active-park active-zone active-zone-iucn
-          active-provincial-bioregion active-mesoscale-bioregion active-realm
-          active-province active-ecoregion])]
+        {:keys [active-boundary] :as boundaries} (get-in db [:state-of-knowledge :boundaries])
+        active-boundary (:id active-boundary)]
     (if
      active-boundary
       {:db (assoc-in db [:state-of-knowledge :statistics :bathymetry :loading?] true)
        :http-xhrio {:method          :get
                     :uri             bathymetry-statistics-url
-                    :params          {:boundary-type        active-boundary
-                                      :network              active-network
-                                      :park                 active-park
-                                      :zone                 active-zone
-                                      :zone-iucn            active-zone-iucn
-                                      :provincial-bioregion active-provincial-bioregion
-                                      :mesoscale-bioregion  active-mesoscale-bioregion
-                                      :realm                active-realm
-                                      :province             active-province
-                                      :ecoregion            active-ecoregion}
+                    :params          (merge
+                                      {:boundary-type        active-boundary}
+                                      (boundary-filter-names boundaries))
                     :response-format (ajax/json-response-format {:keywords? true})
                     :on-success      [:sok/got-bathymetry-statistics]
                     :on-failure      [:ajax/default-err-handler]}}
@@ -336,34 +301,16 @@
 
 (defn get-habitat-observations [{:keys [db]}]
   (let [habitat-observations-url (get-in db [:config :habitat-observations-url])
-        {:keys [active-boundary amp imcra meow]} (get-in db [:state-of-knowledge :boundaries])
-        {:keys [active-network active-park active-zone active-zone-iucn]} amp
-        {:keys [active-provincial-bioregion active-mesoscale-bioregion]} imcra
-        {:keys [active-realm active-province active-ecoregion]} meow
-        active-boundary (:id active-boundary)
-        [active-network active-park active-zone active-zone-iucn
-         active-provincial-bioregion active-mesoscale-bioregion active-realm
-         active-province active-ecoregion]
-        (map
-         :name
-         [active-network active-park active-zone active-zone-iucn
-          active-provincial-bioregion active-mesoscale-bioregion active-realm
-          active-province active-ecoregion])]
+        {:keys [active-boundary] :as boundaries} (get-in db [:state-of-knowledge :boundaries])
+        active-boundary (:id active-boundary)]
     (if
      active-boundary
       {:db (assoc-in db [:state-of-knowledge :statistics :habitat-observations :loading?] true)
        :http-xhrio {:method          :get
                     :uri             habitat-observations-url
-                    :params          {:boundary-type        active-boundary
-                                      :network              active-network
-                                      :park                 active-park
-                                      :zone                 active-zone
-                                      :zone-iucn            active-zone-iucn
-                                      :provincial-bioregion active-provincial-bioregion
-                                      :mesoscale-bioregion  active-mesoscale-bioregion
-                                      :realm                active-realm
-                                      :province             active-province
-                                      :ecoregion            active-ecoregion}
+                    :params          (merge
+                                      {:boundary-type        active-boundary}
+                                      (boundary-filter-names boundaries))
                     :response-format (ajax/json-response-format {:keywords? true})
                     :on-success      [:sok/got-habitat-observations]
                     :on-failure      [:ajax/default-err-handler]}}

--- a/frontend/src/cljs/imas_seamap/state_of_knowledge/events.cljs
+++ b/frontend/src/cljs/imas_seamap/state_of_knowledge/events.cljs
@@ -29,10 +29,9 @@
 (defn- select-boundary-layer
   "Based on the currently active boundary and boundary filters, select an
    appropriate boundary layer."
-  [layers {boundary-id :id} {:keys [amp imcra meow] :as _boundaries}]
+  [layers {boundary-id :id} {:keys [amp imcra _meow] :as _boundaries}]
   (let [{:keys [active-park active-zone active-zone-iucn]} amp
         {:keys [active-mesoscale-bioregion]} imcra
-        {:keys [active-province active-ecoregion]} meow
 
         layer-id (case boundary-id
                    
@@ -45,9 +44,7 @@
                              active-mesoscale-bioregion 1500
                              :else                      182)
 
-                   "meow"  (cond
-                             (or active-province active-ecoregion) 189
-                             :else                                 181)
+                   "meow"  181
 
                    nil)]
     (first-where #(= (:id %) layer-id) layers)))

--- a/frontend/src/cljs/imas_seamap/state_of_knowledge/events.cljs
+++ b/frontend/src/cljs/imas_seamap/state_of_knowledge/events.cljs
@@ -52,7 +52,7 @@
                    nil)]
     (first-where #(= (:id %) layer-id) layers)))
 
-(defn update-active-boundary-layer [{:keys [db]} _]
+(defn update-active-boundary-layer [{:keys [db]} [_ pan?]]
   (let [layers (get-in db [:map :layers])
         active-boundary (get-in db [:state-of-knowledge :boundaries :active-boundary])
 
@@ -60,9 +60,13 @@
         current-boundary-layer  (select-boundary-layer layers active-boundary (get-in db [:state-of-knowledge :boundaries]))
 
         db                      (assoc-in db [:state-of-knowledge :boundaries :active-boundary-layer] current-boundary-layer)]
+    (js/console.warn pan?)
     {:db db
      :dispatch-n [(when previous-boundary-layer [:map/remove-layer previous-boundary-layer])
-                  (when current-boundary-layer [:map/pan-to-layer current-boundary-layer])]}))
+                  (when current-boundary-layer
+                    (if pan?
+                      [:map/pan-to-layer current-boundary-layer]
+                      [:map/add-layer current-boundary-layer]))]}))
 
 (defn update-active-boundary [{:keys [db]} [_ active-boundary]]
   (let [db (-> db
@@ -86,7 +90,7 @@
                   (assoc-in [:state-of-knowledge :boundaries :meow :active-province] nil)
                   (assoc-in [:state-of-knowledge :boundaries :meow :active-ecoregion] nil))))]
     {:db db
-     :dispatch-n [[:sok/update-active-boundary-layer]
+     :dispatch-n [[:sok/update-active-boundary-layer true]
                   [:sok/get-habitat-statistics]
                   [:sok/get-bathymetry-statistics]
                   [:sok/get-habitat-observations]
@@ -100,7 +104,7 @@
               (assoc-in [:state-of-knowledge :boundaries :amp :active-network] network)))
         park (get-in db [:state-of-knowledge :boundaries :amp :active-park])]
     {:db db
-     :dispatch-n [[:sok/update-active-boundary-layer]
+     :dispatch-n [[:sok/update-active-boundary-layer false]
                   [:sok/get-habitat-statistics]
                   [:sok/get-bathymetry-statistics]
                   [:sok/get-habitat-observations]
@@ -116,7 +120,7 @@
                (assoc-in [:state-of-knowledge :boundaries :amp :active-network] network)
                (assoc-in [:state-of-knowledge :boundaries :amp :active-park] park))]
     {:db db
-     :dispatch-n [[:sok/update-active-boundary-layer]
+     :dispatch-n [[:sok/update-active-boundary-layer false]
                   [:sok/get-habitat-statistics]
                   [:sok/get-bathymetry-statistics]
                   [:sok/get-habitat-observations]
@@ -127,7 +131,7 @@
                (assoc-in [:state-of-knowledge :boundaries :amp :active-zone] zone)
                (assoc-in [:state-of-knowledge :boundaries :amp :active-zone-iucn] nil))]
     {:db db
-     :dispatch-n [[:sok/update-active-boundary-layer]
+     :dispatch-n [[:sok/update-active-boundary-layer false]
                   [:sok/get-habitat-statistics]
                   [:sok/get-bathymetry-statistics]
                   [:sok/get-habitat-observations]
@@ -138,7 +142,7 @@
                (assoc-in [:state-of-knowledge :boundaries :amp :active-zone-iucn] zone-iucn)
                (assoc-in [:state-of-knowledge :boundaries :amp :active-zone] nil))]
     {:db db
-     :dispatch-n [[:sok/update-active-boundary-layer]
+     :dispatch-n [[:sok/update-active-boundary-layer false]
                   [:sok/get-habitat-statistics]
                   [:sok/get-bathymetry-statistics]
                   [:sok/get-habitat-observations]
@@ -152,7 +156,7 @@
               (assoc-in [:state-of-knowledge :boundaries :imcra :active-provincial-bioregion] provincial-bioregion)))
         mesoscale-bioregion (get-in db [:state-of-knowledge :boundaries :imcra :active-mesoscale-bioregion])]
     {:db db
-     :dispatch-n [[:sok/update-active-boundary-layer]
+     :dispatch-n [[:sok/update-active-boundary-layer false]
                   [:sok/get-habitat-statistics]
                   [:sok/get-bathymetry-statistics]
                   [:sok/get-habitat-observations]
@@ -168,7 +172,7 @@
                (assoc-in [:state-of-knowledge :boundaries :imcra :active-provincial-bioregion] provincial-bioregion)
                (assoc-in [:state-of-knowledge :boundaries :imcra :active-mesoscale-bioregion] mesoscale-bioregion))]
     {:db db
-     :dispatch-n [[:sok/update-active-boundary-layer]
+     :dispatch-n [[:sok/update-active-boundary-layer false]
                   [:sok/get-habitat-statistics]
                   [:sok/get-bathymetry-statistics]
                   [:sok/get-habitat-observations]
@@ -183,7 +187,7 @@
               (assoc-in [:state-of-knowledge :boundaries :meow :active-ecoregion] nil)))
         ecoregion (get-in db [:state-of-knowledge :boundaries :meow :active-ecoregion])]
     {:db db
-     :dispatch-n [[:sok/update-active-boundary-layer]
+     :dispatch-n [[:sok/update-active-boundary-layer false]
                   [:sok/get-habitat-statistics]
                   [:sok/get-bathymetry-statistics]
                   [:sok/get-habitat-observations]
@@ -203,7 +207,7 @@
               (assoc-in [:state-of-knowledge :boundaries :meow :active-ecoregion] nil)))
         ecoregion (get-in db [:state-of-knowledge :boundaries :meow :active-ecoregion])]
     {:db db
-     :dispatch-n [[:sok/update-active-boundary-layer]
+     :dispatch-n [[:sok/update-active-boundary-layer false]
                   [:sok/get-habitat-statistics]
                   [:sok/get-bathymetry-statistics]
                   [:sok/get-habitat-observations]
@@ -224,7 +228,7 @@
                (assoc-in [:state-of-knowledge :boundaries :meow :active-province] province)
                (assoc-in [:state-of-knowledge :boundaries :meow :active-ecoregion] ecoregion))]
     {:db db
-     :dispatch-n [[:sok/update-active-boundary-layer]
+     :dispatch-n [[:sok/update-active-boundary-layer false]
                   [:sok/get-habitat-statistics]
                   [:sok/get-bathymetry-statistics]
                   [:sok/get-habitat-observations]
@@ -240,7 +244,7 @@
                (assoc-in [:state-of-knowledge :boundaries :meow :active-province] nil)
                (assoc-in [:state-of-knowledge :boundaries :meow :active-ecoregion] nil))]
     {:db db
-     :dispatch-n [[:sok/update-active-boundary-layer]
+     :dispatch-n [[:sok/update-active-boundary-layer false]
                   [:sok/get-habitat-statistics]
                   [:sok/get-bathymetry-statistics]
                   [:sok/get-habitat-observations]]}))
@@ -250,7 +254,7 @@
                (assoc-in [:state-of-knowledge :boundaries :amp :active-zone] nil)
                (assoc-in [:state-of-knowledge :boundaries :amp :active-zone-iucn] nil))]
     {:db db
-     :dispatch-n [[:sok/update-active-boundary-layer]
+     :dispatch-n [[:sok/update-active-boundary-layer false]
                   [:sok/get-habitat-statistics]
                   [:sok/get-bathymetry-statistics]
                   [:sok/get-habitat-observations]]}))

--- a/frontend/src/cljs/imas_seamap/state_of_knowledge/subs.cljs
+++ b/frontend/src/cljs/imas_seamap/state_of_knowledge/subs.cljs
@@ -143,8 +143,8 @@
   (get-in db [:state-of-knowledge :open-pill]))
 
 (defn boundary-layer-filter-fn [db _]
-  (let [active-boundary (get-in db [:state-of-knowledge :boundaries :active-boundary])]
-    (fn [{:keys [id] :as _layer}]
-      (if (= id (:layer active-boundary))
+  (let [active-boundary-layer (get-in db [:state-of-knowledge :boundaries :active-boundary-layer])]
+    (fn [layer]
+      (if (= layer active-boundary-layer)
         {:cql_filter "NETNAME='North'"}
         nil))))

--- a/frontend/src/cljs/imas_seamap/state_of_knowledge/subs.cljs
+++ b/frontend/src/cljs/imas_seamap/state_of_knowledge/subs.cljs
@@ -3,7 +3,7 @@
 ;;; Released under the Affero General Public Licence (AGPL) v3.  See LICENSE file for details.
 (ns imas-seamap.state-of-knowledge.subs
   (:require [imas-seamap.utils :refer [append-query-params-from-map]]
-            [imas-seamap.state-of-knowledge.utils :as utils]))
+            [imas-seamap.state-of-knowledge.utils :as utils :refer [boundary-filter-names]]))
 
 (defn habitat-statistics [db _]
   (let [{:keys [results loading?]} (get-in db [:state-of-knowledge :statistics :habitat])
@@ -143,8 +143,23 @@
   (get-in db [:state-of-knowledge :open-pill]))
 
 (defn boundary-layer-filter-fn [db _]
-  (let [active-boundary-layer (get-in db [:state-of-knowledge :boundaries :active-boundary-layer])]
+  (let [{:keys [active-boundary-layer] :as boundaries} (get-in db [:state-of-knowledge :boundaries])
+        {:keys
+         [network park zone zone-iucn
+          provincial-bioregion mesoscale-bioregion
+          realm province ecoregion]} (boundary-filter-names boundaries)
+        filters (remove
+                 nil?
+                 [(when network (str "NETNAME='" network "'"))
+                  (when park (str "RESNAME='" park "'"))
+                  (when zone (str "ZONENAME='" zone "'"))
+                  (when zone-iucn (str "ZONEIUCN='" zone-iucn "'"))
+                  (when provincial-bioregion (str "PB_NAME='" provincial-bioregion "'"))
+                  (when mesoscale-bioregion (str "MESO_NAME='" mesoscale-bioregion "'"))
+                  (when realm (str "REALM='" realm "'"))
+                  (when province (str "PROVINCE='" province "'"))
+                  (when ecoregion (str "ECOREGION='" ecoregion "'"))])]
     (fn [layer]
-      (if (= layer active-boundary-layer)
-        {:cql_filter "NETNAME='North'"}
+      (if (and (= layer active-boundary-layer) (seq filters))
+        {:cql_filter (apply str (interpose " AND " filters))}
         nil))))

--- a/frontend/src/cljs/imas_seamap/state_of_knowledge/subs.cljs
+++ b/frontend/src/cljs/imas_seamap/state_of_knowledge/subs.cljs
@@ -141,3 +141,10 @@
 
 (defn open-pill [db _]
   (get-in db [:state-of-knowledge :open-pill]))
+
+(defn boundary-layer-filter-fn [db _]
+  (let [active-boundary (get-in db [:state-of-knowledge :boundaries :active-boundary])]
+    (fn [{:keys [id] :as _layer}]
+      (if (= id (:layer active-boundary))
+        {:cql_filter "NETNAME='North'"}
+        nil))))

--- a/frontend/src/cljs/imas_seamap/state_of_knowledge/utils.cljs
+++ b/frontend/src/cljs/imas_seamap/state_of_knowledge/utils.cljs
@@ -7,11 +7,8 @@
 ;; Hardcoding this seems bad, but I'm not sure what to do about it? - TODO: figure out how to NOT hardcode this
 (def boundaries
   [{:id    "amp"
-    :name  "Australian Marine Parks"
-    :layer 1520}
+    :name  "Australian Marine Parks"}
    {:id    "imcra"
-    :name  "Integrated Marine and Coastal Regionalisation of Australia"
-    :layer 1500}
+    :name  "Integrated Marine and Coastal Regionalisation of Australia"}
    {:id    "meow"
-    :name  "Marine Ecoregions of the World"
-    :layer 189}])
+    :name  "Marine Ecoregions of the World"}])

--- a/frontend/src/cljs/imas_seamap/state_of_knowledge/utils.cljs
+++ b/frontend/src/cljs/imas_seamap/state_of_knowledge/utils.cljs
@@ -12,3 +12,17 @@
     :name  "Integrated Marine and Coastal Regionalisation of Australia"}
    {:id    "meow"
     :name  "Marine Ecoregions of the World"}])
+
+(defn boundary-filter-names [{:keys [amp imcra meow] :as _boundaries}]
+  (let [{:keys [active-network active-park active-zone active-zone-iucn]} amp
+        {:keys [active-provincial-bioregion active-mesoscale-bioregion]} imcra
+        {:keys [active-realm active-province active-ecoregion]} meow]
+    {:network              (:name active-network)
+     :park                 (:name active-park)
+     :zone                 (:name active-zone)
+     :zone-iucn            (:name active-zone-iucn)
+     :provincial-bioregion (:name active-provincial-bioregion)
+     :mesoscale-bioregion  (:name active-mesoscale-bioregion)
+     :realm                (:name active-realm)
+     :province             (:name active-province)
+     :ecoregion            (:name active-ecoregion)}))


### PR DESCRIPTION
[ISA-205](https://jira.its.utas.edu.au/browse/ISA-205)

Using CQL filters on the active boundary layer to show which area is currently being filtered to in the state of knowledge.
Appropriate layer that corresponds with filters is now shown (i.e. showing zones layer when zone filter is selected, park filter when park filter is select, etc.)

![Screen Shot 2022-07-29 at 1 56 54 pm](https://user-images.githubusercontent.com/50224230/181679910-a8c44a9b-3681-4142-8240-41b45cf10eb7.png)
