### PR TITLE
Feature: (ISA-55) Divide complex GetMap requests

### DIFF
--- a/backend/catalogue/management/commands/generate_layer_previews.py
+++ b/backend/catalogue/management/commands/generate_layer_previews.py
@@ -84,7 +84,7 @@ def subdivide_requests(layer, horizontal_subdivisions=1, vertical_subdivisions=1
                 'service': 'WMS',
                 'request': 'GetMap',
                 'layers': layer.layer_name,
-                'styles': '',
+                'styles': layer.style or '',
                 'format': 'image/png',
                 'transparent': 'true',
                 'version': '1.1.1',

--- a/backend/catalogue/management/commands/generate_layer_previews.py
+++ b/backend/catalogue/management/commands/generate_layer_previews.py
@@ -39,7 +39,56 @@ def basemap_bbox(north, south, east, west):
         return basemap.crop((left, upper, right, lower))
 
 
-def layer_url(layer):
+def subdivide_requests(layer, subdivisions=1):
+    bbox = {
+        'north': float(layer.maxy),
+        'south': float(layer.miny),
+        'east':  float(layer.maxx),
+        'west':  float(layer.minx)
+    }
+
+    x_delta = bbox['east'] - bbox['west']
+    y_delta = bbox['north'] - bbox['south']
+    aspect_ratio = x_delta / y_delta
+    width = 386
+    height = round(width / aspect_ratio)
+
+    urls = []
+    general_sub_width = width // subdivisions
+    general_x_delta = x_delta / width * general_sub_width
+    for i in range(0, subdivisions):
+        sub_width = general_sub_width
+        sub_x_delta = general_x_delta
+        if i == subdivisions - 1:
+            sub_width += width % subdivisions
+            sub_x_delta = x_delta / width * sub_width
+
+        sub_bbox = {
+            'north': bbox['north'],
+            'south': bbox['south'],
+            'east':  bbox['west'] + i * general_x_delta + sub_x_delta,
+            'west':  bbox['west'] + i * general_x_delta
+        }
+
+        sub_params = {
+            'service': 'WMS',
+            'request': 'GetMap',
+            'layers': layer.layer_name,
+            'styles': '',
+            'format': 'image/png',
+            'transparent': 'true',
+            'version': '1.1.1',
+            'width': sub_width,
+            'height': height,
+            'srs': 'EPSG:4326',
+            'bbox': '{west},{south},{east},{north}'.format(**sub_bbox)
+        }
+
+        urls.append(f'{layer.server_url}?{urlencode(sub_params)}')
+
+    return urls
+
+def retrieve_image(layer, subdivisions=1):
     bbox = {
         'north': float(layer.maxy),
         'south': float(layer.miny),
@@ -53,39 +102,14 @@ def layer_url(layer):
     width = 386
     height = round(width / aspect_ratio)
 
-    params = {
-        'service': 'WMS',
-        'request': 'GetMap',
-        'layers': layer.layer_name,
-        'styles': '',
-        'format': 'image/png',
-        'transparent': 'true',
-        'version': '1.1.1',
-        'width': width,
-        'height': height,
-        'srs': 'EPSG:4326',
-        'bbox': '{west},{south},{east},{north}'.format(**bbox)
-    }
-
-    return f'{layer.server_url}?{urlencode(params)}'
-
-def retrieve_image(layer):
-    bbox = {
-        'north': float(layer.maxy),
-        'south': float(layer.miny),
-        'east':  float(layer.maxx),
-        'west': float(layer.minx)
-    }
-
-    x_delta = bbox['east'] - bbox['west']
-    y_delta = bbox['north'] - bbox['south']
-    aspect_ratio = x_delta / y_delta
-    width = 386
-    height = round(width / aspect_ratio)
-
-    layer_image = Image.open(urlopen(layer_url(layer))).convert('RGBA')
     cropped_basemap = basemap_bbox(**bbox).resize((width, height))
-    cropped_basemap.paste(layer_image, None, layer_image)
+
+    urls = subdivide_requests(layer, subdivisions)
+    for i, url in enumerate(urls):
+        logging.info(f'Retrieving part {i+1}/{subdivisions} from {url}')
+        layer_image = Image.open(urlopen(url)).convert('RGBA')
+        cropped_basemap.paste(layer_image, ((width // subdivisions) * i, 0), layer_image)
+
     return cropped_basemap
 
 
@@ -104,13 +128,15 @@ class Command(BaseCommand):
         layer_id = int(options['layer_id']) if options['layer_id'] != None else None
         only_generate_missing = options['only_generate_missing'].lower() in ['t', 'true'] if options['only_generate_missing'] != None else False
 
+        subdivisions = 64
+
         if layer_id is not None:
             layer = Layer.objects.get(id=layer_id)
 
             filepath = f'layer_previews/{layer.id}.png'
             if not only_generate_missing or not default_storage.exists(filepath):
                 with BytesIO() as bytes_io:
-                    layer_image = retrieve_image(layer)
+                    layer_image = retrieve_image(layer, subdivisions)
                     layer_image.save(bytes_io, 'PNG')
 
                     default_storage.delete(filepath)
@@ -123,19 +149,19 @@ class Command(BaseCommand):
                 if not only_generate_missing or not default_storage.exists(filepath):
                     with BytesIO() as bytes_io:
                         try:
-                            logging.info(f'Retrieving layer {layer.layer_name} ({layer.id})\n{layer_url(layer)}')
-                            layer_image = retrieve_image(layer)
+                            logging.info(f'Retrieving layer {layer.layer_name} ({layer.id})\n{subdivide_requests(layer, subdivisions)}')
+                            layer_image = retrieve_image(layer, subdivisions)
                             layer_image.save(bytes_io, 'PNG')
                             
                             default_storage.delete(filepath)
                             default_storage.save(filepath, File(bytes_io, ''))
                         except Exception:
-                            logging.warn(f'Failed to retrieve layer {layer.layer_name} ({layer.id})\n{layer_url(layer)}')
+                            logging.warn(f'Failed to retrieve layer {layer.layer_name} ({layer.id})\n{subdivide_requests(layer, subdivisions)}')
                             failures.append(layer)
 
             if len(failures):
                 logging.warn('Failed to retrieve the following layers: \n - {}'.format(
                     '\n - '.join(
-                        [f'{layer.layer_name} ({layer.id})\n{layer_url(layer)}' for layer in failures]
+                        [f'{layer.layer_name} ({layer.id})\n{subdivide_requests(layer, subdivisions)}' for layer in failures]
                     )
                 ))

--- a/backend/catalogue/management/commands/generate_layer_previews.py
+++ b/backend/catalogue/management/commands/generate_layer_previews.py
@@ -141,13 +141,20 @@ class Command(BaseCommand):
             '--only_generate_missing',
             help='If true, skips generating images for layers where images already exist'
         )
+        parser.add_argument(
+            '--horizontal_subdivisions',
+            help='Number of columns to break the GetMap query for each layer into'
+        )
+        parser.add_argument(
+            '--vertical_subdivisions',
+            help='Number of rows to break the GetMap query for each layer into'
+        )
 
     def handle(self, *args, **options):
         layer_id = int(options['layer_id']) if options['layer_id'] != None else None
         only_generate_missing = options['only_generate_missing'].lower() in ['t', 'true'] if options['only_generate_missing'] != None else False
-
-        horizontal_subdivisions = 16
-        vertical_subdivisions = 16
+        horizontal_subdivisions = int(options['horizontal_subdivisions']) if options['horizontal_subdivisions'] != None else 1
+        vertical_subdivisions = int(options['vertical_subdivisions']) if options['vertical_subdivisions'] != None else 1
 
         if layer_id is not None:
             layer = Layer.objects.get(id=layer_id)


### PR DESCRIPTION
[ISA-55](https://jira.its.utas.edu.au/browse/ISA-55)

The ability to divide the GetMap requests used in the generation of layer preview images has been added. Dividing the GetMap requests into chunks of the final image is useful for retrieving complex layers such as seamap:SeamapAus_TAS_AbHab_substrata_grp and seamap:FINALPRODUCT_SeamapAus_v2.

Layer style has also been added to the parameters for the GetMap request, which affects the display of some layers (e.g. seamap:SeamapAus_BOUNDARIES_AMP2022).