### PR TITLE
Feature: (ISA-222) Replace magic mode

### DIFF
--- a/frontend/src/cljs/imas_seamap/core.cljs
+++ b/frontend/src/cljs/imas_seamap/core.cljs
@@ -35,7 +35,6 @@
     :map.layers/filter                    msubs/map-layers-filter
     :map.layers/others-filter             msubs/map-other-layers-filter
     :map.layers/priorities                msubs/map-layer-priorities
-    :map.layers/logic                     msubs/map-layer-logic
     :map.layers/lookup                    msubs/map-layer-lookup
     ;:map.layers/params                    msubs/map-layer-extra-params-fn
     :map.layer/info                       subs/map-layer-info

--- a/frontend/src/cljs/imas_seamap/core.cljs
+++ b/frontend/src/cljs/imas_seamap/core.cljs
@@ -41,6 +41,7 @@
     :map.layer.selection/info             msubs/layer-selection-info
     :map.feature/info                     subs/feature-info
     ;:map/region-stats                     msubs/region-stats
+    :map/viewport-only?                   msubs/viewport-only?
     :sok/habitat-statistics               soksubs/habitat-statistics
     :sok/habitat-statistics-download-url  soksubs/habitat-statistics-download-url
     :sok/bathymetry-statistics            soksubs/bathymetry-statistics
@@ -162,6 +163,7 @@
     :map/view-updated                     [mevents/map-view-updated]
     :map/popup-closed                     mevents/destroy-popup
     :map/toggle-ignore-click              mevents/toggle-ignore-click
+    :map/toggle-viewport-only             mevents/toggle-viewport-only
     :sok/update-amp-boundaries            sokevents/update-amp-boundaries
     :sok/update-imcra-boundaries          sokevents/update-imcra-boundaries
     :sok/update-meow-boundaries           sokevents/update-meow-boundaries

--- a/frontend/src/cljs/imas_seamap/core.cljs
+++ b/frontend/src/cljs/imas_seamap/core.cljs
@@ -138,9 +138,6 @@
     :map.layer/opacity-changed            [mevents/layer-set-opacity]
     :map.layers/filter                    mevents/map-set-layer-filter
     :map.layers/others-filter             mevents/map-set-others-layer-filter
-    :map.layers.logic/toggle              [mevents/map-layer-logic-toggle]
-    :map.layers.logic/manual              mevents/map-layer-logic-manual
-    :map.layers.logic/automatic           mevents/map-layer-logic-automatic
     :map.layer.legend/toggle              [mevents/toggle-legend-display]
     :map.layer.selection/enable           mevents/map-start-selecting
     :map.layer.selection/disable          mevents/map-cancel-selecting
@@ -214,7 +211,6 @@
 (def events-for-analytics
   [:help-layer/open
    :map.layer/load-error
-   :map.layers.logic/toggle
    :map/clicked
    :map/pan-to-layer
    :map/toggle-layer

--- a/frontend/src/cljs/imas_seamap/db.cljs
+++ b/frontend/src/cljs/imas_seamap/db.cljs
@@ -27,8 +27,7 @@
                      :active-layers   []
                      :hidden-layers   #{}
                      :preview-layer   nil
-                     :logic           {:type    :map.layer-logic/automatic
-                                       :trigger :map.logic.trigger/automatic}
+                     :logic           {:type :map.layer-logic/automatic}
                      :controls        {:transect false
                                        :download nil}}
    :state-of-knowledge {:boundaries {:active-boundary nil

--- a/frontend/src/cljs/imas_seamap/db.cljs
+++ b/frontend/src/cljs/imas_seamap/db.cljs
@@ -27,6 +27,7 @@
                      :active-layers   []
                      :hidden-layers   #{}
                      :preview-layer   nil
+                     :viewport-only?  false
                      :controls        {:transect false
                                        :download nil}}
    :state-of-knowledge {:boundaries {:active-boundary nil

--- a/frontend/src/cljs/imas_seamap/db.cljs
+++ b/frontend/src/cljs/imas_seamap/db.cljs
@@ -27,7 +27,6 @@
                      :active-layers   []
                      :hidden-layers   #{}
                      :preview-layer   nil
-                     :logic           {:type :map.layer-logic/automatic}
                      :controls        {:transect false
                                        :download nil}}
    :state-of-knowledge {:boundaries {:active-boundary nil

--- a/frontend/src/cljs/imas_seamap/events.cljs
+++ b/frontend/src/cljs/imas_seamap/events.cljs
@@ -159,9 +159,7 @@
 
 (defn load-hash-state
   [db [_ hash-code]]
-  (let [db (merge-in db (parse-state hash-code))
-        db (assoc-in db [:map :logic :type] :map.layer-logic/manual)]
-    db))
+  (merge-in db (parse-state hash-code)))
 
 (defn get-save-state
   [{:keys [db]} [_ save-code]]

--- a/frontend/src/cljs/imas_seamap/map/events.cljs
+++ b/frontend/src/cljs/imas_seamap/map/events.cljs
@@ -5,7 +5,7 @@
   (:require [clojure.string :as string]
             [cljs.spec.alpha :as s]
             [imas-seamap.utils :refer [encode-state ids->layers first-where]]
-            [imas-seamap.map.utils :refer [applicable-layers layer-name bounds->str wgs84->epsg3112 feature-info-html feature-info-json feature-info-none bounds->projected region-stats-habitat-layer sort-by-sort-key]]
+            [imas-seamap.map.utils :refer [layer-name bounds->str wgs84->epsg3112 feature-info-html feature-info-json feature-info-none bounds->projected region-stats-habitat-layer sort-by-sort-key]]
             [ajax.core :as ajax]
             [imas-seamap.blueprint :as b]
             [reagent.core :as r]
@@ -422,11 +422,8 @@
   ;; re-set.  So we have this two step process.  Ditto :active-base /
   ;; :active-base-layer
   [{:keys [db]} _]
-  (let [{:keys [active active-base _legend-ids logic]} (:map db)
-        active-layers [] ; TODO: Set initial layer(s) without magic mode or priorities
-        #_(if (= (:type logic) :map.layer-logic/manual)
-            (vec (ids->layers active (get-in db [:map :layers])))
-            (vec (applicable-layers db :category :habitat)))
+  (let [{:keys [active active-base _legend-ids]} (:map db)
+        active-layers (vec (ids->layers active (get-in db [:map :layers])))
         active-base   (->> (get-in db [:map :grouped-base-layers]) (filter (comp #(= active-base %) :id)) first)
         active-base   (or active-base   ; If no base is set (eg no existing hash-state), use the first candidate
                           (first (get-in db [:map :grouped-base-layers])))

--- a/frontend/src/cljs/imas_seamap/map/events.cljs
+++ b/frontend/src/cljs/imas_seamap/map/events.cljs
@@ -508,3 +508,6 @@
 (defn update-preview-layer [db [_ preview-layer]]
   (assoc-in db [:map :preview-layer] preview-layer))
 
+
+(defn toggle-viewport-only [db _]
+  (update-in db [:map :viewport-only?] not))

--- a/frontend/src/cljs/imas_seamap/map/events.cljs
+++ b/frontend/src/cljs/imas_seamap/map/events.cljs
@@ -403,16 +403,6 @@
                                            (+ x (* horiz (- east  west)))])]
     (update-in db [:map :center] shift-centre)))
 
-(defn layer-visible? [{:keys [west south east north] :as _bounds}
-                      {:keys [bounding_box]          :as _layer}]
-  (not (or (> (:south bounding_box) north)
-           (< (:north bounding_box) south)
-           (> (:west  bounding_box) east)
-           (< (:east  bounding_box) west))))
-
-(defn viewport-layers [{:keys [_west _south _east _north] :as bounds} layers]
-  (filter (partial layer-visible? bounds) layers))
-
 (defn show-initial-layers
   "Figure out the highest priority layer, and display it"
   ;; Slight hack; note we use :active not :active-layers, because

--- a/frontend/src/cljs/imas_seamap/map/events.cljs
+++ b/frontend/src/cljs/imas_seamap/map/events.cljs
@@ -461,21 +461,18 @@
      :put-hash (encode-state db)
      :dispatch [:ui/hide-loading]}))
 
-(defn map-layer-logic-manual [db [_ user-triggered]]
-  (assoc-in db [:map :logic]
-            {:type :map.layer-logic/manual
-             :trigger (if user-triggered :map.logic.trigger/user :map.logic.trigger/automatic)}))
+(defn map-layer-logic-manual [db _]
+  (assoc-in db [:map :logic] {:type :map.layer-logic/manual}))
 
 (defn map-layer-logic-automatic [db _]
-  (assoc-in db [:map :logic] {:type :map.layer-logic/automatic :trigger :map.logic.trigger/automatic}))
+  (assoc-in db [:map :logic] {:type :map.layer-logic/automatic}))
 
-(defn map-layer-logic-toggle [{:keys [db]} [_ user-triggered]]
+(defn map-layer-logic-toggle [{:keys [db]} _]
   (let [type (if (= (get-in db [:map :logic :type])
                     :map.layer-logic/manual)
                :map.layer-logic/automatic
-               :map.layer-logic/manual)
-        trigger (if user-triggered :map.logic.trigger/user :map.logic.trigger/automatic)]
-    (merge {:db (assoc-in db [:map :logic] {:type type :trigger trigger})
+               :map.layer-logic/manual)]
+    (merge {:db (assoc-in db [:map :logic] {:type type })
             :put-hash (encode-state db)}
            ;; Also reset displayed layers, if we're turning auto-mode back on:
            (when (= type :map.layer-logic/automatic)

--- a/frontend/src/cljs/imas_seamap/map/subs.cljs
+++ b/frontend/src/cljs/imas_seamap/map/subs.cljs
@@ -88,9 +88,6 @@
 (defn map-layer-priorities [db _]
   (get-in db [:map :priorities]))
 
-(defn map-layer-logic [db _]
-  (get-in db [:map :logic] {:type :map.layer-logic/automatic}))
-
 (defn map-layers-filter [db _]
   (get-in db [:filters :layers]))
 

--- a/frontend/src/cljs/imas_seamap/map/subs.cljs
+++ b/frontend/src/cljs/imas_seamap/map/subs.cljs
@@ -153,3 +153,6 @@
   (if org-name
     (some #(and (= org-name (:name %)) %) organisations)
     organisations))
+
+(defn viewport-only? [db _]
+  (get-in db [:map :viewport-only?]))

--- a/frontend/src/cljs/imas_seamap/map/subs.cljs
+++ b/frontend/src/cljs/imas_seamap/map/subs.cljs
@@ -89,9 +89,7 @@
   (get-in db [:map :priorities]))
 
 (defn map-layer-logic [db _]
-  (get-in db [:map :logic]
-          {:type    :map.layer-logic/automatic
-           :trigger :map.logic.trigger/automatic}))
+  (get-in db [:map :logic] {:type :map.layer-logic/automatic}))
 
 (defn map-layers-filter [db _]
   (get-in db [:filters :layers]))

--- a/frontend/src/cljs/imas_seamap/map/utils.cljs
+++ b/frontend/src/cljs/imas_seamap/map/utils.cljs
@@ -114,7 +114,8 @@
         viewport-layers (filter #(bbox-intersects? bounds (:bounding_box %)) selected-layers)]
     viewport-layers))
 
-(defn all-priority-layers
+;; TODO: Remove, unused
+#_(defn all-priority-layers
   "Return the list of priority layers: that is, every layer for which
   its priority in *some* group is higher than the priority-cutoff.
   This only applies to habitat and bathymetry layers; other categories

--- a/frontend/src/cljs/imas_seamap/map/utils.cljs
+++ b/frontend/src/cljs/imas_seamap/map/utils.cljs
@@ -230,3 +230,13 @@
   "Sorts a collection by its sort-key first and its id second."
   [coll]
   (sort-by (juxt #(or (:sort_key %) "zzzzzzzzzz") :id) coll))
+
+(defn layer-visible? [{:keys [west south east north] :as _bounds}
+                      {:keys [bounding_box]          :as _layer}]
+  (not (or (> (:south bounding_box) north)
+           (< (:north bounding_box) south)
+           (> (:west  bounding_box) east)
+           (< (:east  bounding_box) west))))
+
+(defn viewport-layers [{:keys [_west _south _east _north] :as bounds} layers]
+  (filter (partial layer-visible? bounds) layers))

--- a/frontend/src/cljs/imas_seamap/map/views.cljs
+++ b/frontend/src/cljs/imas_seamap/map/views.cljs
@@ -162,10 +162,7 @@
         {:keys [drawing? query mouse-loc]}            @(re-frame/subscribe [:transect/info])
         {:keys [selecting? region]}                   @(re-frame/subscribe [:map.layer.selection/info])
         download-info                                 @(re-frame/subscribe [:download/info])
-        layer-priorities                              @(re-frame/subscribe [:map.layers/priorities])
-        ;layer-params                                  @(re-frame/subscribe [:map.layers/params])
         boundary-filter                               @(re-frame/subscribe [:sok/boundary-layer-filter])
-        logic-type                                    @(re-frame/subscribe [:map.layers/logic])
         loading?                                      @(re-frame/subscribe [:app/loading?])]
     (into
      [:div.map-wrapper

--- a/frontend/src/cljs/imas_seamap/specs/app_state.cljs
+++ b/frontend/src/cljs/imas_seamap/specs/app_state.cljs
@@ -168,9 +168,6 @@
 
 (s/def :map/priority-cutoff (s/and pos? integer?))
 
-(s/def :map.logic/type #{:map.layer-logic/automatic :map.layer-logic/manual})
-(s/def :map/logic (s/keys :req-un [:map.logic/type :map.logic/trigger]))
-
 (s/def ::habitat-titles  (s/map-of string? (s/nilable string?)))
 (s/def ::habitat-colours (s/map-of string? string?))
 
@@ -189,8 +186,7 @@
                    :map/groups
                    :map/organisations
                    :map/priorities
-                   :map/priority-cutoff
-                   :map/logic]))
+                   :map/priority-cutoff]))
 
 (s/def :layer/loading-state #{:map.layer/loading :map.layer/loaded})
 (s/def :map.state/error-count (s/map-of :map/layer integer?))

--- a/frontend/src/cljs/imas_seamap/specs/app_state.cljs
+++ b/frontend/src/cljs/imas_seamap/specs/app_state.cljs
@@ -168,6 +168,8 @@
 
 (s/def :map/priority-cutoff (s/and pos? integer?))
 
+(s/def :map/viewport-only? boolean?)
+
 (s/def ::habitat-titles  (s/map-of string? (s/nilable string?)))
 (s/def ::habitat-colours (s/map-of string? string?))
 
@@ -186,7 +188,8 @@
                    :map/groups
                    :map/organisations
                    :map/priorities
-                   :map/priority-cutoff]))
+                   :map/priority-cutoff
+                   :map/viewport-only?]))
 
 (s/def :layer/loading-state #{:map.layer/loading :map.layer/loaded})
 (s/def :map.state/error-count (s/map-of :map/layer integer?))

--- a/frontend/src/cljs/imas_seamap/specs/app_state.cljs
+++ b/frontend/src/cljs/imas_seamap/specs/app_state.cljs
@@ -169,7 +169,6 @@
 (s/def :map/priority-cutoff (s/and pos? integer?))
 
 (s/def :map.logic/type #{:map.layer-logic/automatic :map.layer-logic/manual})
-(s/def :map.logic/trigger #{:map.logic.trigger/automatic :map.logic.trigger/user})
 (s/def :map/logic (s/keys :req-un [:map.logic/type :map.logic/trigger]))
 
 (s/def ::habitat-titles  (s/map-of string? (s/nilable string?)))

--- a/frontend/src/cljs/imas_seamap/views.cljs
+++ b/frontend/src/cljs/imas_seamap/views.cljs
@@ -977,9 +977,6 @@
        {:label "Cancel"                 :combo "esc"}
        [:ui.drawing/cancel])
       (keydown-wrapper
-       {:label "Toggle Layer Logic"     :combo "m"}
-       [:map.layers.logic/toggle])
-      (keydown-wrapper
        {:label "Start Searching Layers" :combo "/" :prevent-default true}
        [:ui.search/focus])
       (keydown-wrapper

--- a/frontend/src/cljs/imas_seamap/views.cljs
+++ b/frontend/src/cljs/imas_seamap/views.cljs
@@ -293,7 +293,8 @@
                 :label     (reagent/as-element [:span icon label])
                 :on-change (handler-dispatch [:map.layers.logic/toggle true])}]]))
 
-(defn layer-logic-toggle-button []
+;; TODO: Remove, unused
+#_(defn layer-logic-toggle-button []
   (let [{:keys [type]} @(re-frame/subscribe [:map.layers/logic])]
     [:div#logic-toggle
      {:data-helper-text "Automatic layer selection picks the best layers to display, or turn off to list all available layers and choose your own"
@@ -903,8 +904,7 @@
                    {:heading "Controls"
                     :icon    "settings"}
                    [transect-toggle]
-                   [selection-button]
-                   [layer-logic-toggle-button]]
+                   [selection-button]]
                   
                   [components/drawer-group
                    {:heading "Settings"

--- a/frontend/src/cljs/imas_seamap/views.cljs
+++ b/frontend/src/cljs/imas_seamap/views.cljs
@@ -1002,7 +1002,6 @@
       [plot-component]]
      [helper-overlay
       :layer-search
-      :logic-toggle
       :plot-footer
       {:selector   ".group-scrollable"
        :helperText "Layers available in your current field of view (zoom out to see more)"}

--- a/frontend/src/cljs/imas_seamap/views.cljs
+++ b/frontend/src/cljs/imas_seamap/views.cljs
@@ -277,6 +277,16 @@
                 :on-click   (handler-dispatch [dispatch-key])
                 :text       label}]]))
 
+(defn viewport-only-toggle []
+  (let [[icon text] (if @(re-frame/subscribe [:map/viewport-only?])
+                      ["map" "Viewport layers only"]
+                      ["globe" "All layers"])]
+    [b/button
+     {:icon     icon
+      :class    "bp3-fill"
+      :on-click #(re-frame/dispatch [:map/toggle-viewport-only])
+      :text     text}]))
+
 ;; TODO: Remove, unused
 #_(defn layer-logic-toggle []
   (let [{:keys [type trigger]} @(re-frame/subscribe [:map.layers/logic])

--- a/frontend/src/cljs/imas_seamap/views.cljs
+++ b/frontend/src/cljs/imas_seamap/views.cljs
@@ -914,7 +914,8 @@
                    {:heading "Controls"
                     :icon    "settings"}
                    [transect-toggle]
-                   [selection-button]]
+                   [selection-button]
+                   [viewport-only-toggle]]
                   
                   [components/drawer-group
                    {:heading "Settings"

--- a/frontend/src/cljs/imas_seamap/views.cljs
+++ b/frontend/src/cljs/imas_seamap/views.cljs
@@ -857,7 +857,9 @@
 (defn left-drawer []
   (let [open? @(re-frame/subscribe [:left-drawer/open?])
         tab   @(re-frame/subscribe [:left-drawer/tab])
-        {:keys [filtered-layers active-layers visible-layers loading-layers error-layers expanded-layers layer-opacities]} @(re-frame/subscribe [:map/layers])]
+        {:keys [filtered-layers active-layers visible-layers viewport-layers loading-layers error-layers expanded-layers layer-opacities]} @(re-frame/subscribe [:map/layers])
+        viewport-only? @(re-frame/subscribe [:map/viewport-only?])
+        catalogue-layers (filterv #(or (not viewport-only?) ((set viewport-layers) %)) filtered-layers)]
     [components/drawer
      {:title
       [:div.left-drawer-header
@@ -881,7 +883,7 @@
          :panel (reagent/as-element
                  [:div
                   [layer-search-filter]
-                  [layer-catalogue filtered-layers
+                  [layer-catalogue catalogue-layers
                    {:active-layers  active-layers
                     :visible-layers visible-layers
                     :loading-fn     loading-layers


### PR DESCRIPTION
[ISA-222](https://jira.its.utas.edu.au/browse/ISA-222)

"Magic mode" has been replaced with an option that only shows layers within the current viewport.
![Screen Shot 2022-08-04 at 4 29 01 pm](https://user-images.githubusercontent.com/50224230/182779157-f468d59e-a00c-4834-9981-c9e1dfb68695.png)
![Screen Shot 2022-08-04 at 4 29 05 pm](https://user-images.githubusercontent.com/50224230/182779189-07653c86-eef7-4bed-8041-1c90f63c78a1.png)
![Screen Shot 2022-08-04 at 4 29 18 pm](https://user-images.githubusercontent.com/50224230/182779197-18cae36e-b694-47b0-bd20-20136e94ef27.png)

Need to figure out how we're going have the national layer displayed on load – hardcode it as suggested by Emma?