### PR TITLE
Feature: (ISA-221) Include server-set CSS in GetFeatureInfo popup

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -8,7 +8,6 @@
 __pycache__/
 local_settings.py
 db.sqlite3
-media/layer_previews/
-media/survey_graphs/
+media/
 
 # End of https://www.gitignore.io/api/django

--- a/backend/catalogue/management/commands/generate_layer_previews.py
+++ b/backend/catalogue/management/commands/generate_layer_previews.py
@@ -10,8 +10,9 @@ import logging
 
 from catalogue.models import Layer
 
+Image.MAX_IMAGE_PIXELS = None
 
-basemap = Image.open(default_storage.open('basemap.png'))
+basemap = Image.open(default_storage.open('land_shallow_topo_21600.tif'))
 
 
 def basemap_latitude_to_pixel(latitude):

--- a/frontend/src/cljs/imas_seamap/map/events.cljs
+++ b/frontend/src/cljs/imas_seamap/map/events.cljs
@@ -190,7 +190,7 @@
           feature-info  (reduce combine-feature-info {} feature-infos)
           had-insecure? (get-in db [:feature-query :had-insecure?])]
       (merge
-       {:location point :had-insecure? had-insecure?}
+       {:location point :had-insecure? had-insecure? :responses feature-infos}
        feature-info))))
 
 (defn got-feature-info [db [_ request-id point info-format response]]

--- a/frontend/src/cljs/imas_seamap/map/events.cljs
+++ b/frontend/src/cljs/imas_seamap/map/events.cljs
@@ -170,28 +170,19 @@
   (update-in db [:map :controls :ignore-click] not))
 
 (defn responses-feature-info [db point]
-  (letfn [(response-to-info ; Converts a response and info format into readable information for the feature info popup
-            [response]
-            (if-let [{:keys [response info-format]} response] ; If we have a response; then
-              (case info-format                               ; process the response into readable information; else
+  (letfn [(response-to-info [response] ; Converts a response and info format into readable information for the feature info popup
+            (when-let [{:keys [response info-format]} response] ; If we have a response then process the response into readable information
+              (case info-format
                 "text/html"        (feature-info-html response)
                 "application/json" (feature-info-json response)
-                feature-info-none)
-              {:status :feature-info/empty}))                 ; use an empty info status
-
-          (combine-feature-info ; Combines two feature infos into one
-            [{info-1 :info status-1 :status} {info-2 :info status-2 :status}]
-            (if (seq (str info-1 info-2))         ; If we have any info from either response; then
-              {:info (str info-1 info-2)}         ; combine the info from the responses and use that; else
-              {:status (or status-1 status-2)}))] ; just use the status from either response
+                feature-info-none)))]
     
     (let [responses     (get-in db [:feature-query :responses])
-          feature-infos (map response-to-info responses)
-          feature-info  (reduce combine-feature-info {} feature-infos)
+          responses     (vec (remove nil? (map response-to-info responses)))
           had-insecure? (get-in db [:feature-query :had-insecure?])]
       (merge
-       {:location point :had-insecure? had-insecure? :responses feature-infos}
-       feature-info))))
+       {:location point :had-insecure? had-insecure? :responses responses}
+       (when (empty? responses) {:status :feature-info/empty})))))
 
 (defn got-feature-info [db [_ request-id point info-format response]]
   (if (not= request-id (get-in db [:feature-query :request-id]))

--- a/frontend/src/cljs/imas_seamap/map/utils.cljs
+++ b/frontend/src/cljs/imas_seamap/map/utils.cljs
@@ -222,19 +222,22 @@
         str)))
 
 (def feature-info-none
-  {:body
+  {:style nil
+   :body
    (str
     "<div>"
-    "<h4>No info available</h4>"
-    "Layer summary not configured"
+    "    <h4>No info available</h4>"
+    "    Layer summary not configured"
     "</div>")})
 
 (defn feature-info-html
   [response]
   (let [parsed (.parseFromString (js/DOMParser.) response "text/html")
-        body  (first (array-seq (.querySelectorAll parsed "body")))]
+        body  (first (array-seq (.querySelectorAll parsed "body")))
+        style  (first (array-seq (.querySelectorAll parsed "style")))] ; only grabs the first style element
     (when (.-firstElementChild body)
-      {:body (.-innerHTML body)})))
+      {:style (when style (.-innerHTML style))
+       :body (.-innerHTML body)})))
 
 (defn feature-info-json
   [response]

--- a/frontend/src/cljs/imas_seamap/map/utils.cljs
+++ b/frontend/src/cljs/imas_seamap/map/utils.cljs
@@ -244,11 +244,31 @@
         property-to-row (fn [{:keys [label value]}] (str "<tr><td>" label "</td><td>" value "</td></tr>"))
         property-rows (str/join "" (map (fn [property] (property-to-row property)) properties))]
     (when (or id (not-empty properties))
-      {:body (str
-              "<div class=\"feature-info-json\">"
-              "<h4>" id "</h4>"
-              "<table>" property-rows "</table>"
-              "</div>")})))
+      {:style
+       (str
+        ".feature-info-json {"
+        "    max-height: 257px;"
+        "    overflow-y: scroll;"
+        "}"
+
+        ".feature-info-json table {"
+        "    border-spacing: 0;"
+        "}"
+
+        ".feature-info-json tr:nth-child(odd) {"
+        "    background-color: rgb(235, 235, 235);"
+        "}"
+
+        ".feature-info-json td {"
+        "    padding: 3px 0px 3px 10px;"
+        "    vertical-align: top;"
+        "}")
+       :body
+       (str
+        "<div class=\"feature-info-json\">"
+        "    <h4>" id "</h4>"
+        "    <table>" property-rows "</table>"
+        "</div>")})))
 
 (defn sort-by-sort-key
   "Sorts a collection by its sort-key first and its id second."

--- a/frontend/src/cljs/imas_seamap/map/utils.cljs
+++ b/frontend/src/cljs/imas_seamap/map/utils.cljs
@@ -222,19 +222,19 @@
         str)))
 
 (def feature-info-none
-  {:info (str
-          "<div>"
-          "<h4>No info available</h4>"
-          "Layer summary not configured"
-          "</div>")})
+  {:body
+   (str
+    "<div>"
+    "<h4>No info available</h4>"
+    "Layer summary not configured"
+    "</div>")})
 
 (defn feature-info-html
   [response]
   (let [parsed (.parseFromString (js/DOMParser.) response "text/html")
         body  (first (array-seq (.querySelectorAll parsed "body")))]
-    (if (.-firstElementChild body)
-      {:info (.-innerHTML body)}
-      {:status :feature-info/empty})))
+    (when (.-firstElementChild body)
+      {:body (.-innerHTML body)})))
 
 (defn feature-info-json
   [response]
@@ -243,13 +243,12 @@
         properties (map (fn [[label value]] {:label label :value value}) (get-in parsed ["features" 0 "properties"]))
         property-to-row (fn [{:keys [label value]}] (str "<tr><td>" label "</td><td>" value "</td></tr>"))
         property-rows (str/join "" (map (fn [property] (property-to-row property)) properties))]
-    (if (or id (not-empty properties))
-      {:info (str
+    (when (or id (not-empty properties))
+      {:body (str
               "<div class=\"feature-info-json\">"
               "<h4>" id "</h4>"
               "<table>" property-rows "</table>"
-              "</div>")}
-      {:status :feature-info/empty})))
+              "</div>")})))
 
 (defn sort-by-sort-key
   "Sorts a collection by its sort-key first and its id second."

--- a/frontend/src/cljs/imas_seamap/map/views.cljs
+++ b/frontend/src/cljs/imas_seamap/map/views.cljs
@@ -130,7 +130,7 @@
     [b/tooltip {:content "Create Shareable URL" :position b/RIGHT}
      [b/icon {:icon "share"}]]]])
 
-(defn popup-component [{:keys [status info-body had-insecure? responses] :as _feature-popup}]
+(defn popup-component [{:keys [status had-insecure? responses] :as _feature-popup}]
   (case status
     :feature-info/waiting        [b/non-ideal-state
                                   {:icon (r/as-element [b/spinner {:intent "success"}])}]
@@ -153,7 +153,7 @@
       (fn [element]
         (when element
           (set! (.-innerHTML element) nil)
-          (doseq [{body :info} responses]
+          (doseq [{body :body} responses]
             (.appendChild
              element
              (create-shadow-dom-element
@@ -168,7 +168,7 @@
   (let [{:keys [center zoom bounds]}                  @(re-frame/subscribe [:map/props])
         {:keys [layer-opacities visible-layers]}      @(re-frame/subscribe [:map/layers])
         {:keys [grouped-base-layers active-base-layer]} @(re-frame/subscribe [:map/base-layers])
-        {:keys [has-info? info-body location] :as fi} @(re-frame/subscribe [:map.feature/info])
+        {:keys [has-info? responses location] :as fi} @(re-frame/subscribe [:map.feature/info])
         {:keys [drawing? query mouse-loc]}            @(re-frame/subscribe [:transect/info])
         {:keys [selecting? region]}                   @(re-frame/subscribe [:map.layer.selection/info])
         download-info                                 @(re-frame/subscribe [:download/info])
@@ -300,6 +300,6 @@
         ;; Key forces creation of new node; otherwise it's closed but not reopened with new content:
          ^{:key (str location)}
          [leaflet/popup {:position location :max-width "100%" :auto-pan false}
-          ^{:key (or info-body (:status fi))}
+          ^{:key (str (or responses (:status fi)))}
           [popup-component fi]])]]
           children)))

--- a/frontend/src/cljs/imas_seamap/map/views.cljs
+++ b/frontend/src/cljs/imas_seamap/map/views.cljs
@@ -153,12 +153,8 @@
       (fn [element]
         (when element
           (set! (.-innerHTML element) nil)
-          (doseq [{body :body} responses]
-            (.appendChild
-             element
-             (create-shadow-dom-element
-              {:style ".floating-pill { background-color: red; }"
-               :body  body})))))}]))
+          (doseq [{:keys [_body _style] :as response} responses]
+            (.appendChild element (create-shadow-dom-element response)))))}]))
 
 (defn- add-raw-handler-once [js-obj event-name handler]
   (when-not (. js-obj listens event-name)

--- a/frontend/src/cljs/imas_seamap/subs.cljs
+++ b/frontend/src/cljs/imas_seamap/subs.cljs
@@ -41,11 +41,12 @@
     (scale-distance s1 s2 remainder-pct)))
 
 (defn feature-info [{:keys [feature] :as _db} _]
-  (if-let [{:keys [status info location had-insecure?]} feature]
+  (if-let [{:keys [status info location had-insecure? responses]} feature]
     {:has-info? true
      :had-insecure? had-insecure?
      :status status
      :info-body info
+     :responses responses
      :location ((juxt :lat :lng) location)}
     {:has-info? false}))
 

--- a/frontend/src/cljs/imas_seamap/subs.cljs
+++ b/frontend/src/cljs/imas_seamap/subs.cljs
@@ -41,11 +41,10 @@
     (scale-distance s1 s2 remainder-pct)))
 
 (defn feature-info [{:keys [feature] :as _db} _]
-  (if-let [{:keys [status info location had-insecure? responses]} feature]
+  (if-let [{:keys [status location had-insecure? responses]} feature]
     {:has-info? true
      :had-insecure? had-insecure?
      :status status
-     :info-body info
      :responses responses
      :location ((juxt :lat :lng) location)}
     {:has-info? false}))

--- a/frontend/src/cljs/imas_seamap/utils.cljs
+++ b/frontend/src/cljs/imas_seamap/utils.cljs
@@ -177,3 +177,17 @@
   "Returns the first item in a collection that fulfills the predicate."
   [pred coll]
   (first (filter pred coll)))
+
+(defn create-shadow-dom-element [{:keys [style body]}]
+  (let [element       (js/document.createElement "div")
+        style-element (js/document.createElement "style")
+        body-element  (js/document.createElement "body")
+        shadow        (.attachShadow element (clj->js {:mode "closed"}))]
+
+    (set! (.-textContent style-element) style)
+    (set! (.-innerHTML body-element) body)
+
+    (.appendChild shadow style-element)
+    (.appendChild shadow body-element)
+
+    element))

--- a/frontend/src/ui/css/app.scss
+++ b/frontend/src/ui/css/app.scss
@@ -567,24 +567,6 @@ input.leaflet-control-layers-selector[type="radio"] {
     margin-left: 3px;
 }
 
-.feature-info-json {
-    max-height: 257px;
-    overflow-y: scroll;
-}
-
-.feature-info-json table {
-    border-spacing: 0;
-}
-
-.feature-info-json tr:nth-child(odd) {
-    background-color: rgb(235, 235, 235);
-}
-
-.feature-info-json td {
-    padding: 3px 0px 3px 10px;
-    vertical-align: top;
-}
-
 .left-drawer-header {
     padding: 12px;
 }


### PR DESCRIPTION
[ISA-221](https://jira.its.utas.edu.au/browse/ISA-221)

Thanks to the encapsulation provided by [Shadow-DOM](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM), we can now include the style from GetFeatureInfo responses in addition to their body content. This has fixed the GFI display for a few layers.

Before:
![Screen Shot 2022-08-05 at 5 22 23 pm](https://user-images.githubusercontent.com/50224230/183025728-a4c6c20b-e27a-4bcb-942c-9e5452c890da.png)
After:
![Screen Shot 2022-08-05 at 5 22 37 pm](https://user-images.githubusercontent.com/50224230/183025745-410479a6-0be5-437d-b246-a01b7b14d45b.png)
