### PR TITLE
Feature: (ISA-222, ISA-223, & ISA-225) Keyed-layers

### DIFF
--- a/backend/catalogue/admin.py
+++ b/backend/catalogue/admin.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2017, Institute of Marine & Antarctic Studies.  Written by Condense Pty Ltd.
 # Released under the Affero General Public Licence (AGPL) v3.  See LICENSE file for details.
 from django.contrib import admin
-from .models import Category, DataClassification, Organisation, ServerType, Layer, LayerGroup, LayerGroupPriority, HabitatDescriptor, BaseLayerGroup, SaveState
+from .models import Category, DataClassification, Organisation, ServerType, Layer, LayerGroup, LayerGroupPriority, HabitatDescriptor, BaseLayerGroup, SaveState, KeyedLayer
 
 admin.site.register(Category)
 admin.site.register(DataClassification)
@@ -14,3 +14,4 @@ admin.site.register(LayerGroup)
 admin.site.register(LayerGroupPriority)
 admin.site.register(BaseLayerGroup)
 admin.site.register(SaveState)
+admin.site.register(KeyedLayer)

--- a/backend/catalogue/models.py
+++ b/backend/catalogue/models.py
@@ -150,3 +150,11 @@ class SaveState(models.Model):
 
     def __str__(self):
         return self.id
+
+@python_2_unicode_compatible
+class KeyedLayer(models.Model):
+    keyword = models.CharField(max_length = 200, primary_key=True)
+    layer = models.ForeignKey(Layer, on_delete=models.PROTECT)
+
+    def __str__(self):
+        return self.keyword

--- a/backend/catalogue/models.py
+++ b/backend/catalogue/models.py
@@ -153,7 +153,7 @@ class SaveState(models.Model):
 
 @python_2_unicode_compatible
 class KeyedLayer(models.Model):
-    keyword = models.CharField(max_length = 200, primary_key=True)
+    keyword = models.CharField(max_length = 200)
     layer = models.ForeignKey(Layer, on_delete=models.PROTECT)
 
     def __str__(self):

--- a/backend/catalogue/serializers.py
+++ b/backend/catalogue/serializers.py
@@ -106,4 +106,4 @@ class CategorySerializer(serializers.ModelSerializer):
 class KeyedLayerSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.KeyedLayer
-        fields = '__all__'
+        fields = ('keyword', 'layer')

--- a/backend/catalogue/serializers.py
+++ b/backend/catalogue/serializers.py
@@ -102,3 +102,8 @@ class CategorySerializer(serializers.ModelSerializer):
     class Meta:
         model = models.Category
         fields = '__all__'
+
+class KeyedLayerSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = models.KeyedLayer
+        fields = '__all__'

--- a/backend/catalogue/viewsets.py
+++ b/backend/catalogue/viewsets.py
@@ -57,3 +57,8 @@ class BaseLayerGroupViewset(viewsets.ReadOnlyModelViewSet):
 class CategoryViewset(viewsets.ReadOnlyModelViewSet):
     queryset = models.Category.objects.all()
     serializer_class = serializers.CategorySerializer
+
+
+class KeyedLayerViewset(viewsets.ReadOnlyModelViewSet):
+    queryset = models.KeyedLayer.objects.all()
+    serializer_class = serializers.KeyedLayerSerializer

--- a/backend/webapp/urls.py
+++ b/backend/webapp/urls.py
@@ -24,6 +24,7 @@ router.register(r'priorities', viewsets.GroupPriorityViewset)
 router.register(r'descriptors', viewsets.DescriptorViewset)
 router.register(r'baselayergroups', viewsets.BaseLayerGroupViewset)
 router.register(r'categories', viewsets.CategoryViewset)
+router.register(r'keyedlayers', viewsets.KeyedLayerViewset)
 
 urlpatterns = [
     re_path(r'^api/habitat/transect', transect),

--- a/database/Procedures/UpdateBathymetry.sql
+++ b/database/Procedures/UpdateBathymetry.sql
@@ -26,6 +26,12 @@ BEGIN
     [Group]      INT         NOT NULL
   );
 
+  DROP TABLE IF EXISTS ##T4;
+  CREATE TABLE ##T4 (
+    [geom]       GEOMETRY    NOT NULL,
+    [Group]      INT         NOT NULL
+  );
+
   DROP TABLE IF EXISTS ##Groups;
   CREATE TABLE ##Groups (
     [geom]       GEOMETRY    NOT NULL
@@ -38,7 +44,7 @@ BEGIN
       ROW_NUMBER() OVER(
         ORDER BY [RESOLUTION], [RANK], [ID]
       ) - 1
-    ) / 15
+    ) / 10
   FROM [dbo].[VW_BATHYMETRY]
   WHERE [RESOLUTION] = @resolution;
   
@@ -60,13 +66,24 @@ BEGIN
       ROW_NUMBER() OVER(
         ORDER BY [Group]
       ) - 1
-    ) / 5
+    ) / 3
   FROM ##T2
+  GROUP BY [Group];
+
+  INSERT INTO ##T4
+  SELECT
+    GEOMETRY::UnionAggregate([geom]),
+    (
+      ROW_NUMBER() OVER(
+        ORDER BY [Group]
+      ) - 1
+    ) / 3
+  FROM ##T3
   GROUP BY [Group];
 
   INSERT INTO ##Groups
   SELECT GEOMETRY::UnionAggregate([geom])
-  FROM ##T3
+  FROM ##T4
   GROUP BY [Group];
 
   DECLARE @geom GEOMETRY = (

--- a/frontend/src/cljs/imas_seamap/core.cljs
+++ b/frontend/src/cljs/imas_seamap/core.cljs
@@ -154,6 +154,7 @@
     :map/update-priorities                mevents/update-priorities
     :map/update-descriptors               mevents/update-descriptors
     :map/update-categories                mevents/update-categories
+    :map/update-keyed-layers              mevents/update-keyed-layers
     :map/update-preview-layer             mevents/update-preview-layer
     :map/initialise-display               [mevents/show-initial-layers]
     :map/pan-to-layer                     [mevents/zoom-to-layer]

--- a/frontend/src/cljs/imas_seamap/db.cljs
+++ b/frontend/src/cljs/imas_seamap/db.cljs
@@ -28,6 +28,7 @@
                      :hidden-layers   #{}
                      :preview-layer   nil
                      :viewport-only?  false
+                     :keyed-layers    {}
                      :controls        {:transect false
                                        :download nil}}
    :state-of-knowledge {:boundaries {:active-boundary nil
@@ -93,6 +94,7 @@
                      :descriptor-url        (str api-url-base "descriptors/")
                      :save-state-url        (str api-url-base "savestates")
                      :category-url          (str api-url-base "categories/")
+                     :keyed-layers-url      (str api-url-base "keyedlayers/")
                      :amp-boundaries-url    (str api-url-base "habitat/ampboundaries")
                      :imcra-boundaries-url  (str api-url-base "habitat/imcraboundaries")
                      :meow-boundaries-url   (str api-url-base "habitat/meowboundaries")

--- a/frontend/src/cljs/imas_seamap/events.cljs
+++ b/frontend/src/cljs/imas_seamap/events.cljs
@@ -109,7 +109,7 @@
                   base-layer-groups
                   grouped-base-layers groups
                   priorities organisations
-                  categories]
+                  categories keyed-layers]
                  :as _map-state} :map
                 {{{:keys [networks parks zones zones-iucn]} :amp
                   {:keys [provincial-bioregions mesoscale-bioregions]} :imcra
@@ -124,7 +124,8 @@
                                    :groups              groups
                                    :priorities          priorities
                                    :organisations       organisations
-                                   :categories          categories})
+                                   :categories          categories
+                                   :keyed-layers        keyed-layers})
                (update-in
                 [:state-of-knowledge :boundaries]
                 #(-> %

--- a/frontend/src/cljs/imas_seamap/events.cljs
+++ b/frontend/src/cljs/imas_seamap/events.cljs
@@ -141,7 +141,7 @@
                (merge {:habitat-colours habitat-colours
                        :habitat-titles  habitat-titles
                        :sorting         sorting}))]
-    (assoc-in db [:map :active-layers] (or (get-in db [:map :keyed-layers :startup]) []))))
+    (assoc-in db [:map :active-layers] (get-in db [:map :keyed-layers :startup] []))))
 
 (defn loading-screen [db [_ msg]]
   (assoc db

--- a/frontend/src/cljs/imas_seamap/events.cljs
+++ b/frontend/src/cljs/imas_seamap/events.cljs
@@ -141,7 +141,7 @@
                (merge {:habitat-colours habitat-colours
                        :habitat-titles  habitat-titles
                        :sorting         sorting}))]
-    (assoc-in db [:map :active-layers] [(:habitat (get-in db [:map :keyed-layers]))])))
+    (assoc-in db [:map :active-layers] (or (get-in db [:map :keyed-layers :startup]) []))))
 
 (defn loading-screen [db [_ msg]]
   (assoc db

--- a/frontend/src/cljs/imas_seamap/events.cljs
+++ b/frontend/src/cljs/imas_seamap/events.cljs
@@ -186,6 +186,7 @@
                 classification-url priority-url
                 descriptor-url
                 category-url
+                keyed-layers-url
                 amp-boundaries-url
                 imcra-boundaries-url
                 meow-boundaries-url]} (:config db)]
@@ -234,6 +235,11 @@
                    :uri             category-url
                    :response-format (ajax/json-response-format {:keywords? true})
                    :on-success      [:map/update-categories]
+                   :on-failure      [:ajax/default-err-handler]}
+                  {:method          :get
+                   :uri             keyed-layers-url
+                   :response-format (ajax/json-response-format {:keywords? true})
+                   :on-success      [:map/update-keyed-layers]
                    :on-failure      [:ajax/default-err-handler]}
                   {:method          :get
                    :uri             amp-boundaries-url

--- a/frontend/src/cljs/imas_seamap/events.cljs
+++ b/frontend/src/cljs/imas_seamap/events.cljs
@@ -141,7 +141,7 @@
                (merge {:habitat-colours habitat-colours
                        :habitat-titles  habitat-titles
                        :sorting         sorting}))]
-    (assoc-in db [:map :active-layers] (vec (applicable-layers db :category :habitat)))))
+    (assoc-in db [:map :active-layers] [(:habitat (get-in db [:map :keyed-layers]))])))
 
 (defn loading-screen [db [_ msg]]
   (assoc db

--- a/frontend/src/cljs/imas_seamap/map/events.cljs
+++ b/frontend/src/cljs/imas_seamap/map/events.cljs
@@ -428,7 +428,7 @@
   (let [{:keys [active active-base _legend-ids]} (:map db)
         active-layers (if active
                         (vec (ids->layers active (get-in db [:map :layers])))
-                        (or (get-in db [:map :keyed-layers :startup]) []))
+                        (get-in db [:map :keyed-layers :startup] []))
         active-base   (->> (get-in db [:map :grouped-base-layers]) (filter (comp #(= active-base %) :id)) first)
         active-base   (or active-base   ; If no base is set (eg no existing hash-state), use the first candidate
                           (first (get-in db [:map :grouped-base-layers])))

--- a/frontend/src/cljs/imas_seamap/map/events.cljs
+++ b/frontend/src/cljs/imas_seamap/map/events.cljs
@@ -428,7 +428,7 @@
   (let [{:keys [active active-base _legend-ids]} (:map db)
         active-layers (if active
                         (vec (ids->layers active (get-in db [:map :layers])))
-                        [(:habitat (get-in db [:map :keyed-layers]))])
+                        (or (get-in db [:map :keyed-layers :startup]) []))
         active-base   (->> (get-in db [:map :grouped-base-layers]) (filter (comp #(= active-base %) :id)) first)
         active-base   (or active-base   ; If no base is set (eg no existing hash-state), use the first candidate
                           (first (get-in db [:map :grouped-base-layers])))

--- a/frontend/src/cljs/imas_seamap/map/events.cljs
+++ b/frontend/src/cljs/imas_seamap/map/events.cljs
@@ -420,7 +420,9 @@
   ;; :active-base-layer
   [{:keys [db]} _]
   (let [{:keys [active active-base _legend-ids]} (:map db)
-        active-layers (vec (ids->layers active (get-in db [:map :layers])))
+        active-layers (if active
+                        (vec (ids->layers active (get-in db [:map :layers])))
+                        [(:habitat (get-in db [:map :keyed-layers]))])
         active-base   (->> (get-in db [:map :grouped-base-layers]) (filter (comp #(= active-base %) :id)) first)
         active-base   (or active-base   ; If no base is set (eg no existing hash-state), use the first candidate
                           (first (get-in db [:map :grouped-base-layers])))

--- a/frontend/src/cljs/imas_seamap/map/events.cljs
+++ b/frontend/src/cljs/imas_seamap/map/events.cljs
@@ -277,12 +277,22 @@
   (let [db (assoc-in db [:map :base-layers] layers)]
     (update-grouped-base-layers db)))
 
+(defn- keyed-layers-join
+  "Using layers and keyed-layers, replaces layer IDs in keyed-layers with layer
+   objects."
+  [{{:keys [layers keyed-layers]} :map :as db}]
+  (let [keyed-layers (reduce-kv
+                      (fn [m k v] (assoc m k (or (first-where #(= (:id %) v) layers) v)))
+                      {} keyed-layers)]
+    (assoc-in db [:map :keyed-layers] keyed-layers)))
+
 (defn update-layers [{:keys [legend-ids opacity-ids] :as db} [_ layers]]
-  (let [layers (process-layers layers)]
-    (-> db
-        (assoc-in [:map :layers] layers)
-        (assoc-in [:layer-state :legend-shown] (init-layer-legend-status layers legend-ids))
-        (assoc-in [:layer-state :opacity] (init-layer-opacities layers opacity-ids)))))
+  (let [layers (process-layers layers)
+        db     (-> db
+                   (assoc-in [:map :layers] layers)
+                   (assoc-in [:layer-state :legend-shown] (init-layer-legend-status layers legend-ids))
+                   (assoc-in [:layer-state :opacity] (init-layer-opacities layers opacity-ids)))]
+    (keyed-layers-join db)))
 
 (defn update-groups [db [_ groups]]
   (assoc-in db [:map :groups] groups))
@@ -320,6 +330,12 @@
     (-> db
         (assoc-in [:map :categories] categories)
         (assoc-in [:sorting :category] (->sort-map categories)))))
+
+(defn update-keyed-layers [db [_ keyed-layers]]
+  (let [keyed-layers (map #(update % :keyword (comp keyword string/lower-case)) keyed-layers) ; keywordize
+        keyed-layers (reduce (fn [acc {:keys [keyword layer]}] (assoc acc keyword layer)) {} keyed-layers) ; to map
+        db           (assoc-in db [:map :keyed-layers] keyed-layers)]
+    (keyed-layers-join db)))
 
 (defn layer-started-loading [db [_ layer]]
   (update-in db [:layer-state :loading-state] assoc layer :map.layer/loading))

--- a/frontend/src/cljs/imas_seamap/map/events.cljs
+++ b/frontend/src/cljs/imas_seamap/map/events.cljs
@@ -279,12 +279,15 @@
 
 (defn- keyed-layers-join
   "Using layers and keyed-layers, replaces layer IDs in keyed-layers with layer
-   objects."
+   objects. We only update keyed-layers if the db contains layers."
   [{{:keys [layers keyed-layers]} :map :as db}]
-  (let [keyed-layers (reduce-kv
-                      (fn [m k v] (assoc m k (or (first-where #(= (:id %) v) layers) v)))
-                      {} keyed-layers)]
-    (assoc-in db [:map :keyed-layers] keyed-layers)))
+  (if (seq layers)
+    (assoc-in
+     db [:map :keyed-layers]
+     (reduce-kv
+      (fn [m k v] (assoc m k (vec (ids->layers v layers))))
+      {} keyed-layers))
+    db))
 
 (defn update-layers [{:keys [legend-ids opacity-ids] :as db} [_ layers]]
   (let [layers (process-layers layers)
@@ -333,7 +336,10 @@
 
 (defn update-keyed-layers [db [_ keyed-layers]]
   (let [keyed-layers (map #(update % :keyword (comp keyword string/lower-case)) keyed-layers) ; keywordize
-        keyed-layers (reduce (fn [acc {:keys [keyword layer]}] (assoc acc keyword layer)) {} keyed-layers) ; to map
+        keyed-layers (group-by :keyword keyed-layers) ; to map
+        keyed-layers (reduce-kv
+                      (fn [m k v] (assoc m k (mapv :layer v)))
+                      {} keyed-layers) ; remove junk, isolate layer IDs
         db           (assoc-in db [:map :keyed-layers] keyed-layers)]
     (keyed-layers-join db)))
 

--- a/frontend/src/cljs/imas_seamap/specs/app_state.cljs
+++ b/frontend/src/cljs/imas_seamap/specs/app_state.cljs
@@ -170,6 +170,9 @@
 
 (s/def :map/viewport-only? boolean?)
 
+(s/def :map/keyed-layers
+  (s/map-of keyword? #{integer? :map/layer}))
+
 (s/def ::habitat-titles  (s/map-of string? (s/nilable string?)))
 (s/def ::habitat-colours (s/map-of string? string?))
 
@@ -189,7 +192,8 @@
                    :map/organisations
                    :map/priorities
                    :map/priority-cutoff
-                   :map/viewport-only?]))
+                   :map/viewport-only?
+                   :map/keyed-layers]))
 
 (s/def :layer/loading-state #{:map.layer/loading :map.layer/loaded})
 (s/def :map.state/error-count (s/map-of :map/layer integer?))

--- a/frontend/src/cljs/imas_seamap/specs/app_state.cljs
+++ b/frontend/src/cljs/imas_seamap/specs/app_state.cljs
@@ -171,7 +171,7 @@
 (s/def :map/viewport-only? boolean?)
 
 (s/def :map/keyed-layers
-  (s/map-of keyword? #{integer? :map/layer}))
+  (s/map-of keyword? (s/coll-of #{integer? :map/layer})))
 
 (s/def ::habitat-titles  (s/map-of string? (s/nilable string?)))
 (s/def ::habitat-colours (s/map-of string? string?))

--- a/frontend/src/cljs/imas_seamap/state_of_knowledge/events.cljs
+++ b/frontend/src/cljs/imas_seamap/state_of_knowledge/events.cljs
@@ -53,7 +53,7 @@
                               :else            :meow-realm)
 
                     nil)]
-    (when layer-key (layer-key keyed-layers))))
+    (when layer-key (first (layer-key keyed-layers)))))
 
 (defn update-active-boundary-layer [{:keys [db]} _]
   (let [keyed-layers (get-in db [:map :keyed-layers])

--- a/frontend/src/cljs/imas_seamap/state_of_knowledge/events.cljs
+++ b/frontend/src/cljs/imas_seamap/state_of_knowledge/events.cljs
@@ -30,36 +30,37 @@
 (defn- select-boundary-layer
   "Based on the currently active boundary and boundary filters, select an
    appropriate boundary layer."
-  [layers {boundary-id :id} {:keys [amp imcra meow] :as _boundaries}]
+  [keyed-layers {boundary-id :id} {:keys [amp imcra meow] :as _boundaries}]
   (let [{:keys [active-park active-zone active-zone-iucn]} amp
         {:keys [active-mesoscale-bioregion]} imcra
         {:keys [active-province active-ecoregion]} meow
 
-        layer-id (case boundary-id
-                   
-                   "amp"   (cond
-                             (or active-zone active-zone-iucn) 1520
-                             active-park                       1569
-                             :else                             1567)
+        layer-key (case boundary-id
 
-                   "imcra" (cond
-                             active-mesoscale-bioregion 1500
-                             :else                      182)
+                    "amp"   (cond
+                              active-zone-iucn :amp-zone-iucn
+                              active-zone      :amp-zone
+                              active-park      :amp-park
+                              :else            :amp-network)
 
-                   "meow"  (cond
-                             active-ecoregion 1570
-                             active-province  189
-                             :else            181)
+                    "imcra" (cond
+                              active-mesoscale-bioregion :imcra-mesoscale-bioregion
+                              :else                      :imcra-provincial-bioregion)
 
-                   nil)]
-    (first-where #(= (:id %) layer-id) layers)))
+                    "meow"  (cond
+                              active-ecoregion :meow-ecoregion
+                              active-province  :meow-province
+                              :else            :meow-realm)
+
+                    nil)]
+    (when layer-key (layer-key keyed-layers))))
 
 (defn update-active-boundary-layer [{:keys [db]} _]
-  (let [layers (get-in db [:map :layers])
+  (let [keyed-layers (get-in db [:map :keyed-layers])
         active-boundary (get-in db [:state-of-knowledge :boundaries :active-boundary])
 
         previous-boundary-layer (get-in db [:state-of-knowledge :boundaries :active-boundary-layer])
-        current-boundary-layer  (select-boundary-layer layers active-boundary (get-in db [:state-of-knowledge :boundaries]))
+        current-boundary-layer  (select-boundary-layer keyed-layers active-boundary (get-in db [:state-of-knowledge :boundaries]))
 
         db                      (assoc-in db [:state-of-knowledge :boundaries :active-boundary-layer] current-boundary-layer)]
     {:db db


### PR DESCRIPTION
[ISA-222](https://jira.its.utas.edu.au/browse/ISA-222), [ISA-223](https://jira.its.utas.edu.au/browse/ISA-223), [ISA-225](https://jira.its.utas.edu.au/browse/ISA-225)

It's become increasingly clear that there's a need to be able to have "hardcoded" layers in the app for certain situations (e.g. default layer(s) on startup). This is a problem if IMAS needs to swap out what hardcoded layers are used in the app if they update the layers in the future.

The solution to this is having a fixed-length table with discrete keywords that alias layers that can then be used in the app instead of directly referring to a layer's ID. What this means is that if IMAS needs to switch out a hardcoded layer in the app, all they need to do is update the keyed-layers table.