### PR TITLE
Feature: (ISA-228) Remove no results popup

### DIFF
--- a/frontend/src/cljs/imas_seamap/map/views.cljs
+++ b/frontend/src/cljs/imas_seamap/map/views.cljs
@@ -355,7 +355,7 @@
        (when has-info?
         ;; Key forces creation of new node; otherwise it's closed but not reopened with new content:
          ^{:key (str location)}
-         [leaflet/popup {:position location :max-width "100%" :auto-pan false}
+         [leaflet/popup {:position location :max-width "100%" :auto-pan false :class (when (= (:status fi) :feature-info/waiting) "waiting")}
           ^{:key (str (or responses (:status fi)))}
           [popup-component fi]])]]
           children)))

--- a/frontend/src/cljs/imas_seamap/map/views.cljs
+++ b/frontend/src/cljs/imas_seamap/map/views.cljs
@@ -193,17 +193,10 @@
    (update :x + (* 2 30))   ; add horizontal padding
    (update :y + (* 2 27)))) ; add vertical padding
 
-(defn popup-component [{:keys [status had-insecure? responses] :as _feature-popup}]
+(defn popup-contents [{:keys [status responses]}]
   (case status
     :feature-info/waiting        [b/non-ideal-state
                                   {:icon (r/as-element [b/spinner {:intent "success"}])}]
-    #_:feature-info/empty          #_[b/non-ideal-state ; should be unreachable, now that no popup is displayed if empty
-                                  (merge
-                                   {:title       "No Results"
-                                    :description "Try clicking elsewhere or adding another layer"
-                                    :icon        "warning-sign"
-                                    :ref         #(when % (re-frame/dispatch [:map/pan-to-popup {:x 305 :y 210}]))}
-                                   (when had-insecure? {:description "(Could not query all displayed external data layers)"}))]
     :feature-info/none-queryable [b/non-ideal-state
                                   {:title       "Invalid Info"
                                    :description "Could not query the external data provider"
@@ -223,6 +216,19 @@
             (.appendChild element (create-shadow-dom-element response)))
           (re-frame/dispatch [:map/pan-to-popup (popup-dimensions element)])))}]))
 
+(defn popup [{:keys [has-info? responses location status] :as _feature-info}]
+  (when (and has-info? (not= status :feature-info/empty))
+    
+    ;; Key forces creation of new node; otherwise it's closed but not reopened with new content:
+    ^{:key (str location)}
+    [leaflet/popup
+     {:position location
+      :max-width "100%"
+      :auto-pan false
+      :class (when (= status :feature-info/waiting) "waiting")}
+
+     ^{:key (str status responses)} [popup-contents {:status status :responses responses}]]))
+
 (defn- add-raw-handler-once [js-obj event-name handler]
   (when-not (. js-obj listens event-name)
     (. js-obj on event-name handler)))
@@ -231,9 +237,9 @@
   (let [{:keys [center zoom bounds]}                  @(re-frame/subscribe [:map/props])
         {:keys [layer-opacities visible-layers]}      @(re-frame/subscribe [:map/layers])
         {:keys [grouped-base-layers active-base-layer]} @(re-frame/subscribe [:map/base-layers])
-        {:keys [has-info? responses location] fi-status :status :as fi} @(re-frame/subscribe [:map.feature/info])
+        feature-info                                  @(re-frame/subscribe [:map.feature/info])
         {:keys [drawing? query mouse-loc] :as transect-info} @(re-frame/subscribe [:transect/info])
-        {:keys [selecting? region] :as region-info} @(re-frame/subscribe [:map.layer.selection/info])
+        {:keys [selecting? region] :as region-info}   @(re-frame/subscribe [:map.layer.selection/info])
         download-info                                 @(re-frame/subscribe [:download/info])
         boundary-filter                               @(re-frame/subscribe [:sok/boundary-layer-filter])
         loading?                                      @(re-frame/subscribe [:app/loading?])]
@@ -352,10 +358,6 @@
         {:position "bottomright"
          :style nil}]
 
-       (when (and has-info? (not= fi-status :feature-info/empty))
-        ;; Key forces creation of new node; otherwise it's closed but not reopened with new content:
-         ^{:key (str location)}
-         [leaflet/popup {:position location :max-width "100%" :auto-pan false :class (when (= fi-status :feature-info/waiting) "waiting")}
-          ^{:key (str (or responses fi-status))}
-          [popup-component fi]])]]
-          children)))
+       [popup feature-info]]]
+     
+     children)))

--- a/frontend/src/cljs/imas_seamap/map/views.cljs
+++ b/frontend/src/cljs/imas_seamap/map/views.cljs
@@ -197,7 +197,7 @@
   (case status
     :feature-info/waiting        [b/non-ideal-state
                                   {:icon (r/as-element [b/spinner {:intent "success"}])}]
-    :feature-info/empty          [b/non-ideal-state
+    #_:feature-info/empty          #_[b/non-ideal-state ; should be unreachable, now that no popup is displayed if empty
                                   (merge
                                    {:title       "No Results"
                                     :description "Try clicking elsewhere or adding another layer"
@@ -231,7 +231,7 @@
   (let [{:keys [center zoom bounds]}                  @(re-frame/subscribe [:map/props])
         {:keys [layer-opacities visible-layers]}      @(re-frame/subscribe [:map/layers])
         {:keys [grouped-base-layers active-base-layer]} @(re-frame/subscribe [:map/base-layers])
-        {:keys [has-info? responses location] :as fi} @(re-frame/subscribe [:map.feature/info])
+        {:keys [has-info? responses location] fi-status :status :as fi} @(re-frame/subscribe [:map.feature/info])
         {:keys [drawing? query mouse-loc] :as transect-info} @(re-frame/subscribe [:transect/info])
         {:keys [selecting? region] :as region-info} @(re-frame/subscribe [:map.layer.selection/info])
         download-info                                 @(re-frame/subscribe [:download/info])
@@ -352,10 +352,10 @@
         {:position "bottomright"
          :style nil}]
 
-       (when has-info?
+       (when (and has-info? (not= fi-status :feature-info/empty))
         ;; Key forces creation of new node; otherwise it's closed but not reopened with new content:
          ^{:key (str location)}
-         [leaflet/popup {:position location :max-width "100%" :auto-pan false :class (when (= (:status fi) :feature-info/waiting) "waiting")}
-          ^{:key (str (or responses (:status fi)))}
+         [leaflet/popup {:position location :max-width "100%" :auto-pan false :class (when (= fi-status :feature-info/waiting) "waiting")}
+          ^{:key (str (or responses fi-status))}
           [popup-component fi]])]]
           children)))

--- a/frontend/src/ui/css/app.scss
+++ b/frontend/src/ui/css/app.scss
@@ -740,3 +740,16 @@ input.leaflet-control-layers-selector[type="radio"] {
 .drawer-children {
     overflow-y: hidden;
 }
+
+.leaflet-popup.waiting .leaflet-popup-content-wrapper {
+    background: none;
+    box-shadow: none;
+}
+
+.leaflet-popup.waiting .leaflet-popup-tip-container {
+    display: none;
+}
+
+.leaflet-popup.waiting .leaflet-popup-close-button {
+    display: none;
+}


### PR DESCRIPTION
[ISA-228](https://jira.its.utas.edu.au/browse/ISA-228)

**Prerequisites:** PR #107 (because I didn't want to deal with any merge conflicts)

Feature-info waiting popup is now invisible (only shows loading spinner):
![Screen Shot 2022-08-11 at 12 46 30 pm](https://user-images.githubusercontent.com/50224230/184056898-6dddc2d2-2ed0-4429-b90f-8c80cabbee72.png)

When no results there is no popup:
![Screen Shot 2022-08-11 at 12 46 41 pm](https://user-images.githubusercontent.com/50224230/184056974-a4609c0a-60b6-4ef3-8758-21d514dc222c.png)
