### PR TITLE
Feature: (ISA-256) Vector legends

### DIFF
--- a/frontend/src/cljs/imas_seamap/core.cljs
+++ b/frontend/src/cljs/imas_seamap/core.cljs
@@ -39,6 +39,7 @@
     :map.layers/lookup                    msubs/map-layer-lookup
     ;:map.layers/params                    msubs/map-layer-extra-params-fn
     :map.layer/info                       subs/map-layer-info
+    :map.layer/legend                     msubs/layer-legend
     :map.layer.selection/info             msubs/layer-selection-info
     :map.feature/info                     subs/feature-info
     ;:map/region-stats                     msubs/region-stats

--- a/frontend/src/cljs/imas_seamap/core.cljs
+++ b/frontend/src/cljs/imas_seamap/core.cljs
@@ -153,7 +153,7 @@
     :map.region-stats/select-habitat      mevents/region-stats-select-habitat
     :map/update-base-layers               mevents/update-base-layers
     :map/update-base-layer-groups         mevents/update-base-layer-groups
-    :map/update-layers                    mevents/update-layers
+    :map/update-layers                    [mevents/update-layers]
     :map/update-organisations             mevents/update-organisations
     :map/update-classifications           mevents/update-classifications
     :map/update-descriptors               mevents/update-descriptors

--- a/frontend/src/cljs/imas_seamap/core.cljs
+++ b/frontend/src/cljs/imas_seamap/core.cljs
@@ -141,6 +141,8 @@
     :map.layer/opacity-changed            [mevents/layer-set-opacity]
     :map.layers/filter                    [mevents/map-set-layer-filter]
     :map.layers/others-filter             mevents/map-set-others-layer-filter
+    :map.layer/get-legend                 [mevents/get-layer-legend]
+    :map.layer/got-legend                 mevents/got-layer-legend
     :map.layer.legend/toggle              [mevents/toggle-legend-display]
     :map.layer.selection/enable           mevents/map-start-selecting
     :map.layer.selection/disable          mevents/map-cancel-selecting

--- a/frontend/src/cljs/imas_seamap/db.cljs
+++ b/frontend/src/cljs/imas_seamap/db.cljs
@@ -27,6 +27,7 @@
                      :preview-layer   nil
                      :viewport-only?  false
                      :keyed-layers    {}
+                     :legends         {}
                      :controls        {:transect false
                                        :download nil}}
    :state-of-knowledge {:boundaries {:active-boundary nil

--- a/frontend/src/cljs/imas_seamap/map/events.cljs
+++ b/frontend/src/cljs/imas_seamap/map/events.cljs
@@ -592,3 +592,21 @@
                           (pos? overflow-left) (- (* overflow-left x-to-lng))
                           (pos? overflow-right) (+ (* overflow-right x-to-lng)))]
     {:dispatch [:map/update-map-view {:center [map-lat map-lng]}]}))
+
+(defn get-layer-legend [{:keys [db]} [_ {:keys [id server_url layer_name] :as layer}]]
+  {:db         (assoc-in db [:map :legends id] :map.legend/loading)
+   :http-xhrio {:method          :get
+                :uri             server_url
+                :params          {:REQUEST     "GetLegendGraphic"
+                                  :LAYER       layer_name
+                                  :TRANSPARENT true
+                                  :SERVICE     "WMS"
+                                  :VERSION     "1.1.1"
+                                  :FORMAT      "application/json"}
+                :response-format (ajax/json-response-format {:keywords? true})
+                :on-success      [:map.layer/got-legend layer]
+                :on-failure      [:ajax/default-err-handler]}})
+
+(defn got-layer-legend [db [_ {:keys [id] :as _layer} legend]]
+  (let [rules (-> legend :Legend first :rules)]
+    (assoc-in db [:map :legends id] rules)))

--- a/frontend/src/cljs/imas_seamap/map/events.cljs
+++ b/frontend/src/cljs/imas_seamap/map/events.cljs
@@ -607,6 +607,6 @@
                 :on-success      [:map.layer/got-legend layer]
                 :on-failure      [:ajax/default-err-handler]}})
 
-(defn got-layer-legend [db [_ {:keys [id] :as _layer} legend]]
-  (let [rules (-> legend :Legend first :rules)]
-    (assoc-in db [:map :legends id] rules)))
+(defn got-layer-legend [db [_ {:keys [id] :as _layer} response]]
+  (let [legend (-> response :Legend first :rules)]
+    (assoc-in db [:map :legends id] legend)))

--- a/frontend/src/cljs/imas_seamap/map/events.cljs
+++ b/frontend/src/cljs/imas_seamap/map/events.cljs
@@ -395,10 +395,13 @@
      :put-hash (encode-state db)
      :dispatch [:map/popup-closed]}))
 
-(defn toggle-legend-display [{:keys [db]} [_ layer]]
+(defn toggle-legend-display [{:keys [db]} [_ {:keys [id] :as layer}]]
   (let [db (update-in db [:layer-state :legend-shown] #(if ((set %) layer) (disj % layer) (conj (set %) layer)))]
-    {:db       db
-     :put-hash (encode-state db)}))
+    (merge
+     {:db       db
+      :put-hash (encode-state db)}
+     (when (not (get-in db [:map :legends id]))  ; Retrieve layer legend data for display if we don't already have it or aren't already retrieving it
+       {:dispatch [:map.layer/get-legend layer]}))))
 
 (defn zoom-to-layer
   "Zoom to the layer's extent, adding it if it wasn't already."

--- a/frontend/src/cljs/imas_seamap/map/events.cljs
+++ b/frontend/src/cljs/imas_seamap/map/events.cljs
@@ -300,13 +300,16 @@
       {} keyed-layers))
     db))
 
-(defn update-layers [{:keys [legend-ids opacity-ids] :as db} [_ layers]]
-  (let [layers (process-layers layers)
+(defn update-layers [{:keys [db]} [_ layers]]
+  (let [{:keys [legend-ids opacity-ids]} db
+        layers (process-layers layers)
         db     (-> db
                    (assoc-in [:map :layers] layers)
                    (assoc-in [:layer-state :legend-shown] (init-layer-legend-status layers legend-ids))
-                   (assoc-in [:layer-state :opacity] (init-layer-opacities layers opacity-ids)))]
-    (keyed-layers-join db)))
+                   (assoc-in [:layer-state :opacity] (init-layer-opacities layers opacity-ids))
+                   keyed-layers-join)]
+    {:db         db
+     :dispatch-n (mapv #(vector :map.layer/get-legend %) (init-layer-legend-status layers legend-ids))}))
 
 (defn- ->sort-map [ms]
   ;; Associate a category of objects (categories, organisations) with

--- a/frontend/src/cljs/imas_seamap/map/layer_views.cljs
+++ b/frontend/src/cljs/imas_seamap/map/layer_views.cljs
@@ -3,7 +3,6 @@
             [reagent.core :as reagent]
             [imas-seamap.blueprint :as b]
             [imas-seamap.components :as components]
-            [imas-seamap.utils :refer [with-params]]
             #_[debux.cs.core :refer [dbg] :include-macros true]))
 
 (defn- layer-status-icons
@@ -90,15 +89,12 @@
     legend-info)])
 
 (defn- legend-display [{:keys [legend_url] :as layer}]
-  (let [{:keys [has-info? loading? info]} @(re-frame/subscribe [:map.layer/legend layer])]
+  (let [{:keys [has-info? info]} @(re-frame/subscribe [:map.layer/legend layer])]
     [:div.legend-wrapper
      (cond
        legend_url [:img {:src legend_url}] ; if we have a custom legend url, use that to display an image
        has-info?  [vector-legend info]     ; else if we have the info for the layer then display it
-       loading?   [b/spinner]              ; else if we're loading show that
-       :else      (do                      ; else dispatch a request for the legend info
-                    (re-frame/dispatch [:map.layer/get-legend layer])
-                    [b/spinner]))]))
+       :else      [b/spinner])]))          ; else if we're loading show that
 
 (defn- layer-details
   "Layer details, including advanced opacity slider control and the layer's legend."

--- a/frontend/src/cljs/imas_seamap/map/subs.cljs
+++ b/frontend/src/cljs/imas_seamap/map/subs.cljs
@@ -152,3 +152,10 @@
 
 (defn viewport-only? [db _]
   (get-in db [:map :viewport-only?]))
+
+(defn layer-legend [db [_ {:keys [id] :as _layer}]]
+  (let [legend-info (get-in db [:map :legends id])
+        loading?    (= legend-info :map.legend/loading)]
+    {:has-info? (and (not loading?) legend-info)
+     :loading?  loading?
+     :info      legend-info}))

--- a/frontend/src/cljs/imas_seamap/specs/app_state.cljs
+++ b/frontend/src/cljs/imas_seamap/specs/app_state.cljs
@@ -28,6 +28,7 @@
 (s/def :map/categories (s/coll-of :map/category
                                   :kind vector?))
 
+(s/def :map.layer/id integer?)
 (s/def :map.layer/name string?)
 (s/def :map.layer/server_url string?)
 (s/def :map.layer/legend_url string?)
@@ -158,7 +159,16 @@
 (s/def :map/viewport-only? boolean?)
 
 (s/def :map/keyed-layers
-  (s/map-of keyword? (s/coll-of #{integer? :map/layer})))
+  (s/map-of keyword?
+            (s/or
+             :id    integer?
+             :layer :map/layer)))
+
+(s/def :map/legends
+  (s/map-of :map.layer/id
+            (s/or
+             :loading #{:map.legend/loading}
+             :legend  map?)))
 
 (s/def ::habitat-titles  (s/map-of string? (s/nilable string?)))
 (s/def ::habitat-colours (s/map-of string? string?))

--- a/frontend/src/ui/css/app.scss
+++ b/frontend/src/ui/css/app.scss
@@ -764,3 +764,21 @@ input.leaflet-control-layers-selector[type="radio"] {
 .leaflet-popup.waiting .leaflet-popup-close-button {
     display: none;
 }
+
+.vector-legend-rule {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    height: 20px;
+}
+
+.vector-legend-rule > :first-child {
+    width: 13px;
+    height: 13px;
+    margin-left: 3px;
+}
+
+.vector-legend-rule > :nth-child(2) {
+    white-space: pre;
+    font-size: 13px;
+}


### PR DESCRIPTION
[ISA-256](https://jira.its.utas.edu.au/browse/ISA-256)

Now using vector legends instead of images.

Layers with a custom legend image url (e.g. MODELLED - Aus Bathymetry Grid 2019 - 250m [GA]) will still use the image from the url provided – open to opinions on this.

Before:
![Screen Shot 2022-08-30 at 1 39 41 pm](https://user-images.githubusercontent.com/50224230/187344222-40711112-7c85-4993-a216-3b14fe14fab2.png)
After:
![Screen Shot 2022-08-30 at 1 39 47 pm](https://user-images.githubusercontent.com/50224230/187344234-48dd97b9-0092-4b0b-b0f3-d16b27a14bfc.png)