### PR TITLE
Feature: (ISA-263) Richer main national layer card UI

### DIFF
--- a/frontend/src/cljs/imas_seamap/map/layer_views.cljs
+++ b/frontend/src/cljs/imas_seamap/map/layer_views.cljs
@@ -94,3 +94,35 @@
    {:elevation 1
     :class     "layer-card"}
    [layer-card-content props]])
+
+(defn- layer-catalogue-controls [{:keys [layer] {:keys [active?]} :layer-state}]
+  [:div.layer-controls
+
+   [layer-control
+    {:tooltip  "Layer info / Download data"
+     :icon     "info-sign"
+     :on-click #(re-frame/dispatch [:map.layer/show-info layer])}]
+
+   [layer-control
+    {:tooltip  "Zoom to layer"
+     :icon     "zoom-to-fit"
+     :on-click #(re-frame/dispatch [:map/pan-to-layer layer])}]
+
+   [b/tooltip {:content (if active? "Deactivate layer" "Activate layer")}
+    [b/checkbox
+     {:checked (boolean active?)
+      :on-change #(re-frame/dispatch [:map/toggle-layer layer])}]]])
+
+(defn- layer-catalogue-header [{:keys [_layer] {:keys [active? visible?] :as layer-state} :layer-state :as props}]
+  [:div.layer-header
+   (when (and active? visible?)
+     [layer-status-icons layer-state])
+   [layer-header-text props]
+   [layer-catalogue-controls props]])
+
+(defn layer-catalogue-content [{:keys [_layer] {:keys [active? expanded?]} :layer-state :as props}]
+  [:div.layer-content
+   {:class (when active? "active-layer")}
+   [layer-catalogue-header props]
+   [b/collapse {:is-open (and active? expanded?)}
+    [layer-details props]]])

--- a/frontend/src/cljs/imas_seamap/map/layer_views.cljs
+++ b/frontend/src/cljs/imas_seamap/map/layer_views.cljs
@@ -1,5 +1,6 @@
 (ns imas-seamap.map.layer-views
   (:require [re-frame.core :as re-frame]
+            [reagent.core :as reagent]
             [imas-seamap.blueprint :as b]
             [imas-seamap.utils :refer [with-params]]
             #_[debux.cs.core :refer [dbg] :include-macros true]))
@@ -127,12 +128,30 @@
    [b/collapse {:is-open (and active? expanded?)}
     [layer-details props]]])
 
-(defn- main-national-layer-details [{:keys [layer] {:keys [opacity]} :layer-state}]
-  [:div.layer-details
-   [b/slider
-    {:label-renderer false :initial-value 0 :max 100 :value opacity
-     :on-change #(re-frame/dispatch [:map.layer/opacity-changed layer %])}]
-   [legend-display layer]])
+
+;; Main national layer
+
+(defn- main-national-layer-details [{:keys [_layer] {:keys [_opacity]} :layer-state}]
+  (let [selected-tab (reagent/atom "legend")]
+    (fn [{:keys [layer] {:keys [opacity]} :layer-state}]
+      [:div.layer-details
+       [b/slider
+        {:label-renderer false :initial-value 0 :max 100 :value opacity
+         :on-change #(re-frame/dispatch [:map.layer/opacity-changed layer %])}]
+       
+       [b/tabs
+        {:selected-tab-id @selected-tab
+         :on-change       #(reset! selected-tab %)}
+        
+        [b/tab
+         {:id    "legend"
+          :title "Legend"
+          :panel (reagent/as-element [legend-display layer])}]
+        
+        [b/tab
+         {:id    "filters"
+          :title "Filters"
+          :panel (reagent/as-element [:div "placeholder"])}]]])))
 
 (defn- main-national-layer-card-content [{:keys [_layer] {:keys [active? expanded?]} :layer-state :as props}]
   [:div.layer-content

--- a/frontend/src/cljs/imas_seamap/map/layer_views.cljs
+++ b/frontend/src/cljs/imas_seamap/map/layer_views.cljs
@@ -1,0 +1,8 @@
+(ns imas-seamap.map.layer-views
+  (:require [imas-seamap.blueprint :as b]
+            #_[debux.cs.core :refer [dbg] :include-macros true]))
+
+(defn layer-card [{:keys [_layer] {:keys [active?]} :other-props}]
+  [b/card
+   {:elevation 1
+    :class (str "layer-card" (when active? " active-layer"))}])

--- a/frontend/src/cljs/imas_seamap/map/layer_views.cljs
+++ b/frontend/src/cljs/imas_seamap/map/layer_views.cljs
@@ -1,9 +1,29 @@
 (ns imas-seamap.map.layer-views
-  (:require [imas-seamap.blueprint :as b]
+  (:require [re-frame.core :as re-frame]
+            [imas-seamap.blueprint :as b]
             #_[debux.cs.core :refer [dbg] :include-macros true]))
 
-(defn- layer-header [{{:keys [name]} :layer}]
-  [:div.layer-header name])
+(defn- layer-status-icons [{:keys [loading? errors?]}]
+  (when (or loading? errors?)
+   [:div.layer-status-icons
+    (when loading? [b/spinner {:class "bp3-text-muted bp3-small"}])
+    (when errors? [b/icon {:icon "warning-sign" :class "bp3-text-muted bp3-small"}])]))
+
+(defn- layer-header-text [{{:keys [name] :as layer} :layer {:keys [expanded? active?]} :other-props}]
+  [b/tooltip
+   {:content (if expanded? "Hide details" "Show details")
+    :disabled (not active?)
+    :class "layer-header-text"}
+   [b/clipped-text
+    {:ellipsize true
+     :on-click  #(re-frame/dispatch [:map.layer.legend/toggle layer])}
+    name]])
+
+(defn- layer-header [{:keys [_layer] {:keys [active? visible?] :as other-props} :other-props :as layer-props}]
+  [:div.layer-header
+   (when (and active? visible?)
+     [layer-status-icons other-props])
+   [layer-header-text layer-props]])
 
 (defn- layer-content [{:keys [_layer _other-props] :as layer-props}]
   [:div.layer-content

--- a/frontend/src/cljs/imas_seamap/map/layer_views.cljs
+++ b/frontend/src/cljs/imas_seamap/map/layer_views.cljs
@@ -2,6 +2,7 @@
   (:require [re-frame.core :as re-frame]
             [reagent.core :as reagent]
             [imas-seamap.blueprint :as b]
+            [imas-seamap.components :as components]
             [imas-seamap.utils :refer [with-params]]
             #_[debux.cs.core :refer [dbg] :include-macros true]))
 
@@ -132,7 +133,8 @@
 ;; Main national layer
 
 (defn- main-national-layer-details [{:keys [_layer] {:keys [_opacity]} :layer-state}]
-  (let [selected-tab (reagent/atom "legend")]
+  (let [selected-tab (reagent/atom "legend") 
+        alternate-view (reagent/atom nil)]   ; Graduate to event probably at some point to be able to filter displayed layer
     (fn [{:keys [layer] {:keys [opacity]} :layer-state}]
       [:div.layer-details
        [b/slider
@@ -146,12 +148,30 @@
         [b/tab
          {:id    "legend"
           :title "Legend"
-          :panel (reagent/as-element [legend-display layer])}]
+          :panel
+          (reagent/as-element
+           [:<>
+            (when @alternate-view [:h2.bp3-heading @alternate-view])
+            [legend-display layer]])}]
         
         [b/tab
          {:id    "filters"
           :title "Filters"
-          :panel (reagent/as-element [:div "placeholder"])}]]])))
+          :panel
+          (reagent/as-element
+           [:div
+            [components/form-group
+             {:label "Alternate View"}
+             [components/select
+              {:value        @alternate-view        
+               :options
+               ["CBICS Classified" "Seagrass" "..." ".." "."]
+               :onChange     #(reset! alternate-view %)
+               :isSearchable true
+               :isClearable  true
+               :keyfns
+               {:id   identity
+                :text identity}}]]])}]]])))
 
 (defn- main-national-layer-card-content [{:keys [_layer] {:keys [active? expanded?]} :layer-state :as props}]
   [:div.layer-content

--- a/frontend/src/cljs/imas_seamap/map/layer_views.cljs
+++ b/frontend/src/cljs/imas_seamap/map/layer_views.cljs
@@ -132,6 +132,24 @@
 
 ;; Main national layer
 
+(defn- main-national-layer-time-filter []
+  (let [value     (reagent/atom 2000)   ; Graduate to event probably at some point to be able to filter displayed layer
+        all-time? (reagent/atom false)] ; Graduate to event probably at some point to be able to filter displayed layer
+    (fn []
+      [components/form-group {:label "Time"}
+       [b/checkbox
+        {:label    "At all points in time"
+         :checked  @all-time?
+         :on-click #(swap! all-time? not)}]
+       [b/slider
+        {:min             2000
+         :max             2022
+         :label-step-size (- 2022 2000)
+         :value           @value
+         :step-size       1
+         :on-change       #(reset! value %)
+         :disabled        @all-time?}]])))
+
 (defn- main-national-layer-details [{:keys [_layer] {:keys [_opacity]} :layer-state}]
   (let [selected-tab (reagent/atom "legend") 
         alternate-view (reagent/atom nil)]   ; Graduate to event probably at some point to be able to filter displayed layer
@@ -159,7 +177,7 @@
           :title "Filters"
           :panel
           (reagent/as-element
-           [:div
+           [:<>
             [components/form-group
              {:label "Alternate View"}
              [components/select
@@ -171,7 +189,8 @@
                :isClearable  true
                :keyfns
                {:id   identity
-                :text identity}}]]])}]]])))
+                :text identity}}]]
+            [main-national-layer-time-filter]])}]]])))
 
 (defn- main-national-layer-card-content [{:keys [_layer] {:keys [active? expanded?]} :layer-state :as props}]
   [:div.layer-content

--- a/frontend/src/cljs/imas_seamap/map/layer_views.cljs
+++ b/frontend/src/cljs/imas_seamap/map/layer_views.cljs
@@ -90,14 +90,15 @@
      :on-change #(re-frame/dispatch [:map.layer/opacity-changed layer %])}]
    [legend-display layer]])
 
-(defn- layer-content [{:keys [_layer] {:keys [active? expanded?]} :other-props :as layer-props}]
+(defn layer-content [{:keys [_layer] {:keys [active? expanded?]} :other-props :as layer-props}]
   [:div.layer-content
+   {:class (when active? "active-layer")}
    [layer-header layer-props]
    [b/collapse {:is-open (and active? expanded?)}
     [layer-details layer-props]]])
 
-(defn layer-card [{:keys [_layer] {:keys [active?]} :other-props :as layer-props}]
+(defn layer-card [{:keys [_layer _other-props] :as layer-props}]
   [b/card
    {:elevation 1
-    :class (str "layer-card" (when active? " active-layer"))}
+    :class     "layer-card"}
    [layer-content layer-props]])

--- a/frontend/src/cljs/imas_seamap/map/layer_views.cljs
+++ b/frontend/src/cljs/imas_seamap/map/layer_views.cljs
@@ -40,10 +40,12 @@
      :on-click #(re-frame/dispatch [:map/pan-to-layer layer])}]
 
    (when active?
-     [layer-control
-      {:tooltip  (if visible? "Hide layer" "Show layer")
-       :icon     (if visible? "eye-on" "eye-off")
-       :on-click #(re-frame/dispatch [:map/toggle-layer-visibility layer])}])
+     [b/tooltip {:content (if visible? "Hide layer" "Show layer")}
+      [b/icon
+       {:icon     (if visible? "eye-on" "eye-off")
+        :size     20
+        :class    "bp3-text-muted layer-control"
+        :on-click #(re-frame/dispatch [:map/toggle-layer-visibility layer])}]])
 
    (when active?
      [layer-control

--- a/frontend/src/cljs/imas_seamap/map/layer_views.cljs
+++ b/frontend/src/cljs/imas_seamap/map/layer_views.cljs
@@ -126,3 +126,23 @@
    [layer-catalogue-header props]
    [b/collapse {:is-open (and active? expanded?)}
     [layer-details props]]])
+
+(defn- main-national-layer-details [{:keys [layer] {:keys [opacity]} :layer-state}]
+  [:div.layer-details
+   [b/slider
+    {:label-renderer false :initial-value 0 :max 100 :value opacity
+     :on-change #(re-frame/dispatch [:map.layer/opacity-changed layer %])}]
+   [legend-display layer]])
+
+(defn- main-national-layer-card-content [{:keys [_layer] {:keys [active? expanded?]} :layer-state :as props}]
+  [:div.layer-content
+   {:class (when active? "active-layer")}
+   [layer-card-header props]
+   [b/collapse {:is-open (and active? expanded?)}
+    [main-national-layer-details props]]])
+
+(defn main-national-layer-card [{:keys [_layer _layer-state] :as props}]
+  [b/card
+   {:elevation 1
+    :class     "layer-card"}
+   [main-national-layer-card-content props]])

--- a/frontend/src/cljs/imas_seamap/map/layer_views.cljs
+++ b/frontend/src/cljs/imas_seamap/map/layer_views.cljs
@@ -2,7 +2,15 @@
   (:require [imas-seamap.blueprint :as b]
             #_[debux.cs.core :refer [dbg] :include-macros true]))
 
-(defn layer-card [{:keys [_layer] {:keys [active?]} :other-props}]
+(defn- layer-header [{{:keys [name]} :layer}]
+  [:div.layer-header name])
+
+(defn- layer-content [{:keys [_layer _other-props] :as layer-props}]
+  [:div.layer-content
+   [layer-header layer-props]])
+
+(defn layer-card [{:keys [_layer] {:keys [active?]} :other-props :as layer-props}]
   [b/card
    {:elevation 1
-    :class (str "layer-card" (when active? " active-layer"))}])
+    :class (str "layer-card" (when active? " active-layer"))}
+   [layer-content layer-props]])

--- a/frontend/src/cljs/imas_seamap/map/layer_views.cljs
+++ b/frontend/src/cljs/imas_seamap/map/layer_views.cljs
@@ -10,7 +10,7 @@
     (when loading? [b/spinner {:class "bp3-text-muted bp3-small"}])
     (when errors? [b/icon {:icon "warning-sign" :class "bp3-text-muted bp3-small"}])]))
 
-(defn- layer-header-text [{{:keys [name] :as layer} :layer {:keys [expanded? active?]} :other-props}]
+(defn- layer-header-text [{{:keys [name] :as layer} :layer {:keys [expanded? active?]} :layer-state}]
   [b/tooltip
    {:content (if expanded? "Hide details" "Show details")
     :disabled (not active?)
@@ -27,7 +27,7 @@
      :class   "bp3-text-muted layer-control"
      :on-click on-click}]])
 
-(defn- layer-controls [{:keys [layer] {:keys [visible? active?]} :other-props}]
+(defn- layer-card-controls [{:keys [layer] {:keys [visible?]} :layer-state}]
   [:div.layer-controls
 
    [layer-control
@@ -40,32 +40,24 @@
      :icon     "zoom-to-fit"
      :on-click #(re-frame/dispatch [:map/pan-to-layer layer])}]
 
-   (when active?
-     [b/tooltip {:content (if visible? "Hide layer" "Show layer")}
-      [b/icon
-       {:icon     (if visible? "eye-on" "eye-off")
-        :size     20
-        :class    "bp3-text-muted layer-control"
-        :on-click #(re-frame/dispatch [:map/toggle-layer-visibility layer])}]])
+   [b/tooltip {:content (if visible? "Hide layer" "Show layer")}
+    [b/icon
+     {:icon     (if visible? "eye-on" "eye-off")
+      :size     20
+      :class    "bp3-text-muted layer-control"
+      :on-click #(re-frame/dispatch [:map/toggle-layer-visibility layer])}]]
 
-   (when active?
-     [layer-control
-      {:tooltip  "Deactivate layer"
-       :icon     "remove"
-       :on-click #(re-frame/dispatch [:map/toggle-layer layer])}])
-   
-   (when-not active?
-     [b/tooltip {:content (if active? "Deactivate layer" "Activate layer")}
-      [b/checkbox
-       {:checked (boolean active?)
-        :on-change #(re-frame/dispatch [:map/toggle-layer layer])}]])])
+   [layer-control
+    {:tooltip  "Deactivate layer"
+     :icon     "remove"
+     :on-click #(re-frame/dispatch [:map/toggle-layer layer])}]])
 
-(defn- layer-header [{:keys [_layer] {:keys [active? visible?] :as other-props} :other-props :as layer-props}]
+(defn- layer-card-header [{:keys [_layer] {:keys [active? visible?] :as layer-state} :layer-state :as props}]
   [:div.layer-header
    (when (and active? visible?)
-     [layer-status-icons other-props])
-   [layer-header-text layer-props]
-   [layer-controls layer-props]])
+     [layer-status-icons layer-state])
+   [layer-header-text props]
+   [layer-card-controls props]])
 
 (defn- legend-display [{:keys [legend_url server_url layer_name style]}]
   ;; Allow a custom url via the legend_url field, else construct a GetLegendGraphic call:
@@ -83,22 +75,22 @@
     [:div.legend-wrapper
      [:img {:src legend-url}]]))
 
-(defn- layer-details [{:keys [layer] {:keys [opacity]} :other-props}]
+(defn- layer-details [{:keys [layer] {:keys [opacity]} :layer-state}]
   [:div.layer-details
    [b/slider
     {:label-renderer false :initial-value 0 :max 100 :value opacity
      :on-change #(re-frame/dispatch [:map.layer/opacity-changed layer %])}]
    [legend-display layer]])
 
-(defn layer-content [{:keys [_layer] {:keys [active? expanded?]} :other-props :as layer-props}]
+(defn- layer-card-content [{:keys [_layer] {:keys [active? expanded?]} :layer-state :as props}]
   [:div.layer-content
    {:class (when active? "active-layer")}
-   [layer-header layer-props]
+   [layer-card-header props]
    [b/collapse {:is-open (and active? expanded?)}
-    [layer-details layer-props]]])
+    [layer-details props]]])
 
-(defn layer-card [{:keys [_layer _other-props] :as layer-props}]
+(defn layer-card [{:keys [_layer _layer-state] :as props}]
   [b/card
    {:elevation 1
     :class     "layer-card"}
-   [layer-content layer-props]])
+   [layer-card-content props]])

--- a/frontend/src/cljs/imas_seamap/map/layer_views.cljs
+++ b/frontend/src/cljs/imas_seamap/map/layer_views.cljs
@@ -19,11 +19,50 @@
      :on-click  #(re-frame/dispatch [:map.layer.legend/toggle layer])}
     name]])
 
+(defn- layer-control [{:keys [tooltip icon on-click]}]
+  [b/tooltip {:content tooltip}
+   [b/icon
+    {:icon    icon
+     :class   "bp3-text-muted layer-control"
+     :on-click on-click}]])
+
+(defn- layer-controls [{:keys [layer] {:keys [visible? active?]} :other-props}]
+  [:div.layer-controls
+
+   [layer-control
+    {:tooltip  "Layer info / Download data"
+     :icon     "info-sign"
+     :on-click #(re-frame/dispatch [:map.layer/show-info layer])}]
+
+   [layer-control
+    {:tooltip  "Zoom to layer"
+     :icon     "zoom-to-fit"
+     :on-click #(re-frame/dispatch [:map/pan-to-layer layer])}]
+
+   (when active?
+     [layer-control
+      {:tooltip  (if visible? "Hide layer" "Show layer")
+       :icon     (if visible? "eye-on" "eye-off")
+       :on-click #(re-frame/dispatch [:map/toggle-layer-visibility layer])}])
+
+   (when active?
+     [layer-control
+      {:tooltip  "Deactivate layer"
+       :icon     "remove"
+       :on-click #(re-frame/dispatch [:map/toggle-layer layer])}])
+   
+   (when-not active?
+     [b/tooltip {:content (if active? "Deactivate layer" "Activate layer")}
+      [b/checkbox
+       {:checked (boolean active?)
+        :on-change #(re-frame/dispatch [:map/toggle-layer layer])}]])])
+
 (defn- layer-header [{:keys [_layer] {:keys [active? visible?] :as other-props} :other-props :as layer-props}]
   [:div.layer-header
    (when (and active? visible?)
      [layer-status-icons other-props])
-   [layer-header-text layer-props]])
+   [layer-header-text layer-props]
+   [layer-controls layer-props]])
 
 (defn- layer-content [{:keys [_layer _other-props] :as layer-props}]
   [:div.layer-content

--- a/frontend/src/cljs/imas_seamap/map/subs.cljs
+++ b/frontend/src/cljs/imas_seamap/map/subs.cljs
@@ -59,7 +59,8 @@
      :visible-layers  (filter (fn [layer] (not (contains? hidden-layers layer))) active-layers)
      :layer-opacities (fn [layer] (get-in layer-state [:opacity layer] 100))
      :filtered-layers filtered-layers
-     :viewport-layers viewport-layers}))
+     :viewport-layers viewport-layers
+     :main-national-layer (first (get-in map [:keyed-layers :main-national-layer]))}))
 
 (defn map-base-layers [{:keys [map]} _]
   (select-keys map [:grouped-base-layers :active-base-layer]))

--- a/frontend/src/cljs/imas_seamap/utils.cljs
+++ b/frontend/src/cljs/imas_seamap/utils.cljs
@@ -231,3 +231,9 @@
     (.appendChild shadow body-element)
 
     element))
+
+(defn with-params [url params]
+  (let [u (goog/Uri. url)]
+    (doseq [[k v] params]
+      (.setParameterValue u (name k) v))
+    (str u)))

--- a/frontend/src/cljs/imas_seamap/views.cljs
+++ b/frontend/src/cljs/imas_seamap/views.cljs
@@ -228,7 +228,7 @@
                        ;; If we have children, toggle expanded state, else add to map
                        (re-frame/dispatch [:ui.catalogue/toggle-node id]))))]
     (fn [layers ordering id layer-props open-all?]
-     [:div.tab-body.layer-controls {:id id}
+     [:div.tab-body {:id id}
       [b/tree {:contents (layers->nodes layers ordering @sorting-info @expanded-states id layer-props open-all?)
                :onNodeCollapse on-close
                :onNodeExpand on-open

--- a/frontend/src/cljs/imas_seamap/views.cljs
+++ b/frontend/src/cljs/imas_seamap/views.cljs
@@ -11,17 +11,11 @@
             [imas-seamap.map.views :refer [map-component]]
             [imas-seamap.state-of-knowledge.views :refer [state-of-knowledge floating-state-of-knowledge-pill floating-boundaries-pill floating-zones-pill]]
             [imas-seamap.plot.views :refer [transect-display-component]]
-            [imas-seamap.utils :refer [handler-fn handler-dispatch] :include-macros true]
+            [imas-seamap.utils :refer [handler-fn handler-dispatch with-params] :include-macros true]
             [imas-seamap.components :as components]
             [imas-seamap.map.utils :refer [layer-search-keywords]]
             [goog.string.format]
             #_[debux.cs.core :refer [dbg] :include-macros true]))
-
-(defn with-params [url params]
-  (let [u (goog/Uri. url)]
-    (doseq [[k v] params]
-      (.setParameterValue u (name k) v))
-    (str u)))
 
 (defn- ->query-selector
   "Normalises selectors for helper-overlay into a form for use with

--- a/frontend/src/cljs/imas_seamap/views.cljs
+++ b/frontend/src/cljs/imas_seamap/views.cljs
@@ -47,7 +47,7 @@
        (apply concat)))
 
 ;; TODO: Update, replace?
-(defn helper-overlay [& element-selectors]
+(defn- helper-overlay [& element-selectors]
   (let [*line-height* 17.6 *padding* 10 *text-width* 200 ;; hard-code
         *vertical-bar* 50 *horiz-bar* 100
         posn->offsets (fn [posn width height]
@@ -89,13 +89,13 @@
             helperText]]]))]))
 
 ;; TODO: Update, replace?
-#_(defn help-button []
+#_(defn- help-button []
   [:div.layer-controls.help-button
    [b/tooltip {:content "Show the quick-help guide"}
     [:span.control.bp3-icon-large.bp3-icon-help.bp3-text-muted
      {:on-click #(re-frame/dispatch [:help-layer/open])}]]])
 
-(defn legend-display [{:keys [legend_url server_url layer_name style]}]
+(defn- legend-display [{:keys [legend_url server_url layer_name style]}]
   ;; Allow a custom url via the legend_url field, else construct a GetLegendGraphic call:
   (let [legend-url (or legend_url
                        (with-params server_url
@@ -111,7 +111,7 @@
     [:div.legend-wrapper
      [:img {:src legend-url}]]))
 
-(defn catalogue-legend
+(defn- catalogue-legend
   [layer {:keys [active? _errors? _loading? expanded? opacity]}]
   [b/collapse {:is-open (and active? expanded?)
                :className "layer-legend"}
@@ -119,7 +119,7 @@
               :on-change #(re-frame/dispatch [:map.layer/opacity-changed layer %])}]
    [legend-display layer]])
 
-(defn catalogue-header [{:keys [name] :as layer} {:keys [active? visible? errors? loading? expanded? _opacity] :as _layer-state}]
+(defn- catalogue-header [{:keys [name] :as layer} {:keys [active? visible? errors? loading? expanded? _opacity] :as _layer-state}]
   [b/tooltip {:content (if expanded? "Click to hide legend" "Click to show legend")
               :class "header-text"
               :disabled (not active?)}
@@ -133,7 +133,7 @@
                       :on-click (handler-dispatch [:map.layer.legend/toggle layer])}
       name]]]])
 
-(defn catalogue-controls [layer {:keys [active? _errors? _loading?] :as _layer-state}]
+(defn- catalogue-controls [layer {:keys [active? _errors? _loading?] :as _layer-state}]
   [:div.catalogue-layer-controls (when active? {:class "layer-active"})
    [b/tooltip {:content "Layer info / Download data"}
     [:span.control.bp3-icon-standard.bp3-icon-info-sign.bp3-text-muted
@@ -146,7 +146,7 @@
      {:checked (boolean active?)
       :on-change (handler-dispatch [:map/toggle-layer layer])}]]])
 
-(defn active-layer-catalogue-controls [layer {:keys [active? visible? _errors? _loading?] :as _layer-state}]
+(defn- active-layer-catalogue-controls [layer {:keys [active? visible? _errors? _loading?] :as _layer-state}]
   [:div.catalogue-layer-controls (when active? {:class "layer-active"})
    [b/tooltip {:content "Layer info / Download data"}
     [:span.control.bp3-icon-standard.bp3-icon-info-sign.bp3-text-muted
@@ -168,7 +168,7 @@
     ;; Sort by key first, then name (ie, return vector of [key name])
     (comp #(vector (get name-key-mapping %) %) first)))
 
-(defn layers->nodes
+(defn- layers->nodes
   "group-ordering is the category keys to order by, eg [:organisation :data_category]"
   [layers [ordering & ordering-remainder :as group-ordering] sorting-info expanded-states id-base
    {:keys [active-layers visible-layers loading-fn expanded-fn error-fn opacity-fn] :as layer-props} open-all?]
@@ -201,7 +201,7 @@
                          #_:secondaryLabel #_(reagent/as-element [catalogue-controls layer layer-state])}))
                     layer-subset))}))
 
-(defn layer-catalogue-tree [_layers _ordering _id _layer-props _open-all?]
+(defn- layer-catalogue-tree [_layers _ordering _id _layer-props _open-all?]
   (let [expanded-states (re-frame/subscribe [:ui.catalogue/nodes])
         sorting-info (re-frame/subscribe [:sorting/info])
         on-open (fn [node]
@@ -222,7 +222,7 @@
                :onNodeExpand on-open
                :onNodeClick on-click}]])))
 
-(defn layer-catalogue [layers layer-props]
+(defn- layer-catalogue [layers layer-props]
   (let [selected-tab @(re-frame/subscribe [:ui.catalogue/tab])
         select-tab   #(re-frame/dispatch [:ui.catalogue/select-tab %1])
         open-all?    (>= (count @(re-frame/subscribe [:map.layers/filter])) 3)]
@@ -241,7 +241,7 @@
         :panel (reagent/as-element
                 [layer-catalogue-tree layers [:category :organisation :data_classification] "org" layer-props open-all?])}]]]))
 
-(defn transect-toggle []
+(defn- transect-toggle []
   (let [{:keys [drawing? query]} @(re-frame/subscribe [:transect/info])
         [text icon dispatch] (cond
                                drawing? ["Cancel Measurement" "undo"   :transect.draw/disable]
@@ -253,7 +253,7 @@
                 :on-click (handler-dispatch [dispatch])
                 :text     text}]]))
 
-(defn selection-button []
+(defn- selection-button []
   (let [{:keys [selecting? region]} @(re-frame/subscribe [:map.layer.selection/info])
         [dispatch-key label]        (cond
                                       selecting? [:map.layer.selection/disable "Cancel Selecting"]
@@ -265,7 +265,7 @@
                 :on-click   (handler-dispatch [dispatch-key])
                 :text       label}]]))
 
-(defn viewport-only-toggle []
+(defn- viewport-only-toggle []
   (let [[icon text] (if @(re-frame/subscribe [:map/viewport-only?])
                       ["globe" "All layers"]
                       ["map" "Viewport layers only"])]
@@ -275,7 +275,7 @@
       :on-click #(re-frame/dispatch [:map/toggle-viewport-only])
       :text     text}]))
 
-(defn layer-search-filter []
+(defn- layer-search-filter []
   (let [filter-text (re-frame/subscribe [:map.layers/filter])]
     [:div.bp3-input-group {:data-helper-text "Filter Layers"}
      [:span.bp3-icon.bp3-icon-search]
@@ -286,14 +286,14 @@
                                 :on-change   (handler-dispatch
                                                [:map.layers/filter (.. event -target -value)])}]]))
 
-(defn active-layer-card [layer-spec {:keys [_active? _visible? _loading? _errors? _expanded? _opacity-fn] :as layer-state}]
+(defn- active-layer-card [layer-spec {:keys [_active? _visible? _loading? _errors? _expanded? _opacity-fn] :as layer-state}]
   [:div.layer-wrapper.bp3-card.bp3-elevation-1.layer-active.bp3-interactive
    [:div.header-row.height-static
     [catalogue-header layer-spec layer-state]
     [active-layer-catalogue-controls layer-spec layer-state]]
    [catalogue-legend layer-spec layer-state]])
 
-(defn active-layer-selection-list
+(defn- active-layer-selection-list
   [{:keys [layers visible-layers loading-fn error-fn expanded-fn opacity-fn]}]
   [components/items-selection-list
    {:items
@@ -313,7 +313,7 @@
     :data-path   [:map :active-layers]
     :is-reversed true}])
 
-(defn plot-component-animatable [{:keys [on-add on-remove]
+(defn- plot-component-animatable [{:keys [on-add on-remove]
                                   :or   {on-add identity on-remove identity}
                                   :as   _props}
                                  _child-component
@@ -331,7 +331,7 @@
                               (merge child-props
                                      (js->clj % :keywordize-keys true))])]])}))
 
-(defn plot-component []
+(defn- plot-component []
   (let [show-plot (re-frame/subscribe [:transect.plot/show?])
         force-resize #(js/window.dispatchEvent (js/Event. "resize"))
         transect-results (re-frame/subscribe [:transect/results])]
@@ -352,7 +352,7 @@
                                               :on-mouseout
                                               #(re-frame/dispatch [:transect.plot/mouseout]))]])]])))
 
-(defn loading-display []
+(defn- loading-display []
   (let [loading?  @(re-frame/subscribe [:app/loading?])
         main-msg  @(re-frame/subscribe [:app/load-normal-msg])
         error-msg @(re-frame/subscribe [:app/load-error-msg])]
@@ -367,7 +367,7 @@
           {:title  main-msg
            :icon (reagent/as-element [b/spinner {:intent "success"}])}])])))
 
-(defn welcome-dialogue []
+(defn- welcome-dialogue []
   (let [open? @(re-frame/subscribe [:welcome-layer/open?])]
     [b/dialogue {:title      "Welcome to Seamap Australia!"
                  :class "welcome-splash"
@@ -400,7 +400,7 @@
                   :auto-focus true
                   :on-click   (handler-dispatch [:welcome-layer/close])}]]]]))
 
-(defn metadata-record [_props]
+(defn- metadata-record [_props]
   (let [expanded (reagent/atom false)]
     (fn  [{:keys [license-name license-link license-img constraints other]
            {:keys [category organisation name metadata_url server_url layer_name]} :layer
@@ -467,7 +467,7 @@
               :disabled   disabled?
               :right-icon "caret-down"}]])
 
-(defn info-card []
+(defn- info-card []
   (let [layer-info                       @(re-frame/subscribe [:map.layer/info])
         {:keys [metadata_url] :as layer} (:layer layer-info)
         title                            (or (get-in layer-info [:layer :name]) "Layer Information")
@@ -504,7 +504,7 @@
                   :intent     b/INTENT-PRIMARY
                   :on-click   (handler-dispatch [:map.layer/close-info])}]]]]))
 
-(defn floating-pills []
+(defn- floating-pills []
   (let [collapsed                (:collapsed @(re-frame/subscribe [:ui/sidebar]))
         state-of-knowledge-open? @(re-frame/subscribe [:sok/open?])
         amp-boundaries           @(re-frame/subscribe [:sok/valid-amp-boundaries])
@@ -540,7 +540,7 @@
          amp-boundaries
          {:expanded? (= open-pill "zones")})])]))
 
-(defn layers-search-omnibar []
+(defn- layers-search-omnibar []
   (let [categories @(re-frame/subscribe [:map/categories-map])
         open?                @(re-frame/subscribe [:layers-search-omnibar/open?])
         {:keys [filtered-layers]} @(re-frame/subscribe [:map/layers])]
@@ -562,7 +562,7 @@
                         data_classification]))
        :keywords    #(layer-search-keywords categories %)}}]))
 
-(defn left-drawer []
+(defn- left-drawer []
   (let [open? @(re-frame/subscribe [:left-drawer/open?])
         tab   @(re-frame/subscribe [:left-drawer/tab])
         {:keys [filtered-layers active-layers visible-layers viewport-layers loading-layers error-layers expanded-layers layer-opacities]} @(re-frame/subscribe [:map/layers])
@@ -635,7 +635,7 @@
                      :text     "Reset Interface"
                      :on-click   #(re-frame/dispatch [:re-boot])}]]])}]]]]))
 
-(defn layer-preview [_preview-layer-url]
+(defn- layer-preview [_preview-layer-url]
   (let [previous-url (reagent/atom nil) ; keeps track of previous url for the purposes of tracking its changes
         error? (reagent/atom false)]    ; keeps track of if previous url had an error in displaying
     (fn [preview-layer-url]

--- a/frontend/src/cljs/imas_seamap/views.cljs
+++ b/frontend/src/cljs/imas_seamap/views.cljs
@@ -287,41 +287,6 @@
       :on-click #(re-frame/dispatch [:map/toggle-viewport-only])
       :text     text}]))
 
-;; TODO: Remove, unused
-#_(defn layer-logic-toggle []
-  (let [{:keys [type trigger]} @(re-frame/subscribe [:map.layers/logic])
-        user-triggered?        (= trigger :map.logic.trigger/user)
-        [checked? label icon]  (if (= type :map.layer-logic/automatic)
-                                 [true  " Automatic Layer Selection" [:i.fa.fa-magic]]
-                                 [false " Choose Layers Manually"    [:span.bp3-icon-standard.bp3-icon-hand]])]
-    [:div#logic-toggle.logic-toggle
-     (merge {:data-helper-text "Automatic layer selection picks the best layers to display, or turn off to list all available layers and choose your own"
-             :data-text-width "380px"}
-            (when-not (or checked? user-triggered?)
-              {:class "external-trigger"}))
-     [b/switch {:checked   checked?
-                :label     (reagent/as-element [:span icon label])
-                :on-change (handler-dispatch [:map.layers.logic/toggle true])}]]))
-
-;; TODO: Remove, unused
-#_(defn layer-logic-toggle-button []
-  (let [{:keys [type]} @(re-frame/subscribe [:map.layers/logic])]
-    [:div#logic-toggle
-     {:data-helper-text "Automatic layer selection picks the best layers to display, or turn off to list all available layers and choose your own"
-      :data-text-width "380px"}
-     (if (= type :map.layer-logic/automatic)
-       [b/button
-        {:class "bp3-fill"
-         :on-click  #(re-frame/dispatch [:map.layers.logic/toggle true])}
-        [:span
-         [:i.fa.fa-magic]
-         "Automatic Layer Selection"]]
-       [b/button
-        {:icon "hand"
-         :class "bp3-fill"
-         :text "Choose Layers Manually"
-         :on-click  #(re-frame/dispatch [:map.layers.logic/toggle true])}])]))
-
 (defn layer-search-filter []
   (let [filter-text (re-frame/subscribe [:map.layers/filter])]
     [:div.bp3-input-group {:data-helper-text "Filter Layers"}
@@ -333,47 +298,12 @@
                                 :on-change   (handler-dispatch
                                                [:map.layers/filter (.. event -target -value)])}]]))
 
-
-;; TODO: Remove, unused
-#_(defn layer-card [layer-spec {:keys [active? _visible? _loading? _errors? _expanded? _opacity-fn] :as other-props}]
-  [:div.layer-wrapper.bp3-card.bp3-elevation-1
-   {:class (when active? "layer-active bp3-interactive")}
-   [:div.header-row.height-static
-    [catalogue-header layer-spec other-props]
-    [catalogue-controls layer-spec other-props]]
-   [catalogue-legend layer-spec other-props]])
-
 (defn active-layer-card [layer-spec {:keys [_active? _visible? _loading? _errors? _expanded? _opacity-fn] :as other-props}]
   [:div.layer-wrapper.bp3-card.bp3-elevation-1.layer-active.bp3-interactive
    [:div.header-row.height-static
     [catalogue-header layer-spec other-props]
     [active-layer-catalogue-controls layer-spec other-props]]
    [catalogue-legend layer-spec other-props]])
-
-;; TODO: Remove, unused
-#_(defn layer-group [{:keys [expanded] :or {expanded false} :as _props} _layers _active-layers _visible-layers _loading-fn _error-fn _expanded-fn _opacity-fn]
-  (let [expanded (reagent/atom expanded)]
-    (fn [{:keys [id title classes] :as props} layers active-layers visible-layers loading-fn error-fn expanded-fn opacity-fn]
-      [:div.layer-group.height-managed
-       (merge {:class (str classes (if @expanded " expanded" " collapsed"))}
-              (when id {:id id}))
-       [:h1.bp3-heading {:on-click (handler-fn (swap! expanded not))}
-        [:span.bp3-icon-standard {:class (if @expanded "bp3-icon-chevron-down" "bp3-icon-chevron-right")}]
-        (str title " (" (count layers) ")")]
-       [b/collapse {:is-open               @expanded
-                    :keep-children-mounted true
-                    :className             "height-managed"}
-        (when-let [extra-component (:extra-component props)]
-          extra-component)
-        [:div.height-managed.group-scrollable
-         (for [layer layers]
-           ^{:key (:layer_name layer)}
-           [layer-card layer {:active?   (some #{layer} active-layers)
-                              :visible?  (some #{layer} visible-layers)
-                              :loading?  (loading-fn layer)
-                              :errors?   (error-fn layer)
-                              :expanded? (expanded-fn layer)
-                              :opacity   (opacity-fn layer)}])]]])))
 
 (defn active-layer-selection-list
   [{:keys [layers visible-layers loading-fn error-fn expanded-fn opacity-fn]}]
@@ -394,30 +324,6 @@
       :disabled    false
       :data-path   [:map :active-layers]
       :is-reversed true}]))
-
-;; TODO: Remove, unused
-#_(defn active-layer-group
-  [layers active-layers visible-layers loading-fn error-fn expanded-fn opacity-fn]
-  [:div.active-layer-group.height-managed
-   [:h1.bp3-heading
-    (str "Layers (" (count layers) ")")]
-   [:div.height-managed.group-scrollable
-    [active-layer-selection-list
-     {:layers         layers
-      :visible-layers visible-layers
-      :loading-fn     loading-fn
-      :error-fn       error-fn
-      :expanded-fn    expanded-fn
-      :opacity-fn     opacity-fn}]]])
-
-;; TODO: Remove, unused
-#_(defn settings-controls []
-  [:div#settings
-   [b/button {:id         "reset-button"
-              :icon       "undo"
-              :class "bp3-fill"
-              :on-click   (handler-dispatch [:re-boot])
-              :text       "Reset Interface"}]])
 
 (defn plot-component-animatable [{:keys [on-add on-remove]
                                   :or   {on-add identity on-remove identity}
@@ -610,179 +516,6 @@
                   :intent     b/INTENT-PRIMARY
                   :on-click   (handler-dispatch [:map.layer/close-info])}]]]]))
 
-;; TODO: Remove, unused
-#_(defn- as-icon [icon-name description]
-  (reagent/as-element [b/tooltip {:content  description
-                                  :position RIGHT}
-                       [:span.bp3-icon-standard {:class (str "bp3-icon-" icon-name)}]]))
-
-;; TODO: Remove, unused
-#_(defn active-layers-tab
-  [layers active-layers visible-layers loading-fn error-fn expanded-fn opacity-fn]
-  [:div.sidebar-tab.height-managed
-   [active-layer-group layers active-layers visible-layers loading-fn error-fn expanded-fn opacity-fn]
-   [help-button]])
-
-;; TODO: Remove, unused
-#_(defn catalogue-layers-button
-  [{:keys [category]}]
-  (let [title (:display_name category)]
-    [b/button
-     {:icon     "more"
-      :text     title
-      :on-click #(re-frame/dispatch [:drawer-panel-stack/open-catalogue-panel (:name category)])}]))
-
-;; TODO: Remove, unused
-#_(defn base-panel []
-  (let [categories @(re-frame/subscribe [:map/display-categories])]
-    {:content
-     [:div
-      [components/drawer-group
-       {:heading "Controls"
-        :icon    "settings"}
-       [transect-toggle]
-       [selection-button]
-       [layer-logic-toggle-button]]
-      
-      [components/drawer-group
-       {:heading "Catalogue Layers"
-        :icon    "list-detail-view"}
-       (for [category categories]
-         [catalogue-layers-button
-          {:key      (:name category)
-           :category category}])]
-      [components/drawer-group
-       {:heading "Settings"
-        :icon    "cog"}
-       [b/button
-        {:icon     "undo"
-         :text     "Reset Interface"
-         :on-click   #(re-frame/dispatch [:re-boot])}]]]}))
-
-;; TODO: Remove, unused
-#_(defn catalogue-layers-panel
-  [{:keys [title layers active-layers visible-layers loading-layers error-layers expanded-layers layer-opacities]}]
-  {:title   title
-   :content
-   [:div.sidebar-tab.height-managed
-    [layer-search-filter]
-    [layer-catalogue layers
-     {:active-layers  active-layers
-      :visible-layers visible-layers
-      :loading-fn     loading-layers
-      :error-fn       error-layers
-      :expanded-fn    expanded-layers
-      :opacity-fn     layer-opacities}]]})
-
-;; TODO: Remove, unused
-#_(defn drawer-panel-selection
-  [panel map-layers]
-  (let [{:keys [panel props]} panel
-        {:keys [groups active-layers visible-layers loading-layers error-layers expanded-layers layer-opacities]} map-layers]
-    (case panel
-      :drawer-panel/catalogue-layers
-      (catalogue-layers-panel
-       (merge
-        props
-        {:layers          ((:group props) groups)
-         :active-layers   active-layers
-         :visible-layers  visible-layers
-         :loading-layers  loading-layers
-         :error-layers    error-layers
-         :expanded-layers expanded-layers
-         :layer-opacities layer-opacities})))))
-;; TODO: Remove, unused
-#_(defn drawer-panel-stack
-  []
-  (let [map-layers @(re-frame/subscribe [:map/layers])
-        panels @(re-frame/subscribe [:drawer-panel-stack/panels])
-        display-panels
-        (map #(drawer-panel-selection % map-layers) panels)]
-    [components/panel-stack
-     {:panels (concat [(base-panel)] display-panels)
-      :on-close #(re-frame/dispatch [:drawer-panel-stack/pop])}]))
-
-;; TODO: Remove, unused
-#_(defn active-layers-sidebar []
-  (let [{:keys [collapsed selected] :as _sidebar-state}                            @(re-frame/subscribe [:ui/sidebar])
-        {:keys [active-layers visible-layers loading-layers error-layers expanded-layers layer-opacities]} @(re-frame/subscribe [:map/layers])]
-    [sidebar {:id        "floating-sidebar"
-              :selected  selected
-              :collapsed collapsed
-              :closeIcon (reagent/as-element [:span.bp3-icon-standard.bp3-icon-caret-left])
-              :on-close  #(re-frame/dispatch [:ui.sidebar/close])
-              :on-open   #(re-frame/dispatch [:ui.sidebar/open %])}
-     [sidebar-tab {:header "Active Layers"
-                   :icon   (as-icon "eye-open"
-                                    (str "Active Layers (" (count active-layers) ")"))
-                   :id     "tab-activelayers"}
-      [active-layers-tab active-layers active-layers visible-layers loading-layers error-layers expanded-layers layer-opacities]]]))
-
-;; TODO: Remove, unused
-#_(defn floating-menu-bar []
-  [:div.floating-menu-bar
-   [:div.floating-menu-bar-drawer-button
-    {:on-click #(re-frame/dispatch [:left-drawer/toggle])}
-    [b/icon
-     {:icon "menu"
-      :icon-size 20}]]
-   [:div.floating-menu-bar-search-button
-    {:on-click #(re-frame/dispatch [:layers-search-omnibar/open])}
-    [b/icon
-     {:icon "search"
-      :icon-size 16}]
-    "Search Layers..."]])
-
-;; TODO: Remove, unused
-#_(defn floating-menu-active-layers
-  [{:keys [active-layers visible-layers loading-layers error-layers expanded-layers layer-opacities]}]
-  [:div.floating-menu-active-layers
-   [:div.header
-    [b/icon
-     {:icon "eye-open"
-      :icon-size 18}]
-    [:h1 (str "Active Layers (" (count active-layers) ")")]]
-   [:div.content
-    [active-layer-selection-list
-     {:layers         active-layers
-      :visible-layers visible-layers
-      :loading-fn     loading-layers
-      :error-fn       error-layers
-      :expanded-fn    expanded-layers
-      :opacity-fn     layer-opacities}]]])
-
-;; TODO: Remove, unused
-#_(defn floating-menu []
-  (let [{:keys [active-layers] :as map-layers} @(re-frame/subscribe [:map/layers])]
-    [:div.floating-menu-positioning
-     [:div.floating-menu
-      [floating-menu-bar]
-      (when (seq active-layers) [floating-menu-active-layers map-layers])]]))
-
-;; TODO: Remove, unused
-#_(defn floating-transect-pill
-  [{:keys [drawing? query]}]
-  (let [[text icon dispatch] (cond
-                           drawing? ["Cancel Transect" "undo"   :transect.draw/disable]
-                           query    ["Clear Transect"  "eraser" :transect.draw/clear]
-                           :else    ["Draw Transect"   "edit"   :transect.draw/enable])]
-    [components/floating-pill-button
-     {:text     text
-      :icon     icon
-      :on-click #(re-frame/dispatch [dispatch])}]))
-
-;; TODO: Remove, unused
-#_(defn floating-region-pill
-  [{:keys [selecting? region]}]
-  (let [[text icon dispatch] (cond
-                               selecting? ["Cancel Selecting" "undo"   :map.layer.selection/disable]
-                               region     ["Clear Selection"  "eraser" :map.layer.selection/clear]
-                               :else      ["Select Region"    "widget" :map.layer.selection/enable])]
-    [components/floating-pill-button
-     {:text     text
-      :icon     icon
-      :on-click #(re-frame/dispatch [dispatch])}]))
-
 (defn floating-pills []
   (let [collapsed                (:collapsed @(re-frame/subscribe [:ui/sidebar]))
         state-of-knowledge-open? @(re-frame/subscribe [:sok/open?])
@@ -840,15 +573,6 @@
                          (:name (category categories)))
                         data_classification]))
        :keywords    #(layer-search-keywords categories %)}}]))
-
-;; TODO: Remove, unused
-#_(defn catalogue-layer-search-button []
-  [:div.catalogue-layer-search-button
-   {:on-click #(re-frame/dispatch [:layers-search-omnibar/open])}
-   [b/icon
-    {:icon "search"
-     :icon-size 16}]
-   "Search Layers..."])
 
 (defn left-drawer []
   (let [open? @(re-frame/subscribe [:left-drawer/open?])

--- a/frontend/src/cljs/imas_seamap/views.cljs
+++ b/frontend/src/cljs/imas_seamap/views.cljs
@@ -292,12 +292,12 @@
                                 :on-change   (handler-dispatch
                                                [:map.layers/filter (.. event -target -value)])}]]))
 
-(defn active-layer-card [layer-spec {:keys [_active? _visible? _loading? _errors? _expanded? _opacity-fn] :as other-props}]
+(defn active-layer-card [layer-spec {:keys [_active? _visible? _loading? _errors? _expanded? _opacity-fn] :as layer-state}]
   [:div.layer-wrapper.bp3-card.bp3-elevation-1.layer-active.bp3-interactive
    [:div.header-row.height-static
-    [catalogue-header layer-spec other-props]
-    [active-layer-catalogue-controls layer-spec other-props]]
-   [catalogue-legend layer-spec other-props]])
+    [catalogue-header layer-spec layer-state]
+    [active-layer-catalogue-controls layer-spec layer-state]]
+   [catalogue-legend layer-spec layer-state]])
 
 (defn active-layer-selection-list
   [{:keys [layers visible-layers loading-fn error-fn expanded-fn opacity-fn]}]

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -5,6 +5,7 @@ $floating-menu-padding: 10px;
 @import 'ui/css/floating-pills';
 @import 'ui/css/left-drawer';
 @import 'ui/css/state-of-knowledge';
+@import 'ui/css/layer-card';
 @import 'ui/Select/Select';
 @import 'ui/SelectionList/SelectionList';
 @import 'ui/Omnibar/Omnibar';

--- a/frontend/src/ui/SelectionList/SelectionList.css
+++ b/frontend/src/ui/SelectionList/SelectionList.css
@@ -17,7 +17,7 @@
 
 .DragHandleWrapperLabel {
     flex: 1 1 auto;
-    overflow: hidden;
+    min-width: 0;
 }
 
 .DragHandleWrapperRemoveButton {

--- a/frontend/src/ui/SelectionList/SelectionList.jsx
+++ b/frontend/src/ui/SelectionList/SelectionList.jsx
@@ -68,7 +68,7 @@ if (!document.body) {
     document.body.appendChild(portal);
 }
 
-function PortalAwareItem({ provided, snapshot, itemLabel, removeButton, className, isDragDisabled }) {
+function PortalAwareItem({ provided, snapshot, itemLabel, removeButton, className, isDragDisabled, zIndex }) {
 
     const usePortal = snapshot.isDragging;
 
@@ -86,7 +86,7 @@ function PortalAwareItem({ provided, snapshot, itemLabel, removeButton, classNam
                 {...provided.dragHandleProps}>
                 { isDragDisabled ? <span/> : <DragHandle /> }
             </div>
-            <div className="DragHandleWrapperLabel">
+            <div className="DragHandleWrapperLabel" style={{"zIndex": zIndex}}>
                 {itemLabel}
             </div>
             {
@@ -331,6 +331,7 @@ export function ItemsSelectionList({ items, onReorder, disabled }) {
                                     isDragDisabled={isDragDisabled}>
                                     {(provided, snapshot) => (
                                         <PortalAwareItem
+                                            zIndex={items.length - index}
                                             provided={provided}
                                             snapshot={snapshot}
                                             className="SelectionListItem"

--- a/frontend/src/ui/css/app.scss
+++ b/frontend/src/ui/css/app.scss
@@ -764,3 +764,7 @@ input.leaflet-control-layers-selector[type="radio"] {
 .leaflet-popup.waiting .leaflet-popup-close-button {
     display: none;
 }
+
+.bp3-checkbox {
+    margin: 0;
+}

--- a/frontend/src/ui/css/app.scss
+++ b/frontend/src/ui/css/app.scss
@@ -481,6 +481,10 @@ input.leaflet-control-layers-selector[type="radio"] {
     margin-left: 6px;
 }
 
+.form-group:not(:last-child) {
+    margin-bottom: 8px;
+}
+
 .donut-chart {
     width: 100%;
 }

--- a/frontend/src/ui/css/app.scss
+++ b/frontend/src/ui/css/app.scss
@@ -77,10 +77,6 @@ footer {
     opacity: 1;
 }
 
-.height-static {
-    flex-grow: 0;
-    flex-shrink: 0;
-}
 .bp3-collapse>.bp3-collapse-body,
 .height-managed {
     display: flex;
@@ -122,118 +118,10 @@ footer {
     margin-top: 10px;
 }
 
-/* Layer cards */
-.layer-group {
-    padding-top: 10px;
-    overflow-y: hidden;
-}
-.layer-group.collapsed {
-    min-height: 30px;
-}
-.layer-group.expanded {
-    min-height: 115px;
-}
-.layer-group.expanded.needs-extra {
-    min-height: 150px;
-}
-.active-layer-group {
-    padding-top: 10px;
-    overflow-y: hidden;
-}
-
 .group-scrollable{
     overflow-y: auto;
     padding: 2px;
     margin-bottom: 10px;
-}
-
-.layer-wrapper.bp3-card {
-    min-width: 0;
-    margin-bottom: 5px;
-}
-
-.layer-wrapper .header-row,
-.layer-wrapper .subheader-row {
-    display: flex;
-    flex-direction: row;
-    overflow: hidden;
-}
-
-.header-row .layer-wrapper {
-    width: 100%;
-}
-
-.layer-wrapper .subheader-row {
-    transition: height 200ms ease-out;
-    height: 0;
-}
-.layer-wrapper:hover .subheader-row {
-    height: 20px;
-}
-
-.header-text .bp3-popover-target {
-    display: flex;
-}
-
-.layer-wrapper .header-text {
-    flex: 1 1 auto;
-    overflow: hidden;
-}
-
-.layer-wrapper .header-row .view-controls {
-    flex: 0;
-    margin-left: 10px;
-}
-
-.layer-wrapper .control-row {
-    flex: 1 1 auto;
-}
-
-.catalogue-layer-controls .control {
-    margin-left: 2px;
-    opacity: 0.8;
-}
-.catalogue-layer-controls .control:hover {
-    opacity: 1;
-}
-
-.layer-active .header-text,
-.layer-active .bp3-icon-eye-on {
-    color: #0F9960;
-}
-
-.layer-active .bp3-icon-eye-on:hover {
-    color: #C23030;
-}
-
-.layer-active .bp3-icon-remove:hover {
-    color: #C23030;
-}
-
-.layer-active .header-text {
-    font-style: italic;
-}
-
-.layer-active .header-text-wrapper.has-icons {
-    display: flex;
-    flex-direction: row;
-}
-
-.header-status-icons {
-    padding-right: 10px
-}
-
-.layer-wrapper .legend-wrapper {
-    overflow-x: hidden;
-}
-
-.layer-wrapper .legend-wrapper img {
-    max-width: 100%;
-}
-
-.catalogue-layer-controls {
-    flex: 0 0 auto;
-    display: flex;
 }
 
 .catalogue-add {
@@ -243,29 +131,23 @@ footer {
     flex: 0 0 auto;
 }
 
-.layer-wrapper .bp3-tree-node-content {
+.catalogue-layer-node .bp3-tree-node-content {
     padding: 0;
     height: auto;
 }
-.layer-wrapper .bp3-tree-node-label > div {
+
+.catalogue-layer-node .bp3-tree-node-label > div {
     padding-left: 62px;
     padding-bottom: 5px;
     min-height: 30px;
 }
 
-.layer-wrapper .bp3-tree-node-caret-none {
+.catalogue-layer-node .bp3-tree-node-caret-none {
     display: none;
 }
 
-.layer-wrapper .bp3-tree-node-label {
+.catalogue-layer-node .bp3-tree-node-label {
     padding: 0;
-}
-
-.bp3-tree-node-label .layer-legend {
-    padding-right: 9px;
-}
-.catalogue-layer-controls > span {
-    padding-left: 2px;
 }
 
 .transect-overlay {
@@ -421,16 +303,6 @@ rect#background {
 /* Map customisation */
 /* Don't display the edit toolbar: */
 .leaflet-draw.leaflet-control > .leaflet-draw-section:nth-child(2) { display: none !important; }
-.layer-group > h1 {
-    font-size: 16px;
-    font-weight: bold;
-    cursor: pointer;
-}
-
-.active-layer-group > h1 {
-    font-size: 16px;
-    font-weight: bold;
-}
 
 .leaflet-grab {
     cursor: default;
@@ -563,12 +435,6 @@ input.leaflet-control-layers-selector[type="radio"] {
 }
 .leaflet-control-layers-list {
     padding: 0;
-}
-
-/* Fixes checkbox alignment inside of layer card controls */
-.catalogue-layer-controls .bp3-checkbox {
-    margin-bottom: 0;
-    margin-left: 3px;
 }
 
 .left-drawer-header {

--- a/frontend/src/ui/css/layer-card.scss
+++ b/frontend/src/ui/css/layer-card.scss
@@ -55,3 +55,11 @@
     gap: 6px;
     height: 20px;
 }
+
+.legend-wrapper {
+    overflow-x: hidden;
+}
+
+.legend-wrapper img {
+    max-width: 100%;
+}

--- a/frontend/src/ui/css/layer-card.scss
+++ b/frontend/src/ui/css/layer-card.scss
@@ -1,0 +1,57 @@
+.layer-card {
+    margin: 4px 2px;
+}
+
+.active-layer .layer-header-text {
+    flex: 1 1;
+    overflow: hidden;
+}
+
+.active-layer .layer-header-text {
+    color: #0F9960;
+    font-style: italic;
+}
+
+.layer-header-text .bp3-popover-target {
+    display: flex;
+}
+
+.layer-status-icons {
+    flex: 0 0;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.layer-status-icons .bp3-icon,
+.layer-control {
+    opacity: 0.8;
+}
+
+.layer-control:hover {
+    opacity: 1;
+}
+
+/* Special controls */
+.layer-control.bp3-icon-eye-on {
+    color: #0F9960;
+}
+
+.layer-control.bp3-icon-eye-on:hover,
+.layer-control.bp3-icon-remove:hover {
+    color: #C23030;
+}
+
+.layer-controls {
+    flex: 0 0;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.layer-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    height: 20px;
+}

--- a/frontend/src/ui/css/layer-card.scss
+++ b/frontend/src/ui/css/layer-card.scss
@@ -2,7 +2,7 @@
     margin: 4px 2px;
 }
 
-.active-layer .layer-header-text {
+.layer-header-text {
     flex: 1 1;
     overflow: hidden;
 }

--- a/frontend/src/ui/css/left-drawer.scss
+++ b/frontend/src/ui/css/left-drawer.scss
@@ -23,6 +23,7 @@
 	overflow-y: hidden;
 	display: flex;
 	flex-direction: column;
+	height: 100%;
 }
 
 .left-drawer-tabs > .bp3-tab-panel {

--- a/frontend/src/ui/css/state-of-knowledge.scss
+++ b/frontend/src/ui/css/state-of-knowledge.scss
@@ -66,10 +66,6 @@
     width: 436px;
 }
 
-.state-of-knowledge-pill-content .form-group:not(:last-child) {
-    margin-bottom: 8px;
-}
-
 /* Fixes bug that was preventing the use of react select fields (and probably other things) while a drawer was open */
 .bp3-overlay-start-focus-trap.bp3-overlay-enter-done {
     display: none;


### PR DESCRIPTION
[ISA-263](https://jira.its.utas.edu.au/browse/ISA-263)

Messy diffs incoming!

On top of starting a basic UI for a richer main national layer card, a lot of the layer card component stuff has been refactored and should be much neater. Of most note is that the components were cleaned up with descriptions and moved into a separate view file.

As a part of the cleaning, unused components in the old view have been removed, and unused css classes have been removed (there could be selectors that I missed, but I was quite thorough).

Pretty pictures of main national layer card:
![Screen Shot 2022-09-01 at 12 31 12 pm](https://user-images.githubusercontent.com/50224230/187819712-eba69639-3065-4441-b275-45214e1da9f2.png)
![Screen Shot 2022-09-01 at 12 31 47 pm](https://user-images.githubusercontent.com/50224230/187819729-19a048c8-638d-4b19-a46a-69d0e29c1545.png)
![Screen Shot 2022-09-01 at 12 32 37 pm](https://user-images.githubusercontent.com/50224230/187819804-a6bd7e9f-eb9d-4493-8cf4-db60fadad15b.png)

The UI elements are "dumb" and don't actually affect the display of the layers in the map – separate ticket when we get to it.