### PR TITLE
(ISA-245) pip-audit github action

### DIFF
--- a/.github/workflows/auditrequirements.yml
+++ b/.github/workflows/auditrequirements.yml
@@ -1,0 +1,20 @@
+name: Audit requirements
+
+on:
+  schedule:
+    - cron:  '0 0 * * 0' # 0:00 every Sunday
+
+jobs:
+  pip-audit:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - uses: pypa/gh-action-pip-audit@v1.0.0
+        with:
+          inputs: deploy_requirements.txt
+          summary: true
+          # ignore-vulns: | # Ignore vulnerabilities as needed: https://github.com/pypa/gh-action-pip-audit#ignore-vulns


### PR DESCRIPTION
[ISA-245](https://jira.its.utas.edu.au/browse/ISA-245)

I did some reading on [pip-audit](https://github.com/pypa/gh-action-pip-audit#configuration) and general [GitHub workflow actions syntax](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions) and managed to come up with the following file.

I think it should run Sunday 00:00 every week, and when it does it checks our `deploy_requirements.txt` for any vulnerabilities. We should be able to add vulnerabilities to ignore as needed.

In regards to receiving notifications if the workflow run fails, I believe that would be me [according to this](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/notifications-for-workflow-runs).