### PR TITLE
(ISA-275) Optionally remember saved state

### DIFF
--- a/frontend/src/cljs/imas_seamap/core.cljs
+++ b/frontend/src/cljs/imas_seamap/core.cljs
@@ -81,7 +81,7 @@
     :app/load-normal-msg                  subs/load-normal-msg
     :app/load-error-msg                   subs/load-error-msg
     :info/message                         subs/user-message
-    :autosave-application-state?          subs/autosave-application-state?}
+    :autosave?                            subs/autosave?}
 
    :events
    {:boot                                 [events/boot (re-frame/inject-cofx :save-code) (re-frame/inject-cofx :hash-code)]
@@ -102,8 +102,8 @@
     :create-save-state                    [events/create-save-state]
     :create-save-state-success            [events/create-save-state-success]
     :create-save-state-failure            [events/create-save-state-failure]
-    :toggle-autosave-application-state    [events/toggle-autosave-application-state]
-    :put-hash-if-autosave                 [events/put-hash-if-autosave]
+    :toggle-autosave                      [events/toggle-autosave]
+    :maybe-put-hash                       [events/maybe-put-hash]
     :info/show-message                    [events/show-message]
     :info/clear-message                   events/clear-message
     :transect/query                       [events/transect-query]
@@ -270,7 +270,7 @@
                               :transect/maybe-query
                               :welcome-layer/open
                               :map/update-leaflet-map
-                              :put-hash-if-autosave))
+                              :maybe-put-hash))
    (when-not ^boolean goog.DEBUG (analytics-for events-for-analytics))])
 
 (defn register-handlers! [{:keys [subs events]}]

--- a/frontend/src/cljs/imas_seamap/core.cljs
+++ b/frontend/src/cljs/imas_seamap/core.cljs
@@ -103,7 +103,7 @@
     :create-save-state-success            [events/create-save-state-success]
     :create-save-state-failure            [events/create-save-state-failure]
     :toggle-autosave                      [events/toggle-autosave]
-    :maybe-put-hash                       [events/maybe-put-hash]
+    :maybe-autosave                       [events/maybe-autosave]
     :info/show-message                    [events/show-message]
     :info/clear-message                   events/clear-message
     :transect/query                       [events/transect-query]
@@ -270,7 +270,7 @@
                               :transect/maybe-query
                               :welcome-layer/open
                               :map/update-leaflet-map
-                              :maybe-put-hash))
+                              :maybe-autosave))
    (when-not ^boolean goog.DEBUG (analytics-for events-for-analytics))])
 
 (defn register-handlers! [{:keys [subs events]}]

--- a/frontend/src/cljs/imas_seamap/core.cljs
+++ b/frontend/src/cljs/imas_seamap/core.cljs
@@ -84,7 +84,7 @@
     :autosave?                            subs/autosave?}
 
    :events
-   {:boot                                 [events/boot (re-frame/inject-cofx :save-code) (re-frame/inject-cofx :hash-code)]
+   {:boot                                 [events/boot (re-frame/inject-cofx :save-code) (re-frame/inject-cofx :hash-code) (re-frame/inject-cofx :cookie/get [:cookie-state])]
     :re-boot                              [events/re-boot]
     :ajax/default-success-handler         (fn [db [_ arg]] (js/console.log arg) db)
     :ajax/default-err-handler             (fn [db [_ arg]] (js/console.error arg) db)

--- a/frontend/src/cljs/imas_seamap/core.cljs
+++ b/frontend/src/cljs/imas_seamap/core.cljs
@@ -102,7 +102,8 @@
     :create-save-state                    [events/create-save-state]
     :create-save-state-success            [events/create-save-state-success]
     :create-save-state-failure            [events/create-save-state-failure]
-    :toggle-autosave-application-state    events/toggle-autosave-application-state
+    :toggle-autosave-application-state    [events/toggle-autosave-application-state]
+    :put-hash-if-autosave                 [events/put-hash-if-autosave]
     :info/show-message                    [events/show-message]
     :info/clear-message                   events/clear-message
     :transect/query                       [events/transect-query]
@@ -268,7 +269,8 @@
                               :sok/get-habitat-observations
                               :transect/maybe-query
                               :welcome-layer/open
-                              :map/update-leaflet-map))
+                              :map/update-leaflet-map
+                              :put-hash-if-autosave))
    (when-not ^boolean goog.DEBUG (analytics-for events-for-analytics))])
 
 (defn register-handlers! [{:keys [subs events]}]

--- a/frontend/src/cljs/imas_seamap/core.cljs
+++ b/frontend/src/cljs/imas_seamap/core.cljs
@@ -80,7 +80,8 @@
     :app/loading?                         subs/app-loading?
     :app/load-normal-msg                  subs/load-normal-msg
     :app/load-error-msg                   subs/load-error-msg
-    :info/message                         subs/user-message}
+    :info/message                         subs/user-message
+    :autosave-application-state?          subs/autosave-application-state?}
 
    :events
    {:boot                                 [events/boot (re-frame/inject-cofx :save-code) (re-frame/inject-cofx :hash-code)]
@@ -101,6 +102,7 @@
     :create-save-state                    [events/create-save-state]
     :create-save-state-success            [events/create-save-state-success]
     :create-save-state-failure            [events/create-save-state-failure]
+    :toggle-autosave-application-state    events/toggle-autosave-application-state
     :info/show-message                    [events/show-message]
     :info/clear-message                   events/clear-message
     :transect/query                       [events/transect-query]

--- a/frontend/src/cljs/imas_seamap/db.cljs
+++ b/frontend/src/cljs/imas_seamap/db.cljs
@@ -86,7 +86,7 @@
                                              :expanded #{}}
                      :sidebar               {:collapsed false
                                              :selected  "tab-activelayers"}}
-   :autosave-application-state? false
+   :autosave?       false
    :config          {:layer-url             (str api-url-base "layers/")
                      :base-layer-url        (str api-url-base "baselayers/")
                      :base-layer-group-url  (str api-url-base "baselayergroups/")

--- a/frontend/src/cljs/imas_seamap/db.cljs
+++ b/frontend/src/cljs/imas_seamap/db.cljs
@@ -86,6 +86,7 @@
                                              :expanded #{}}
                      :sidebar               {:collapsed false
                                              :selected  "tab-activelayers"}}
+   :autosave-application-state? false
    :config          {:layer-url             (str api-url-base "layers/")
                      :base-layer-url        (str api-url-base "baselayers/")
                      :base-layer-group-url  (str api-url-base "baselayergroups/")

--- a/frontend/src/cljs/imas_seamap/events.cljs
+++ b/frontend/src/cljs/imas_seamap/events.cljs
@@ -150,7 +150,7 @@
         {:keys [zoom center]} (:map db)]
         {:db         db
          :dispatch-n [[:map/update-map-view {:zoom zoom :center center :instant? true}]
-                      [:maybe-put-hash]]}))
+                      [:maybe-autosave]]}))
 
 (defn loading-screen [db [_ msg]]
   (assoc db
@@ -396,7 +396,7 @@
         habitat-layers (filter habitat-layer? visible-layers)]
     (merge
      {:db         db
-      :dispatch-n (cond-> [[:maybe-put-hash]]
+      :dispatch-n (cond-> [[:maybe-autosave]]
                     (seq habitat-layers) ; only display transect plot if there's an active habitat layer
                     (conj [:transect.plot/show]
                           [:transect.query/habitat query-id linestring]
@@ -591,18 +591,18 @@
 (defn catalogue-select-tab [{:keys [db]} [_ tabid]]
   (let [db (assoc-in db [:display :catalogue :tab] tabid)]
     {:db       db
-     :dispatch [:maybe-put-hash]}))
+     :dispatch [:maybe-autosave]}))
 
 (defn catalogue-toggle-node [{:keys [db]} [_ nodeid]]
   (let [nodes (get-in db [:display :catalogue :expanded])
         db    (update-in db [:display :catalogue :expanded] (if (nodes nodeid) disj conj) nodeid)]
     {:db       db
-     :dispatch [:maybe-put-hash]}))
+     :dispatch [:maybe-autosave]}))
 
 (defn catalogue-add-node [{:keys [db]} [_ nodeid]]
   (let [db (update-in db [:display :catalogue :expanded] conj nodeid)]
    {:db       db
-    :dispatch [:maybe-put-hash]}))
+    :dispatch [:maybe-autosave]}))
 
 (defn catalogue-add-nodes-to-layer
   "Opens nodes in catalogue along path to specified layer"
@@ -625,7 +625,7 @@
                ;; Allow the left tab to close as well as open, if clicking same icon:
                (assoc-in [:display :sidebar :collapsed] (and (= tabid selected) (not collapsed))))]
     {:db       db
-     :dispatch [:maybe-put-hash]}))
+     :dispatch [:maybe-autosave]}))
 
 (defn sidebar-close [db _]
   (assoc-in db [:display :sidebar :collapsed] true))
@@ -651,7 +651,7 @@
         readded (into [] (concat (subvec removed 0 dst-idx) [element] (subvec removed dst-idx (count removed))))
         db (assoc-in db data-path readded)]
     {:db       db
-     :dispatch [:maybe-put-hash]}))
+     :dispatch [:maybe-autosave]}))
 
 (defn left-drawer-toggle [db _]
   (update-in db [:display :left-drawer] not))
@@ -665,7 +665,7 @@
 (defn left-drawer-tab [{:keys [db]} [_ tab]]
   (let [db (assoc-in db [:display :left-drawer-tab] tab)]
     {:db       db
-     :dispatch [:maybe-put-hash]}))
+     :dispatch [:maybe-autosave]}))
 
 (defn layers-search-omnibar-toggle [db _]
   (update-in db [:display :layers-search-omnibar] not))
@@ -681,7 +681,7 @@
 
 (defn toggle-autosave [{:keys [db]} _]
   {:db       (update db :autosave? not)
-   :dispatch [:maybe-put-hash]})
+   :dispatch [:maybe-autosave]})
 
-(defn maybe-put-hash [{{:keys [autosave?] :as db} :db} _]
+(defn maybe-autosave [{{:keys [autosave?] :as db} :db} _]
   (when autosave? {:put-hash (encode-state db)}))

--- a/frontend/src/cljs/imas_seamap/events.cljs
+++ b/frontend/src/cljs/imas_seamap/events.cljs
@@ -396,10 +396,12 @@
         habitat-layers (filter habitat-layer? visible-layers)]
     (merge
      {:db         db
-      :dispatch-n [[:maybe-put-hash]
-                   (when (seq habitat-layers) [:transect.plot/show])                                 ; only display transect plot if there's an active habitat layer
-                   (when (seq habitat-layers) [:transect.query/habitat query-id linestring])         ; only query transect habitat
-                   (when (seq habitat-layers) [:transect.query/bathymetry query-id linestring])]}))) ; only query transect bathymetry
+      :dispatch-n (cond-> [[:maybe-put-hash]]
+                    (seq habitat-layers) ; only display transect plot if there's an active habitat layer
+                    (conj [:transect.plot/show]
+                          [:transect.query/habitat query-id linestring]
+                          [:transect.query/bathymetry query-id linestring]))})))
+
 (defn transect-maybe-query [{:keys [db]}]
   ;; When existing transect state is rehydrated it will have the
   ;; query, but that will need to be re-executed. Only do this if we

--- a/frontend/src/cljs/imas_seamap/events.cljs
+++ b/frontend/src/cljs/imas_seamap/events.cljs
@@ -678,3 +678,6 @@
 
 (defn mouse-pos [db [_ mouse-pos]]
   (assoc-in db [:display :mouse-pos] mouse-pos))
+
+(defn toggle-autosave-application-state [db _]
+  (update db :autosave-application-state? not))

--- a/frontend/src/cljs/imas_seamap/map/events.cljs
+++ b/frontend/src/cljs/imas_seamap/map/events.cljs
@@ -24,7 +24,7 @@
     (when selected-base-layer
       (let [db (assoc-in db [:map :active-base-layer] selected-base-layer)]
         {:db       db
-         :dispatch [:put-hash-if-autosave]}))))
+         :dispatch [:maybe-put-hash]}))))
 
 (defn bounds-for-zoom
   "GetFeatureInfo requires the pixel coordinates and dimensions around a
@@ -218,7 +218,7 @@
 (defn map-set-layer-filter [{:keys [db]} [_ filter-text]]
   (let [db (assoc-in db [:filters :layers] filter-text)]
     {:db       db
-     :dispatch [:put-hash-if-autosave]}))
+     :dispatch [:maybe-put-hash]}))
 
 (defn map-set-others-layer-filter [db [_ filter-text]]
   (assoc-in db [:filters :other-layers] filter-text))
@@ -227,7 +227,7 @@
   (s/assert (s/int-in 0 100) opacity)
   (let [db (assoc-in db [:layer-state :opacity layer] opacity)]
     {:db       db
-     :dispatch [:put-hash-if-autosave]}))
+     :dispatch [:maybe-put-hash]}))
 
 (defn process-layer [layer]
   (-> layer
@@ -387,7 +387,7 @@
                  (assoc-in [:state-of-knowledge :statistics :habitat-observations :show-layers?] false)))]
     {:db         db
      :dispatch-n [[:map/popup-closed]
-                  [:put-hash-if-autosave]]}))
+                  [:maybe-put-hash]]}))
 
 (defn toggle-layer-visibility
   [{:keys [db]} [_ layer]]
@@ -396,12 +396,12 @@
         db (update-in db [:map :hidden-layers] #((if hidden? disj conj) % layer))]
     {:db         db
      :dispatch-n [[:map/popup-closed]
-                  [:put-hash-if-autosave]]}))
+                  [:maybe-put-hash]]}))
 
 (defn toggle-legend-display [{:keys [db]} [_ {:keys [id] :as layer}]]
   (let [db (update-in db [:layer-state :legend-shown] #(if ((set %) layer) (disj % layer) (conj (set %) layer)))]
     {:db         db
-     :dispatch-n [[:put-hash-if-autosave]
+     :dispatch-n [[:maybe-put-hash]
                   (when-not (get-in db [:map :legends id]) [:map.layer/get-legend layer])]})) ; Retrieve layer legend data for display if we don't already have it or aren't already retrieving it
 
 (defn zoom-to-layer
@@ -412,7 +412,7 @@
                           (not already-active?) (update-in [:map :active-layers] (partial toggle-layer-logic layer)))]
     {:db         db
      :dispatch-n [[:map/update-map-view {:bounds bounding_box}]
-                  [:put-hash-if-autosave]]}))
+                  [:maybe-put-hash]]}))
 
 (defn region-stats-select-habitat [db [_ layer]]
   (assoc-in db [:region-stats :habitat-layer] layer))
@@ -459,7 +459,7 @@
                           (assoc :initialised true))]
     {:db         db
      :dispatch-n [[:ui/hide-loading]
-                  [:put-hash-if-autosave]]}))
+                  [:maybe-put-hash]]}))
 
 (defn update-leaflet-map [db [_ leaflet-map]]
   (when (not= leaflet-map (get-in db [:map :leaflet-map]))
@@ -495,7 +495,7 @@
                    :center center
                    :bounds bounds)]
     {:db       db
-     :dispatch [:put-hash-if-autosave]}))
+     :dispatch [:maybe-put-hash]}))
 
 (defn map-start-selecting [db _]
   (-> db
@@ -533,7 +533,7 @@
                         db)]
     {:db         db
      :dispatch-n [[:map/popup-closed]
-                  [:put-hash-if-autosave]]}))
+                  [:maybe-put-hash]]}))
 
 (defn remove-layer
   [{:keys [db]} [_ layer]]
@@ -555,7 +555,7 @@
                   (assoc-in [:state-of-knowledge :statistics :habitat-observations :show-layers?] false)))]
     {:db         db
      :dispatch-n [[:map/popup-closed]
-                  [:put-hash-if-autosave]]}))
+                  [:maybe-put-hash]]}))
 
 (defn add-layer-from-omnibar
   [{:keys [db]} [_ layer]]
@@ -573,7 +573,7 @@
 (defn toggle-viewport-only [{:keys [db]} _]
   (let [db (update-in db [:map :viewport-only?] not)]
     {:db       db
-     :dispatch [:put-hash-if-autosave]}))
+     :dispatch [:maybe-put-hash]}))
 
 (defn pan-to-popup
   "Based on a known location and size of the popup, we can find out if it will be

--- a/frontend/src/cljs/imas_seamap/map/events.cljs
+++ b/frontend/src/cljs/imas_seamap/map/events.cljs
@@ -24,7 +24,7 @@
     (when selected-base-layer
       (let [db (assoc-in db [:map :active-base-layer] selected-base-layer)]
         {:db       db
-         :dispatch [:maybe-put-hash]}))))
+         :dispatch [:maybe-autosave]}))))
 
 (defn bounds-for-zoom
   "GetFeatureInfo requires the pixel coordinates and dimensions around a
@@ -218,7 +218,7 @@
 (defn map-set-layer-filter [{:keys [db]} [_ filter-text]]
   (let [db (assoc-in db [:filters :layers] filter-text)]
     {:db       db
-     :dispatch [:maybe-put-hash]}))
+     :dispatch [:maybe-autosave]}))
 
 (defn map-set-others-layer-filter [db [_ filter-text]]
   (assoc-in db [:filters :other-layers] filter-text))
@@ -227,7 +227,7 @@
   (s/assert (s/int-in 0 100) opacity)
   (let [db (assoc-in db [:layer-state :opacity layer] opacity)]
     {:db       db
-     :dispatch [:maybe-put-hash]}))
+     :dispatch [:maybe-autosave]}))
 
 (defn process-layer [layer]
   (-> layer
@@ -387,7 +387,7 @@
                  (assoc-in [:state-of-knowledge :statistics :habitat-observations :show-layers?] false)))]
     {:db         db
      :dispatch-n [[:map/popup-closed]
-                  [:maybe-put-hash]]}))
+                  [:maybe-autosave]]}))
 
 (defn toggle-layer-visibility
   [{:keys [db]} [_ layer]]
@@ -396,12 +396,12 @@
         db (update-in db [:map :hidden-layers] #((if hidden? disj conj) % layer))]
     {:db         db
      :dispatch-n [[:map/popup-closed]
-                  [:maybe-put-hash]]}))
+                  [:maybe-autosave]]}))
 
 (defn toggle-legend-display [{:keys [db]} [_ {:keys [id] :as layer}]]
   (let [db (update-in db [:layer-state :legend-shown] #(if ((set %) layer) (disj % layer) (conj (set %) layer)))]
     {:db         db
-     :dispatch-n [[:maybe-put-hash]
+     :dispatch-n [[:maybe-autosave]
                   (when-not (get-in db [:map :legends id]) [:map.layer/get-legend layer])]})) ; Retrieve layer legend data for display if we don't already have it or aren't already retrieving it
 
 (defn zoom-to-layer
@@ -412,7 +412,7 @@
                           (not already-active?) (update-in [:map :active-layers] (partial toggle-layer-logic layer)))]
     {:db         db
      :dispatch-n [[:map/update-map-view {:bounds bounding_box}]
-                  [:maybe-put-hash]]}))
+                  [:maybe-autosave]]}))
 
 (defn region-stats-select-habitat [db [_ layer]]
   (assoc-in db [:region-stats :habitat-layer] layer))
@@ -459,7 +459,7 @@
                           (assoc :initialised true))]
     {:db         db
      :dispatch-n [[:ui/hide-loading]
-                  [:maybe-put-hash]]}))
+                  [:maybe-autosave]]}))
 
 (defn update-leaflet-map [db [_ leaflet-map]]
   (when (not= leaflet-map (get-in db [:map :leaflet-map]))
@@ -495,7 +495,7 @@
                    :center center
                    :bounds bounds)]
     {:db       db
-     :dispatch [:maybe-put-hash]}))
+     :dispatch [:maybe-autosave]}))
 
 (defn map-start-selecting [db _]
   (-> db
@@ -533,7 +533,7 @@
                         db)]
     {:db         db
      :dispatch-n [[:map/popup-closed]
-                  [:maybe-put-hash]]}))
+                  [:maybe-autosave]]}))
 
 (defn remove-layer
   [{:keys [db]} [_ layer]]
@@ -555,7 +555,7 @@
                   (assoc-in [:state-of-knowledge :statistics :habitat-observations :show-layers?] false)))]
     {:db         db
      :dispatch-n [[:map/popup-closed]
-                  [:maybe-put-hash]]}))
+                  [:maybe-autosave]]}))
 
 (defn add-layer-from-omnibar
   [{:keys [db]} [_ layer]]
@@ -573,7 +573,7 @@
 (defn toggle-viewport-only [{:keys [db]} _]
   (let [db (update-in db [:map :viewport-only?] not)]
     {:db       db
-     :dispatch [:maybe-put-hash]}))
+     :dispatch [:maybe-autosave]}))
 
 (defn pan-to-popup
   "Based on a known location and size of the popup, we can find out if it will be

--- a/frontend/src/cljs/imas_seamap/subs.cljs
+++ b/frontend/src/cljs/imas_seamap/subs.cljs
@@ -144,5 +144,5 @@
 (defn mouse-pos [db _]
   (get-in db [:display :mouse-pos]))
 
-(defn autosave-application-state? [db _]
-  (:autosave-application-state? db))
+(defn autosave? [db _]
+  (:autosave? db))

--- a/frontend/src/cljs/imas_seamap/subs.cljs
+++ b/frontend/src/cljs/imas_seamap/subs.cljs
@@ -143,3 +143,6 @@
 
 (defn mouse-pos [db _]
   (get-in db [:display :mouse-pos]))
+
+(defn autosave-application-state? [db _]
+  (:autosave-application-state? db))

--- a/frontend/src/cljs/imas_seamap/utils.cljs
+++ b/frontend/src/cljs/imas_seamap/utils.cljs
@@ -70,7 +70,8 @@
                                       [:filters :layers]
                                       :layer-state
                                       [:transect :show?]
-                                      [:transect :query]])
+                                      [:transect :query]
+                                      :autosave?])
                        (assoc :map pruned-map)
                        (assoc-in [:state-of-knowledge :boundaries] pruned-boundaries)
                        (assoc-in [:state-of-knowledge :statistics] pruned-statistics)
@@ -115,7 +116,8 @@
                  [:map :bounds]
                  [:map :viewport-only?]
                  :legend-ids
-                 :opacity-ids]))
+                 :opacity-ids
+                 :autosave?]))
 
 (defn parse-state [hash-str]
   (try

--- a/frontend/src/cljs/imas_seamap/views.cljs
+++ b/frontend/src/cljs/imas_seamap/views.cljs
@@ -202,6 +202,16 @@
       :on-click #(re-frame/dispatch [:map/toggle-viewport-only])
       :text     text}]))
 
+(defn- autosave-application-state-toggle []
+  (let [[icon text] (if @(re-frame/subscribe [:autosave-application-state?])
+                      ["disable" "Disable autosave application state"]
+                      ["floppy-disk" "Enable autosave application state"])]
+    [b/button
+     {:icon     icon
+      :class    "bp3-fill"
+      :on-click #(re-frame/dispatch [:toggle-autosave-application-state])
+      :text     text}]))
+
 (defn- layer-search-filter []
   (let [filter-text (re-frame/subscribe [:map.layers/filter])]
     [:div.bp3-input-group {:data-helper-text "Filter Layers"}
@@ -560,6 +570,7 @@
                   [components/drawer-group
                    {:heading "Settings"
                     :icon    "cog"}
+                   [autosave-application-state-toggle]
                    [viewport-only-toggle]
                    [b/button
                     {:icon     "undo"

--- a/frontend/src/cljs/imas_seamap/views.cljs
+++ b/frontend/src/cljs/imas_seamap/views.cljs
@@ -203,13 +203,13 @@
       :text     text}]))
 
 (defn- autosave-application-state-toggle []
-  (let [[icon text] (if @(re-frame/subscribe [:autosave-application-state?])
+  (let [[icon text] (if @(re-frame/subscribe [:autosave?])
                       ["disable" "Disable autosave application state"]
                       ["floppy-disk" "Enable autosave application state"])]
     [b/button
      {:icon     icon
       :class    "bp3-fill"
-      :on-click #(re-frame/dispatch [:toggle-autosave-application-state])
+      :on-click #(re-frame/dispatch [:toggle-autosave])
       :text     text}]))
 
 (defn- layer-search-filter []


### PR DESCRIPTION
[ISA-275](https://jira.its.utas.edu.au/browse/ISA-275)

So I'm not certain on my implementation, which is why I'm looking to you for a second opinion.
The way I've done this is I've registered a new event named `:put-hash-if-autosave`, and everything that previously used the `:put-hash` effect now dispatches that event instead.

I was considering registering a new effect for this, but decided against it due to clunkiness (since it would have to check if saves were enabled, encode the state, and put-hash in a single effect – [day8 discourage complex effects like that](https://github.com/day8/re-frame/blob/master/docs/Effects.md#:~:text=A%20word%20of%20advice%20-%20make%20them%20as%20simple%20as%20possible%2C%20and%20then%20simplify%20them%20further.%20You%20don%27t%20want%20them%20containing%20any%20fancy%20logic.)).