### PR TITLE
(ISA-257) Load state dynamically

### DIFF
--- a/frontend/src/cljs/imas_seamap/core.cljs
+++ b/frontend/src/cljs/imas_seamap/core.cljs
@@ -90,7 +90,7 @@
     :ajax/default-err-handler             (fn [db [_ arg]] (js/console.error arg) db)
     :load-hash-state                      [events/load-hash-state]
     :get-save-state                       [events/get-save-state]
-    :load-save-state                      [events/load-save-state]
+    :get-save-state-success               [events/get-save-state-success]
     :initialise-db                        [events/initialise-db]
     :initialise-layers                    [events/initialise-layers]
     :loading-failed                       events/loading-failed

--- a/frontend/src/cljs/imas_seamap/core.cljs
+++ b/frontend/src/cljs/imas_seamap/core.cljs
@@ -85,6 +85,7 @@
 
    :events
    {:boot                                 [events/boot (re-frame/inject-cofx :save-code) (re-frame/inject-cofx :hash-code) (re-frame/inject-cofx :cookie/get [:cookie-state])]
+    :set-state                            [events/set-state]
     :re-boot                              [events/re-boot]
     :ajax/default-success-handler         (fn [db [_ arg]] (js/console.log arg) db)
     :ajax/default-err-handler             (fn [db [_ arg]] (js/console.error arg) db)

--- a/frontend/src/cljs/imas_seamap/map/events.cljs
+++ b/frontend/src/cljs/imas_seamap/map/events.cljs
@@ -480,11 +480,10 @@
   (when leaflet-map
     (if instant?
       (do
-        (when (or zoom center) (.setView leaflet-map (clj->js (or center old-center)) (or zoom old-zoom)))
+        (when (or zoom (seq center)) (.setView leaflet-map (clj->js (or center old-center)) (or zoom old-zoom)))
         (when (seq bounds) (.fitBounds leaflet-map (-> bounds map->bounds clj->js))))
       (do
-        (when zoom (.setZoom leaflet-map zoom))
-        (when (seq center) (.flyTo leaflet-map (clj->js center)))
+        (when (or zoom (seq center)) (.flyTo leaflet-map (clj->js (if (seq center) center old-center)) (or zoom old-zoom)))
         (when (seq bounds) (.flyToBounds leaflet-map (-> bounds map->bounds clj->js))))))
   nil)
 

--- a/frontend/src/cljs/imas_seamap/utils.cljs
+++ b/frontend/src/cljs/imas_seamap/utils.cljs
@@ -263,6 +263,7 @@
     [:map :categories]
     [:map :keyed-layers]
     [:map :leaflet-map]
+    [:map :legends]
     [:state-of-knowledge :boundaries :amp :networks]
     [:state-of-knowledge :boundaries :amp :parks]
     [:state-of-knowledge :boundaries :amp :zones]

--- a/frontend/src/cljs/imas_seamap/utils.cljs
+++ b/frontend/src/cljs/imas_seamap/utils.cljs
@@ -249,3 +249,29 @@
        (map-indexed vector)
        (filter #(pred (second %)))
        (map first)))
+
+(defn ajax-loaded-info
+  "Returns db of all the info retrieved via ajax"
+  [db]
+  (select-keys*
+   db
+   [[:map :layers]
+    [:map :base-layers]
+    [:map :base-layer-groups]
+    [:map :grouped-base-layers]
+    [:map :organisations]
+    [:map :categories]
+    [:map :keyed-layers]
+    [:map :leaflet-map]
+    [:state-of-knowledge :boundaries :amp :networks]
+    [:state-of-knowledge :boundaries :amp :parks]
+    [:state-of-knowledge :boundaries :amp :zones]
+    [:state-of-knowledge :boundaries :amp :zones-iucn]
+    [:state-of-knowledge :boundaries :imcra :provincial-bioregions]
+    [:state-of-knowledge :boundaries :imcra :mesoscale-bioregions]
+    [:state-of-knowledge :boundaries :meow :realms]
+    [:state-of-knowledge :boundaries :meow :provinces]
+    [:state-of-knowledge :boundaries :meow :ecoregions]
+    [:habitat-colours]
+    [:habitat-titles]
+    [:sorting]]))


### PR DESCRIPTION
[ISA-257](https://jira.its.utas.edu.au/browse/ISA-257)

There are a few changes to make this work neatly:
- `:get-save-state` event has been modified so that instead of dispatching a single static event `:load-save-state` on success, the event it dispatches is dynamically set based on a dispatch parameter (so we don't have to make a separate event to grab the hashstate for a shortcode for each thing we want to do with a shortcode).
- The code that extracts the ajax-loaded info from the database in `:re-boot` has been separated into a utility function (and made neater).
- Small map flyTo bugfix, not important
- Most of the `:re-boot` code has been moved into a new event named `:set-state` which sets the state of the application to that of the supplied hashstate.

With all that out of the way, we now have the ability to load saved-state dynamically from a shortcode/hashstate. To do so from a shortcode would be as simple as: `(re-frame/dispatch [:get-save-state <shortcode> [:set-state]])`

I did consider neatening up the boot-flow code in this branch, but that's probably best left alone (or to be changed at another time).