### PR TITLE
(ISA-260) Open story map in right sidebar

### DIFF
--- a/frontend/src/cljs/imas_seamap/core.cljs
+++ b/frontend/src/cljs/imas_seamap/core.cljs
@@ -212,6 +212,8 @@
     :sok/bathymetry-toggle-show-layers    [sokevents/bathymetry-toggle-show-layers]
     :sok/habitat-observations-toggle-show-layers [sokevents/habitat-observations-toggle-show-layers]
     :sm/update-featured-maps              smevents/update-featured-maps
+    :sm/featured-map                      [smevents/featured-map]
+    :sm.featured-map/open                 smevents/featured-map-open
     :ui/show-loading                      events/loading-screen
     :ui/hide-loading                      events/application-loaded
     :ui.catalogue/select-tab              [events/catalogue-select-tab]

--- a/frontend/src/cljs/imas_seamap/core.cljs
+++ b/frontend/src/cljs/imas_seamap/core.cljs
@@ -90,7 +90,7 @@
 
    :events
    {:boot                                 [events/boot (re-frame/inject-cofx :save-code) (re-frame/inject-cofx :hash-code) (re-frame/inject-cofx :cookie/get [:cookie-state])]
-    :set-state                            [events/set-state]
+    :merge-state                          [events/merge-state]
     :re-boot                              [events/re-boot]
     :ajax/default-success-handler         (fn [db [_ arg]] (js/console.log arg) db)
     :ajax/default-err-handler             (fn [db [_ arg]] (js/console.error arg) db)

--- a/frontend/src/cljs/imas_seamap/core.cljs
+++ b/frontend/src/cljs/imas_seamap/core.cljs
@@ -65,6 +65,8 @@
     :sok/open-pill                        soksubs/open-pill
     :sok/boundary-layer-filter            soksubs/boundary-layer-filter-fn
     :sm/featured-maps                     smsubs/featured-maps
+    :sm/featured-map                      smsubs/featured-map
+    :sm.featured-map/open?                smsubs/featured-map-open?
     :sorting/info                         subs/sorting-info
     :download/info                        subs/download-info
     :transect/info                        subs/transect-info

--- a/frontend/src/cljs/imas_seamap/core.cljs
+++ b/frontend/src/cljs/imas_seamap/core.cljs
@@ -213,7 +213,7 @@
     :sok/habitat-observations-toggle-show-layers [sokevents/habitat-observations-toggle-show-layers]
     :sm/update-featured-maps              smevents/update-featured-maps
     :sm/featured-map                      [smevents/featured-map]
-    :sm.featured-map/open                 smevents/featured-map-open
+    :sm.featured-map/open                 [smevents/featured-map-open]
     :ui/show-loading                      events/loading-screen
     :ui/hide-loading                      events/application-loaded
     :ui.catalogue/select-tab              [events/catalogue-select-tab]

--- a/frontend/src/cljs/imas_seamap/db.cljs
+++ b/frontend/src/cljs/imas_seamap/db.cljs
@@ -64,7 +64,8 @@
                                                             :show-layers?   false}}
                         :open-pill  nil}
    :story-maps      {:featured-maps []
-                     :active-map    nil}
+                     :featured-map  nil
+                     :open?         false}
    :layer-state     {:loading-state {}
                      :tile-count    {}
                      :error-count   {}

--- a/frontend/src/cljs/imas_seamap/map/events.cljs
+++ b/frontend/src/cljs/imas_seamap/map/events.cljs
@@ -453,9 +453,13 @@
         active-base   (->> (get-in db [:map :grouped-base-layers]) (filter (comp #(= active-base %) :id)) first)
         active-base   (or active-base   ; If no base is set (eg no existing hash-state), use the first candidate
                           (first (get-in db [:map :grouped-base-layers])))
+        story-maps    (get-in db [:story-maps :featured-maps])
+        featured-map  (get-in db [:story-maps :featured-map])
+        featured-map  (first-where #(= (% :id) featured-map) story-maps)
         db            (-> db
                           (assoc-in [:map :active-layers] active-layers)
                           (assoc-in [:map :active-base-layer] active-base)
+                          (assoc-in [:story-maps :featured-map] featured-map)
                           (assoc :initialised true))]
     {:db         db
      :dispatch-n [[:ui/hide-loading]

--- a/frontend/src/cljs/imas_seamap/specs/app_state.cljs
+++ b/frontend/src/cljs/imas_seamap/specs/app_state.cljs
@@ -499,10 +499,12 @@
 
 (s/def :story-maps/featured-maps (s/coll-of :story-maps/story-map
                                             :kind vector?))
-(s/def :story-maps/active-map (s/nilable :story-maps/story-map))
+(s/def :story-maps/featured-map (s/nilable :story-maps/story-map))
+(s/def :story-maps/open? boolean?)
 (s/def ::story-maps
   (s/def :req-un [:story-maps/featured-maps
-                  :story-maps/active-map]))
+                  :story-maps/featured-map
+                  :story-maps/open?]))
 
 
 ;; display

--- a/frontend/src/cljs/imas_seamap/state_of_knowledge/views.cljs
+++ b/frontend/src/cljs/imas_seamap/state_of_knowledge/views.cljs
@@ -291,7 +291,9 @@
    {:title       "State of Knowledge"
     :position    "right"
     :size        "460px"
-    :isOpen      @(re-frame/subscribe [:sok/open?])
+    :isOpen      (and
+                  @(re-frame/subscribe [:sok/open?])
+                  (not @(re-frame/subscribe [:sm.featured-map/open?])))
     :onClose     #(re-frame/dispatch [:sok/close])
     :hasBackdrop false
     :className   "state-of-knowledge-drawer"}

--- a/frontend/src/cljs/imas_seamap/story_maps/events.cljs
+++ b/frontend/src/cljs/imas_seamap/story_maps/events.cljs
@@ -25,8 +25,10 @@
   (assoc-in db [:story-maps :featured-maps] (mapv response->story-map response)))
 
 (defn featured-map [{:keys [db]} [_ story-map]]
-  {:db (assoc-in db [:story-maps :featured-map] story-map)
-   :dispatch [:sm.featured-map/open true]})
+  {:db         (assoc-in db [:story-maps :featured-map] story-map)
+   :dispatch-n [[:sm.featured-map/open true]
+                [:maybe-autosave]]})
 
-(defn featured-map-open [db [_ open?]]
-  (assoc-in db [:story-maps :open?] open?))
+(defn featured-map-open [{:keys [db]} [_ open?]]
+  {:db       (assoc-in db [:story-maps :open?] open?)
+   :dispatch [:maybe-autosave]})

--- a/frontend/src/cljs/imas_seamap/story_maps/events.cljs
+++ b/frontend/src/cljs/imas_seamap/story_maps/events.cljs
@@ -24,10 +24,13 @@
 (defn update-featured-maps [db [_ response]]
   (assoc-in db [:story-maps :featured-maps] (mapv response->story-map response)))
 
-(defn featured-map [{:keys [db]} [_ story-map]]
-  {:db         (assoc-in db [:story-maps :featured-map] story-map)
-   :dispatch-n [[:sm.featured-map/open true]
-                [:maybe-autosave]]})
+(defn featured-map [{:keys [db]} [_ {:keys [map-links] :as story-map}]]
+  (let [db        (assoc-in db [:story-maps :featured-map] story-map)
+        shortcode (-> map-links first :shortcode)]
+    {:db         db
+     :dispatch-n [[:sm.featured-map/open true]
+                  [:maybe-autosave]
+                  (when shortcode [:get-save-state shortcode [:merge-state]])]}))
 
 (defn featured-map-open [{:keys [db]} [_ open?]]
   {:db       (assoc-in db [:story-maps :open?] open?)

--- a/frontend/src/cljs/imas_seamap/story_maps/events.cljs
+++ b/frontend/src/cljs/imas_seamap/story_maps/events.cljs
@@ -23,3 +23,10 @@
 
 (defn update-featured-maps [db [_ response]]
   (assoc-in db [:story-maps :featured-maps] (mapv response->story-map response)))
+
+(defn featured-map [{:keys [db]} [_ story-map]]
+  {:db (assoc-in db [:story-maps :featured-map] story-map)
+   :dispatch [:sm.featured-map/open true]})
+
+(defn featured-map-open [db [_ open?]]
+  (assoc-in db [:story-maps :open?] open?))

--- a/frontend/src/cljs/imas_seamap/story_maps/subs.cljs
+++ b/frontend/src/cljs/imas_seamap/story_maps/subs.cljs
@@ -5,3 +5,14 @@
 
 (defn featured-maps [db _]
   (get-in db [:story-maps :featured-maps]))
+
+(defn featured-map [db _]
+  (get-in db [:story-maps :featured-map]))
+
+(defn featured-map-open?
+  "There's a reason that we separately track the drawer open/closed state; if we
+   just told the drawer to be open when the featured map was not nil, then when we
+   erase the featured map the drawer would have errors as it's closing saying it
+   has no title/content to display while in the closing state."
+  [db _]
+  (get-in db [:story-maps :open?]))

--- a/frontend/src/cljs/imas_seamap/story_maps/views.cljs
+++ b/frontend/src/cljs/imas_seamap/story_maps/views.cljs
@@ -34,7 +34,7 @@
     {:icon     "search"
      :text     "Show me"
      :intent   "primary"
-     :on-click #(re-frame/dispatch [:get-save-state shortcode [:set-state]])}]])
+     :on-click #(re-frame/dispatch [:get-save-state shortcode [:merge-state]])}]])
 
 (defn featured-map-drawer []
   (let [{:keys [title content map-links] :as _story-map} @(re-frame/subscribe [:sm/featured-map])]

--- a/frontend/src/cljs/imas_seamap/story_maps/views.cljs
+++ b/frontend/src/cljs/imas_seamap/story_maps/views.cljs
@@ -4,13 +4,15 @@
 (ns imas-seamap.story-maps.views
   (:require [re-frame.core :as re-frame]
             [imas-seamap.blueprint :as b]
+            [imas-seamap.components :as components]
             [clojure.pprint]))
 
-(defn featured-map [{:keys [title content image] :as _story-map}]
+(defn- featured-map [{:keys [title content image] :as story-map}]
   [b/card
    {:elevation   1
     :interactive true
-    :class       "featured-map"}
+    :class       "featured-map"
+    :on-click    #(re-frame/dispatch [:sm/featured-map story-map])}
    (when (seq image)
      [:div.image-container
       [:img {:src image}]])
@@ -23,3 +25,14 @@
      (for [{:keys [id] :as story-map} story-maps]
        ^{:key (str id)}
        [featured-map story-map])]))
+
+(defn featured-map-drawer []
+  (let [{:keys [title content] :as _story-map} @(re-frame/subscribe [:sm/featured-map])]
+   [components/drawer
+    {:title    title
+     :position "right"
+     :size     "460px"
+     :isOpen   @(re-frame/subscribe [:sm.featured-map/open?])
+     :onClose  #(re-frame/dispatch [:sm.featured-map/open false])
+     :hasBackdrop false}
+    [:div content]]))

--- a/frontend/src/cljs/imas_seamap/story_maps/views.cljs
+++ b/frontend/src/cljs/imas_seamap/story_maps/views.cljs
@@ -26,13 +26,28 @@
        ^{:key (str id)}
        [featured-map story-map])]))
 
+(defn- map-link [{:keys [subtitle description shortcode] :as _map-link}]
+  [:div.map-link
+   [:div.subtitle subtitle]
+   [:div.description description]
+   [b/button
+    {:icon     "search"
+     :text     "Show me"
+     :intent   "primary"
+     :on-click #(re-frame/dispatch [:get-save-state shortcode [:set-state]])}]])
+
 (defn featured-map-drawer []
-  (let [{:keys [title content] :as _story-map} @(re-frame/subscribe [:sm/featured-map])]
+  (let [{:keys [title content map-links] :as _story-map} @(re-frame/subscribe [:sm/featured-map])]
    [components/drawer
-    {:title    title
-     :position "right"
-     :size     "460px"
-     :isOpen   @(re-frame/subscribe [:sm.featured-map/open?])
-     :onClose  #(re-frame/dispatch [:sm.featured-map/open false])
-     :hasBackdrop false}
-    [:div content]]))
+    {:title       (or title "Featured Map") ; suitable default that shouldn't be seen anyway
+     :position    "right"
+     :size        "460px"
+     :isOpen      @(re-frame/subscribe [:sm.featured-map/open?])
+     :onClose     #(re-frame/dispatch [:sm.featured-map/open false])
+     :hasBackdrop false
+     :className   "featured-map-drawer"}
+    [:<>
+     [:div content]
+     (for [{:keys [subtitle] :as map-link-val} map-links]
+       ^{:key subtitle}
+       [map-link map-link-val])]]))

--- a/frontend/src/cljs/imas_seamap/utils.cljs
+++ b/frontend/src/cljs/imas_seamap/utils.cljs
@@ -40,7 +40,7 @@
 
 (defn encode-state
   "Returns a string suitable for storing in the URL's hash"
-  [{map-state :map {boundaries-state :boundaries statistics-state :statistics} :state-of-knowledge :as db}]
+  [{:keys [story-maps] map-state :map {boundaries-state :boundaries statistics-state :statistics} :state-of-knowledge :as db}]
   (let [pruned-map (-> (select-keys map-state [:center :zoom :active-layers :active-base-layer :viewport-only? :bounds])
                        (rename-keys {:active-layers :active :active-base-layer :active-base})
                        (update :active (partial map :id))
@@ -63,6 +63,8 @@
                            [[:habitat :show-layers?]
                             [:bathymetry :show-layers?]
                             [:habitat-observations :show-layers?]])
+        pruned-story-maps (-> (select-keys story-maps [:featured-map :open?])
+                              (update :featured-map :id))
         db         (-> db
                        (select-keys* [[:display :sidebar :selected]
                                       [:display :catalogue]
@@ -76,6 +78,7 @@
                        (assoc :map pruned-map)
                        (assoc-in [:state-of-knowledge :boundaries] pruned-boundaries)
                        (assoc-in [:state-of-knowledge :statistics] pruned-statistics)
+                       (assoc :story-maps pruned-story-maps)
                        #_(update-in [:display :catalogue :expanded] #(into {} (filter second %))))
         legends    (->> db :layer-state :legend-shown (map :id))
         opacities  (->> db :layer-state :opacity (reduce (fn [acc [k v]] (if (= v 100) acc (conj acc [(:id k) v]))) {}))
@@ -109,6 +112,8 @@
                  [:state-of-knowledge :statistics :habitat :show-layers?]
                  [:state-of-knowledge :statistics :bathymetry :show-layers?]
                  [:state-of-knowledge :statistics :habitat-observations :show-layers?]
+                 [:story-maps :featured-map]
+                 [:story-maps :open?]
                  [:transect :show?]
                  [:transect :query]
                  [:map :active]
@@ -273,6 +278,7 @@
     [:state-of-knowledge :boundaries :meow :realms]
     [:state-of-knowledge :boundaries :meow :provinces]
     [:state-of-knowledge :boundaries :meow :ecoregions]
+    [:story-maps :featured-maps]
     [:habitat-colours]
     [:habitat-titles]
     [:sorting]]))

--- a/frontend/src/cljs/imas_seamap/views.cljs
+++ b/frontend/src/cljs/imas_seamap/views.cljs
@@ -663,10 +663,10 @@
   (let [hot-keys (use-memo (fn [] hotkeys-combos))
         ;; We don't need the results of this, just need to ensure it's called!
         _ #_{:keys [handle-keydown handle-keyup]} (use-hotkeys hot-keys)
-        catalogue-open?          @(re-frame/subscribe [:left-drawer/open?])
-        state-of-knowledge-open? @(re-frame/subscribe [:sok/open?])]
+        catalogue-open?    @(re-frame/subscribe [:left-drawer/open?])
+        right-drawer-open? (or @(re-frame/subscribe [:sok/open?]) @(re-frame/subscribe [:sm.featured-map/open?]))]
     [:div#main-wrapper ;{:on-key-down handle-keydown :on-key-up handle-keyup}
-     {:class (str (when catalogue-open? " catalogue-open") (when state-of-knowledge-open? " state-of-knowledge-open"))}
+     {:class (str (when catalogue-open? " catalogue-open") (when right-drawer-open? " right-drawer-open"))}
      [:div#content-wrapper
       [map-component [floating-pills]]
       [plot-component]]

--- a/frontend/src/cljs/imas_seamap/views.cljs
+++ b/frontend/src/cljs/imas_seamap/views.cljs
@@ -11,7 +11,7 @@
             [imas-seamap.map.views :refer [map-component]]
             [imas-seamap.map.layer-views :refer [layer-card layer-catalogue-content main-national-layer-card]]
             [imas-seamap.state-of-knowledge.views :refer [state-of-knowledge floating-state-of-knowledge-pill floating-boundaries-pill floating-zones-pill]]
-            [imas-seamap.story-maps.views :refer [featured-maps]]
+            [imas-seamap.story-maps.views :refer [featured-maps featured-map-drawer]]
             [imas-seamap.plot.views :refer [transect-display-component]]
             [imas-seamap.utils :refer [handler-fn handler-dispatch] :include-macros true]
             [imas-seamap.components :as components]
@@ -694,6 +694,7 @@
      [loading-display]
      [left-drawer]
      [state-of-knowledge]
+     [featured-map-drawer]
      [layers-search-omnibar]
      [layer-preview @(re-frame/subscribe [:ui/preview-layer-url])]]))
 

--- a/frontend/src/ui/css/app.scss
+++ b/frontend/src/ui/css/app.scss
@@ -613,7 +613,7 @@ input.leaflet-control-layers-selector[type="radio"] {
 }
 
 .drawer-children {
-    overflow-y: hidden;
+    overflow-y: auto;
 }
 
 .distance-tooltip {

--- a/frontend/src/ui/css/state-of-knowledge.scss
+++ b/frontend/src/ui/css/state-of-knowledge.scss
@@ -1,4 +1,4 @@
-.state-of-knowledge-open .leaflet-right {
+.right-drawer-open .leaflet-right {
     right: 460px;
 }
 

--- a/frontend/src/ui/css/story-maps.scss
+++ b/frontend/src/ui/css/story-maps.scss
@@ -26,3 +26,26 @@
     font-weight: bold;
     font-size: 16px;
 }
+
+.featured-map-drawer .drawer-children {
+    padding: 20px 16px;
+}
+
+.map-link {
+    max-width: 720px;
+    padding: 8px 12px;
+    border: 2px solid black;
+    position: relative;
+    margin: 20px 0;
+}
+
+.map-link .subtitle {
+    padding: 0 8px;
+    position: absolute;
+    top: -10px;
+    background-color: white;
+}
+
+.map-link .description {
+    margin: 6px 0 8px 0;
+}


### PR DESCRIPTION
[ISA-260](https://jira.its.utas.edu.au/browse/ISA-260)

Look at PRs #124 and #126 before this one!

Story map is now shown in the right drawer, with clickable buttons that load different map states.

Start with a story map list.
![Screen Shot 2022-09-14 at 5 04 42 pm](https://user-images.githubusercontent.com/50224230/190086025-5a21c9f0-0565-4716-9c60-4d3b542de487.png)

Open a story map by clicking on it in the list. The map state will automatically change to the one first listed in the story map.
![Screen Shot 2022-09-14 at 5 04 51 pm](https://user-images.githubusercontent.com/50224230/190086045-b4cb1e77-d9ec-4e78-a37c-2f11f13eac1d.png)

Other map states can be viewed by clicking the buttons.
![Screen Shot 2022-09-14 at 5 05 02 pm](https://user-images.githubusercontent.com/50224230/190086058-b5ce533c-51d2-4045-a352-008d556a0422.png)
