### PR TITLE
Bugfix: (ISA-282) JSON legend fixes

### DIFF
--- a/frontend/src/cljs/imas_seamap/map/events.cljs
+++ b/frontend/src/cljs/imas_seamap/map/events.cljs
@@ -658,7 +658,10 @@
                      (fn [{:keys [title filter symbolizers]}]
                        {:label  title
                         :filter filter
-                        :color  (-> symbolizers first :Polygon :fill)})))]
+                        :style
+                        {:background-color (-> symbolizers first :Polygon :fill)
+                         :height           "100%"
+                         :width            "100%"}})))]
     (assoc-in db [:map :legends id] legend)))
 
 (defmethod get-layer-legend-success :feature
@@ -669,8 +672,11 @@
           (convert-value-info
             [{:keys [label] :as value-info}]
             {:label   (or label name)
-             :color   (-> value-info :symbol :color convert-color)
-             :outline (-> value-info :symbol :outline :color convert-color)})]
+             :style
+             {:background-color (-> value-info :symbol :color convert-color)
+              :border           (str "solid 2px " (-> value-info :symbol :outline :color convert-color))
+              :height           "100%"
+              :width            "100%"}})]
     (let [render-info (get-in response [:drawingInfo :renderer])
           legend      (if (:uniqueValueInfos render-info)
                         (mapv convert-value-info (:uniqueValueInfos render-info))

--- a/frontend/src/cljs/imas_seamap/map/events.cljs
+++ b/frontend/src/cljs/imas_seamap/map/events.cljs
@@ -659,9 +659,21 @@
                        {:label  title
                         :filter filter
                         :style
-                        {:background-color (-> symbolizers first :Polygon :fill)
-                         :height           "100%"
-                         :width            "100%"}})))]
+                        (cond
+                          (-> symbolizers first :Polygon)
+                          {:background-color (-> symbolizers first :Polygon :fill)
+                           :height           "100%"
+                           :width            "100%"}
+                          
+                          (-> symbolizers first :Point)
+                          (let [{:keys [graphics size]} (-> symbolizers first :Point)
+                                {:keys [mark fill stroke stroke-width]} (first graphics)]
+                            (merge
+                             {:background-color fill
+                              :border           (str "solid " stroke-width "px " stroke)
+                              :width            (str size "px")
+                              :height           (str size "px")}
+                             (when (= mark "circle") {:border-radius "100%"}))))})))]
     (assoc-in db [:map :legends id] legend)))
 
 (defmethod get-layer-legend-success :feature

--- a/frontend/src/cljs/imas_seamap/map/events.cljs
+++ b/frontend/src/cljs/imas_seamap/map/events.cljs
@@ -5,7 +5,7 @@
   (:require [clojure.string :as string]
             [re-frame.core :as re-frame]
             [cljs.spec.alpha :as s]
-            [imas-seamap.utils :refer [encode-state ids->layers first-where index-of append-query-params-from-map]]
+            [imas-seamap.utils :refer [encode-state ids->layers first-where index-of append-query-params]]
             [imas-seamap.map.utils :refer [layer-name bounds->str wgs84->epsg3112 feature-info-html feature-info-json feature-info-none bounds->projected region-stats-habitat-layer sort-by-sort-key map->bounds leaflet-props mouseevent->coords]]
             [ajax.core :as ajax]
             [imas-seamap.blueprint :as b]
@@ -680,7 +680,7 @@
                          {:label  title
                           :filter filter
                           :style  (-> symbolizers first wms-symbolizer->key)})))
-                 (append-query-params-from-map                                                     ; else we just use an image for the legend graphic
+                 (append-query-params                                                              ; else we just use an image for the legend graphic
                   server_url
                   {:REQUEST     "GetLegendGraphic"
                    :LAYER       layer_name

--- a/frontend/src/cljs/imas_seamap/map/events.cljs
+++ b/frontend/src/cljs/imas_seamap/map/events.cljs
@@ -5,7 +5,7 @@
   (:require [clojure.string :as string]
             [re-frame.core :as re-frame]
             [cljs.spec.alpha :as s]
-            [imas-seamap.utils :refer [encode-state ids->layers first-where index-of]]
+            [imas-seamap.utils :refer [encode-state ids->layers first-where index-of append-query-params-from-map]]
             [imas-seamap.map.utils :refer [layer-name bounds->str wgs84->epsg3112 feature-info-html feature-info-json feature-info-none bounds->projected region-stats-habitat-layer sort-by-sort-key map->bounds leaflet-props mouseevent->coords]]
             [ajax.core :as ajax]
             [imas-seamap.blueprint :as b]
@@ -652,28 +652,40 @@
 (defmulti get-layer-legend-success #(get-in %2 [1 :layer_type]))
 
 (defmethod get-layer-legend-success :wms
-  [db [_ {:keys [id] :as _layer} response]]
-  (let [legend (->> response :Legend first :rules
-                    (mapv
-                     (fn [{:keys [title filter symbolizers]}]
-                       {:label  title
-                        :filter filter
-                        :style
-                        (cond
-                          (-> symbolizers first :Polygon)
-                          {:background-color (-> symbolizers first :Polygon :fill)
-                           :height           "100%"
-                           :width            "100%"}
-                          
-                          (-> symbolizers first :Point)
-                          (let [{:keys [graphics size]} (-> symbolizers first :Point)
-                                {:keys [mark fill stroke stroke-width]} (first graphics)]
-                            (merge
-                             {:background-color fill
-                              :border           (str "solid " stroke-width "px " stroke)
-                              :width            (str size "px")
-                              :height           (str size "px")}
-                             (when (= mark "circle") {:border-radius "100%"}))))})))]
+  [db [_ {:keys [id server_url layer_name] :as _layer} response]]
+  (let [legend (cond
+                 (-> response :Legend first :rules first :symbolizers first :Raster)
+                 (append-query-params-from-map
+                  server_url
+                  {:REQUEST     "GetLegendGraphic"
+                   :LAYER       layer_name
+                   :TRANSPARENT true
+                   :SERVICE     "WMS"
+                   :VERSION     "1.1.1"
+                   :FORMAT      "image/png"})
+
+                 :else
+                 (->> response :Legend first :rules
+                      (mapv
+                       (fn [{:keys [title filter symbolizers]}]
+                         {:label  title
+                          :filter filter
+                          :style
+                          (cond
+                            (-> symbolizers first :Polygon)
+                            {:background-color (-> symbolizers first :Polygon :fill)
+                             :height           "100%"
+                             :width            "100%"}
+
+                            (-> symbolizers first :Point)
+                            (let [{:keys [graphics size]} (-> symbolizers first :Point)
+                                  {:keys [mark fill stroke stroke-width]} (first graphics)]
+                              (merge
+                               {:background-color fill
+                                :border           (str "solid " stroke-width "px " stroke)
+                                :width            (str size "px")
+                                :height           (str size "px")}
+                               (when (= mark "circle") {:border-radius "100%"}))))}))))]
     (assoc-in db [:map :legends id] legend)))
 
 (defmethod get-layer-legend-success :feature

--- a/frontend/src/cljs/imas_seamap/map/layer_views.cljs
+++ b/frontend/src/cljs/imas_seamap/map/layer_views.cljs
@@ -75,8 +75,8 @@
 
 (defn- vector-legend-entry [{:keys [label color outline] :as _entry}]
   [:div.vector-legend-entry
-   [:div {:style {:background-color color :border (when outline (str "solid 2px " outline))}}]
-   [:div label]])
+   [:div.key {:style {:background-color color :border (when outline (str "solid 2px " outline))}}]
+   [:div.label label]])
 
 (defn- vector-legend [legend-info]
   [:div

--- a/frontend/src/cljs/imas_seamap/map/layer_views.cljs
+++ b/frontend/src/cljs/imas_seamap/map/layer_views.cljs
@@ -74,7 +74,7 @@
    [layer-card-controls props]])
 
 (defn- vector-legend-entry [{:keys [label color outline] :as _entry}]
-  [:div.vector-legend-rule
+  [:div.vector-legend-entry
    [:div {:style {:background-color color :border (when outline (str "solid 2px " outline))}}]
    [:div label]])
 

--- a/frontend/src/cljs/imas_seamap/map/layer_views.cljs
+++ b/frontend/src/cljs/imas_seamap/map/layer_views.cljs
@@ -73,9 +73,10 @@
    [layer-header-text props]
    [layer-card-controls props]])
 
-(defn- vector-legend-entry [{:keys [label color outline] :as _entry}]
+(defn- vector-legend-entry [{:keys [label style] :as _entry}]
   [:div.vector-legend-entry
-   [:div.key {:style {:background-color color :border (when outline (str "solid 2px " outline))}}]
+   [:div.key
+    [:div {:style style}]]
    [:div.label label]])
 
 (defn- vector-legend [legend-info]

--- a/frontend/src/cljs/imas_seamap/map/layer_views.cljs
+++ b/frontend/src/cljs/imas_seamap/map/layer_views.cljs
@@ -79,23 +79,25 @@
     [:div {:style style}]]
    [:div.label label]])
 
-(defn- vector-legend [legend-info]
-  [:div
-   (map
-    (fn [{:keys [label] :as entry}]
-      ^{:key label}
-      [vector-legend-entry entry])
-    legend-info)])
+(defn- legend [legend-info]
+  (if (string? legend-info)
+    [:img {:src legend-info}] ; if legend-info is a string, we treat it as a url to a legend graphic
+    [:<>                      ; else we render the legend as a vector legend
+     (map
+      (fn [{:keys [label] :as entry}]
+        ^{:key label}
+        [vector-legend-entry entry])
+      legend-info)]))
 
 (defn- legend-display [{:keys [legend_url] :as layer}]
   (let [{:keys [status info]} @(re-frame/subscribe [:map.layer/legend layer])]
     [:div.legend-wrapper
      (if legend_url 
-       [:img {:src legend_url}] ; if we have a custom legend url, use that to display an image
-       (case status             ; else use legend status to decide action
+       [legend legend_url] ; if we have a custom legend url, use that
+       (case status        ; else use legend status to decide action
 
          :map.legend/loaded
-         [vector-legend info]
+         [legend info]
 
          :map.legend/loading
          [b/non-ideal-state

--- a/frontend/src/cljs/imas_seamap/state_of_knowledge/subs.cljs
+++ b/frontend/src/cljs/imas_seamap/state_of_knowledge/subs.cljs
@@ -2,7 +2,7 @@
 ;;; Copyright (c) 2017, Institute of Marine & Antarctic Studies.  Written by Condense Pty Ltd.
 ;;; Released under the Affero General Public Licence (AGPL) v3.  See LICENSE file for details.
 (ns imas-seamap.state-of-knowledge.subs
-  (:require [imas-seamap.utils :refer [append-query-params-from-map]]
+  (:require [imas-seamap.utils :refer [append-query-params]]
             [imas-seamap.state-of-knowledge.utils :as utils :refer [boundary-filter-names cql-filter]]))
 
 (defn habitat-statistics [db _]
@@ -25,7 +25,7 @@
          [active-network active-park active-zone active-zone-iucn
           active-provincial-bioregion active-mesoscale-bioregion active-realm
           active-province active-ecoregion])]
-    (append-query-params-from-map
+    (append-query-params
      habitat-statistics-url
      {:boundary-type        active-boundary
       :network              active-network
@@ -59,7 +59,7 @@
          [active-network active-park active-zone active-zone-iucn
           active-provincial-bioregion active-mesoscale-bioregion active-realm
           active-province active-ecoregion])]
-    (append-query-params-from-map
+    (append-query-params
      bathymetry-statistics-url
      {:boundary-type        active-boundary
       :network              active-network

--- a/frontend/src/cljs/imas_seamap/utils.cljs
+++ b/frontend/src/cljs/imas_seamap/utils.cljs
@@ -199,7 +199,7 @@
   [url params]
   (reduce-kv (fn [acc key val] (str acc "?" (name key) "=" val)) url params))
 
-(defn append-query-params-from-map
+(defn append-query-params
   [url params]
   (let [params (map (fn [[key val]] (str (name key) "=" val)) params)
         params (apply str (interpose "&" params))]

--- a/frontend/src/ui/css/layer-card.scss
+++ b/frontend/src/ui/css/layer-card.scss
@@ -64,20 +64,20 @@
     height: 150px;
 }
 
-.vector-legend-rule {
+.vector-legend-entry {
     display: flex;
     align-items: center;
     gap: 7px;
     height: 20px;
 }
 
-.vector-legend-rule > :first-child {
+.vector-legend-entry > :first-child {
     width: 13px;
     height: 13px;
     margin-left: 3px;
 }
 
-.vector-legend-rule > :nth-child(2) {
+.vector-legend-entry > :nth-child(2) {
     white-space: pre;
     font-size: 13px;
 }

--- a/frontend/src/ui/css/layer-card.scss
+++ b/frontend/src/ui/css/layer-card.scss
@@ -75,6 +75,15 @@
     width: 13px;
     height: 13px;
     margin-left: 3px;
+    position: relative;
+}
+
+.vector-legend-entry > .key > * {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    -webkit-transform: translate(-50%, -50%);
+    transform: translate(-50%, -50%);
 }
 
 .vector-legend-entry > .label {

--- a/frontend/src/ui/css/layer-card.scss
+++ b/frontend/src/ui/css/layer-card.scss
@@ -71,13 +71,13 @@
     height: 20px;
 }
 
-.vector-legend-entry > :first-child {
+.vector-legend-entry > .key {
     width: 13px;
     height: 13px;
     margin-left: 3px;
 }
 
-.vector-legend-entry > :nth-child(2) {
+.vector-legend-entry > .label {
     white-space: pre;
     font-size: 13px;
 }


### PR DESCRIPTION
[ISA-282](https://jira.its.utas.edu.au/browse/ISA-282)

Point layer support, and using layer legend image as backup if unsupported by the app.

![Screen Shot 2022-09-15 at 12 54 13 pm](https://user-images.githubusercontent.com/50224230/190303337-7ca77c43-9903-44c1-99d2-3a78e85b608b.png)

I did consider using SVGs for the point layer legend keys, but that would take extra time (and I'm not sure how I'd dynamically set something like the stroke and colours based on the source data).