### PR TITLE
(ISA-265) ESRI GetFeatureInfo equivalent

### DIFF
--- a/frontend/src/cljs/imas_seamap/core.cljs
+++ b/frontend/src/cljs/imas_seamap/core.cljs
@@ -131,6 +131,7 @@
     :transect.plot/toggle-visibility      events/transect-visibility-toggle
     :map.feature/show                     mevents/show-popup
     :map/clicked                          [mevents/map-click-dispatcher]
+    :map/get-feature-info                 [mevents/get-feature-info]
     :map/got-featureinfo                  mevents/got-feature-info
     :map/got-featureinfo-err              mevents/got-feature-info-error
     :map/toggle-layer                     [mevents/toggle-layer]

--- a/frontend/src/cljs/imas_seamap/interop/leaflet.cljs
+++ b/frontend/src/cljs/imas_seamap/interop/leaflet.cljs
@@ -7,6 +7,7 @@
             ["react-leaflet" :as ReactLeaflet]
             ["@react-leaflet/core" :as ReactLeafletCore]
             ["react-leaflet-custom-control" :as ReactLeafletControl]
+            ["esri-leaflet" :as esri]
             ["leaflet-draw"]
             ["leaflet-easyprint"]
             ["/leaflet-coordinates/leaflet-coordinates"] ; Cannot use Leaflet.Coordinates module directly, because clojurescript isn't friendly with dots in module import names.
@@ -34,6 +35,7 @@
 (def coordinates-control (r/adapt-react-class (ReactLeafletCore/createControlComponent #(.coordinates (.-control L) %))))
 (def geojson-feature     L/geoJson)
 (def latlng              L/LatLng)
+(def esri-query          #(.query esri (clj->js %)))
 
 ;;; Multiple basemaps:
 (def layers-control         (r/adapt-react-class ReactLeaflet/LayersControl))

--- a/frontend/src/cljs/imas_seamap/map/events.cljs
+++ b/frontend/src/cljs/imas_seamap/map/events.cljs
@@ -109,7 +109,7 @@
        :INFO_FORMAT   "application/json"
        :SERVICE       "WMS"
        :VERSION       "1.1.1"}
-      :response-format (ajax/text-response-format)
+      :response-format (ajax/json-response-format {:keywords? true})
       :on-success      [:map/got-featureinfo request-id point "application/json"]
       :on-failure      [:map/got-featureinfo-err request-id point]}}))
 
@@ -257,11 +257,7 @@
   (-> layer
       (update :category    (comp keyword string/lower-case))
       (update :server_type (comp keyword string/lower-case))
-      (update :layer_type  (comp keyword string/lower-case))
-      (assoc  :info-format (case (:info_format_type layer)
-                             1 "text/html"
-                             2 "application/json"
-                             nil))))
+      (update :layer_type  (comp keyword string/lower-case))))
 
 (defn process-layers [layers]
   (mapv process-layer layers))

--- a/frontend/src/cljs/imas_seamap/map/events.cljs
+++ b/frontend/src/cljs/imas_seamap/map/events.cljs
@@ -124,7 +124,7 @@
     (.run query (fn [error feature-collection _response]
                   (if error
                     (re-frame/dispatch [:map/got-featureinfo-err request-id point nil])
-                    (re-frame/dispatch [:map/got-featureinfo request-id point "application/json" (js->clj feature-collection) layers]))))
+                    (re-frame/dispatch [:map/got-featureinfo request-id point "application/json" layers (js->clj feature-collection)]))))
     nil))
 
 (defmethod get-feature-info :default
@@ -224,7 +224,7 @@
     (when (seq responses)
       {:location point :had-insecure? had-insecure? :responses responses :show? true})))
 
-(defn got-feature-info [db [_ request-id point info-format response layers]]
+(defn got-feature-info [db [_ request-id point info-format layers response]]
   (if (not= request-id (get-in db [:feature-query :request-id]))
     db ; Ignore late responses to old clicks
     (let [db (-> db

--- a/frontend/src/cljs/imas_seamap/map/events.cljs
+++ b/frontend/src/cljs/imas_seamap/map/events.cljs
@@ -264,11 +264,10 @@
      :dispatch [:maybe-autosave]}))
 
 (defn process-layer [layer]
-  (let [layer (-> layer
-                  (update :category    (comp keyword string/lower-case))
-                  (update :server_type (comp keyword string/lower-case))
-                  (update :layer_type  (comp keyword string/lower-case)))]
-    (if (= (:layer_type layer) :feature) (assoc layer :info_format_type 4) layer)))
+  (-> layer
+      (update :category    (comp keyword string/lower-case))
+      (update :server_type (comp keyword string/lower-case))
+      (update :layer_type  (comp keyword string/lower-case))))
 
 (defn process-layers [layers]
   (mapv process-layer layers))

--- a/frontend/src/cljs/imas_seamap/map/utils.cljs
+++ b/frontend/src/cljs/imas_seamap/map/utils.cljs
@@ -192,11 +192,13 @@
        (str
         ".feature-info-json {"
         "    max-height: 257px;"
-        "    overflow-y: scroll;"
+        "    overflow-y: auto;"
+        "    width: 391px;"
         "}"
 
         ".feature-info-json table {"
         "    border-spacing: 0;"
+        "    width: 100%;"
         "}"
 
         ".feature-info-json tr:nth-child(odd) {"
@@ -206,6 +208,12 @@
         ".feature-info-json td {"
         "    padding: 3px 0px 3px 10px;"
         "    vertical-align: top;"
+        "}"
+
+        ".feature-info-json h4 {"
+        "    width: 100%;"
+        "    text-overflow: ellipsis;"
+        "    overflow-x: hidden;"
         "}")
        :body
        (str

--- a/frontend/src/cljs/imas_seamap/map/utils.cljs
+++ b/frontend/src/cljs/imas_seamap/map/utils.cljs
@@ -179,9 +179,9 @@
 
 (defn feature-info-json
   [response]
-  (let [parsed (js->clj (.parse js/JSON response))
-        id (get-in parsed ["features" 0 "id"])
-        properties (map (fn [[label value]] {:label label :value value}) (get-in parsed ["features" 0 "properties"]))
+  (js/console.log response)
+  (let [id (get-in response [:features 0 :id])
+        properties (map (fn [[label value]] {:label label :value value}) (get-in response [:features 0 :properties]))
         property-to-row (fn [{:keys [label value]}] (str "<tr><td>" label "</td><td>" value "</td></tr>"))
         property-rows (string/join "" (map (fn [property] (property-to-row property)) properties))]
     (when (or id (not-empty properties))

--- a/frontend/src/cljs/imas_seamap/map/utils.cljs
+++ b/frontend/src/cljs/imas_seamap/map/utils.cljs
@@ -183,8 +183,8 @@
 
 (defmethod feature-info-response->display "application/json"
   [{:keys [response _info-format]}]
-  (let [id (get-in response [:features 0 :id])
-        properties (map (fn [[label value]] {:label label :value value}) (get-in response [:features 0 :properties]))
+  (let [id (get-in response ["features" 0 "id"])
+        properties (map (fn [[label value]] {:label label :value value}) (get-in response ["features" 0 "properties"]))
         property-to-row (fn [{:keys [label value]}] (str "<tr><td>" label "</td><td>" value "</td></tr>"))
         property-rows (string/join "" (map (fn [property] (property-to-row property)) properties))]
     (when (or id (not-empty properties))


### PR DESCRIPTION
[ISA-265](https://jira.its.utas.edu.au/browse/ISA-265)

Did a little bit of tidying on the code that gets feature info, so now requests are dispatched in multimethods that depend on the layer info format type (so it should now be extendible to future format types should the need arise).

Can now also handle ESRI layers. It's very handy that L.esri.query returns a FeatureCollection response, since that's what we were already using for the JSON layers. ESRI feature layers responses display the same as the JSON layers.
![Screen Shot 2022-09-21 at 3 05 48 pm](https://user-images.githubusercontent.com/50224230/191419699-69b41f36-8c6b-488b-9a83-3b5c6cd0be60.png)
