### PR TITLE
(ISA-296) Catalogue layer tooltips

### DIFF
--- a/backend/catalogue/models.py
+++ b/backend/catalogue/models.py
@@ -88,6 +88,7 @@ class Layer(models.Model):
     keywords = models.CharField(max_length = 400, null=True, blank=True)
     style = models.CharField(max_length=200, null=True, blank=True)
     layer_type = models.CharField(max_length=10)
+    tooltip = models.TextField(null=True, blank=True)
 
     def __str__(self):
         return self.name

--- a/frontend/src/cljs/imas_seamap/map/layer_views.cljs
+++ b/frontend/src/cljs/imas_seamap/map/layer_views.cljs
@@ -204,10 +204,16 @@
 ;; Main national layer
 
 (defn- main-national-layer-header-text
-  [{{:keys [name] :as layer} :layer}]
+  [{{:keys [name] :as layer} :layer {:keys [active? expanded?]} :layer-state {:keys [tooltip]} :national-layer-details :as _props}]
   [:div.layer-header-text
    {:on-click  #(re-frame/dispatch [:map.layer.legend/toggle layer])}
-   [b/tooltip {:content "Main national layer!"}
+   [b/tooltip
+    {:content
+     (cond
+       (seq tooltip) tooltip
+       expanded?     "Hide details"
+       :else         "Show details")
+     :disabled (not (or active? (seq tooltip)))}
     [b/clipped-text {:ellipsize true}
      name]]])
 
@@ -241,7 +247,7 @@
      :on-click #(re-frame/dispatch [:map/toggle-layer layer])}]])
 
 (defn- main-national-layer-card-header
-  [{:keys [_layer] {:keys [visible?] :as layer-state} :layer-state :as props}]
+  [{:keys [_layer _national-layer-details] {:keys [visible?] :as layer-state} :layer-state :as props}]
   [:div.layer-header
    (when visible?
      [layer-status-icons layer-state])
@@ -316,7 +322,7 @@
 (defn- main-national-layer-card-content
   "Content of the main national layer card; includes both the header and the main
    national layer details that can be expanded and collapsed."
-  [{{:keys [tooltip]} :layer {:keys [active? expanded?]} :layer-state :as props}]
+  [{:keys [_layer] {:keys [active? expanded?]} :layer-state {:keys [tooltip]} :national-layer-details :as props}]
   [:div.layer-content
    {:class (str (when active? "active-layer") (when (seq tooltip) " has-tooltip"))}
    [main-national-layer-card-header props]
@@ -326,14 +332,19 @@
 (defn main-national-layer-card
   "Wrapper of main-national-layer-card-content in a card for displaying in lists."
   [{:keys [_layer] :as props}]
-  (let [layer-state @(re-frame/subscribe [:map.national-layer/state])]
+  (let [layer-state @(re-frame/subscribe [:map.national-layer/state])
+        {:keys
+         [_years _year _alternate-views _alternate-view _displayed-layer _tooltip]
+         :as national-layer-details}
+        @(re-frame/subscribe [:map/national-layer])
+        props (assoc props :layer-state layer-state :national-layer-details national-layer-details)]
     [b/card
      {:elevation 1
       :class     "layer-card"}
      [main-national-layer-card-content (assoc props :layer-state layer-state)]]))
 
 (defn- main-national-layer-catalogue-header
-  [{:keys [_layer] {:keys [active? visible?] :as layer-state} :layer-state :as props}]
+  [{:keys [_layer _national-layer-details] {:keys [active? visible?] :as layer-state} :layer-state :as props}]
   [:div.layer-header
    (when (and active? visible?)
      [layer-status-icons layer-state])
@@ -341,7 +352,7 @@
    [layer-catalogue-controls props]])
 
 (defn- main-national-layer-catalogue-details
-  [{:keys [layer] {:keys [opacity]} :layer-state}]
+  [{:keys [layer _national-layer-details] {:keys [opacity]} :layer-state}]
   (let [{:keys [displayed-layer]} @(re-frame/subscribe [:map/national-layer])]
     [:div.layer-details
      [b/slider
@@ -352,10 +363,13 @@
      [legend-display displayed-layer]]))
 
 (defn main-national-layer-catalogue-content
-  [{{:keys [tooltip]} :layer :as props}]
-  (let [{:keys [active? expanded?] :as layer-state} @(re-frame/subscribe [:map.national-layer/state])
-        {:keys [displayed-layer]} @(re-frame/subscribe [:map.national-layer/state])
-        props (assoc props :layer-state layer-state)]
+  [{:keys [_layer] :as props}]
+  (let [{:keys [active? expanded? displayed-layer] :as layer-state} @(re-frame/subscribe [:map.national-layer/state])
+        {:keys
+         [_years _year _alternate-views _alternate-view _displayed-layer tooltip]
+         :as national-layer-details}
+        @(re-frame/subscribe [:map/national-layer])
+        props (assoc props :layer-state layer-state :national-layer-details national-layer-details)]
     [:div.layer-content
      {:on-mouse-over #(re-frame/dispatch [:map/update-preview-layer displayed-layer])
       :on-mouse-out  #(re-frame/dispatch [:map/update-preview-layer nil])

--- a/frontend/src/cljs/imas_seamap/map/layer_views.cljs
+++ b/frontend/src/cljs/imas_seamap/map/layer_views.cljs
@@ -17,12 +17,16 @@
 (defn- layer-header-text
   "Layer name, with some other fancy stuff on top. Clicking it will expand the
    layer's details."
-  [{{:keys [name] :as layer} :layer {:keys [expanded? active?]} :layer-state}]
+  [{{:keys [name tooltip] :as layer} :layer {:keys [expanded? active?]} :layer-state}]
   [:div.layer-header-text
    {:on-click  #(re-frame/dispatch [:map.layer.legend/toggle layer])}
    [b/tooltip
-   {:content (if expanded? "Hide details" "Show details")
-    :disabled (not active?)}
+   {:content
+    (cond
+      (seq tooltip) tooltip
+      expanded?     "Hide details"
+      :else         "Show details")
+    :disabled (not (or active? (seq tooltip)))}
    [b/clipped-text {:ellipsize true}
     name]]])
 
@@ -136,9 +140,9 @@
 (defn- layer-card-content
   "Content of a layer card; includes both the header and the details that can be
    expanded and collapsed."
-  [{:keys [_layer] {:keys [active? expanded?]} :layer-state :as props}]
+  [{{:keys [tooltip]} :layer {:keys [active? expanded?]} :layer-state :as props}]
   [:div.layer-content
-   {:class (when active? "active-layer")}
+   {:class (str (when active? "active-layer") (when (seq tooltip) " has-tooltip"))}
    [layer-card-header props]
    [b/collapse {:is-open (and active? expanded?)}
     [layer-details props]]])
@@ -187,11 +191,11 @@
 (defn layer-catalogue-content
   "Content of a layer catalogue element; includes both the header and the details
    that can be expanded and collapsed."
-  [{:keys [layer] {:keys [active? expanded?]} :layer-state :as props}]
+  [{{:keys [tooltip] :as layer} :layer {:keys [active? expanded?]} :layer-state :as props}]
   [:div.layer-content
    {:on-mouse-over #(re-frame/dispatch [:map/update-preview-layer layer])
     :on-mouse-out  #(re-frame/dispatch [:map/update-preview-layer nil])
-    :class         (when active? "active-layer")}
+    :class         (str (when active? "active-layer") (when (seq tooltip) " has-tooltip"))}
    [layer-catalogue-header props]
    [b/collapse {:is-open (and active? expanded?)}
     [layer-details props]]])
@@ -304,9 +308,9 @@
 (defn- main-national-layer-card-content
   "Content of the main national layer card; includes both the header and the main
    national layer details that can be expanded and collapsed."
-  [{:keys [_layer] {:keys [active? expanded?]} :layer-state :as props}]
+  [{{:keys [tooltip]} :layer {:keys [active? expanded?]} :layer-state :as props}]
   [:div.layer-content
-   {:class (when active? "active-layer")}
+   {:class (str (when active? "active-layer") (when (seq tooltip) " has-tooltip"))}
    [main-national-layer-card-header props]
    [b/collapse {:is-open (and active? expanded?)}
     [main-national-layer-details props]]])
@@ -332,14 +336,14 @@
      [legend-display displayed-layer]]))
 
 (defn main-national-layer-catalogue-content
-  [{:keys [_layer] :as props}]
+  [{{:keys [tooltip]} :layer :as props}]
   (let [{:keys [active? expanded?] :as layer-state} @(re-frame/subscribe [:map.national-layer/state])
         {:keys [displayed-layer]} @(re-frame/subscribe [:map.national-layer/state])
         props (assoc props :layer-state layer-state)]
     [:div.layer-content
      {:on-mouse-over #(re-frame/dispatch [:map/update-preview-layer displayed-layer])
       :on-mouse-out  #(re-frame/dispatch [:map/update-preview-layer nil])
-      :class         (when active? "active-layer")}
+      :class         (str (when active? "active-layer") (when (seq tooltip) " has-tooltip"))}
      [layer-catalogue-header props]
      [b/collapse {:is-open (and active? expanded?)}
       [main-national-layer-catalogue-details props]]]))

--- a/frontend/src/cljs/imas_seamap/map/layer_views.cljs
+++ b/frontend/src/cljs/imas_seamap/map/layer_views.cljs
@@ -203,6 +203,14 @@
 
 ;; Main national layer
 
+(defn- main-national-layer-header-text
+  [{{:keys [name] :as layer} :layer}]
+  [:div.layer-header-text
+   {:on-click  #(re-frame/dispatch [:map.layer.legend/toggle layer])}
+   [b/tooltip {:content "Main national layer!"}
+    [b/clipped-text {:ellipsize true}
+     name]]])
+
 (defn- main-national-layer-card-controls
   "To the right of the layer name. Basic controls for the layer. Different from
    regular layer card controls because the controls are based on the state of the
@@ -237,7 +245,7 @@
   [:div.layer-header
    (when visible?
      [layer-status-icons layer-state])
-   [layer-header-text props]
+   [main-national-layer-header-text props]
    [main-national-layer-card-controls props]])
 
 (defn- main-national-layer-alternate-view-select
@@ -324,6 +332,14 @@
       :class     "layer-card"}
      [main-national-layer-card-content (assoc props :layer-state layer-state)]]))
 
+(defn- main-national-layer-catalogue-header
+  [{:keys [_layer] {:keys [active? visible?] :as layer-state} :layer-state :as props}]
+  [:div.layer-header
+   (when (and active? visible?)
+     [layer-status-icons layer-state])
+   [main-national-layer-header-text props]
+   [layer-catalogue-controls props]])
+
 (defn- main-national-layer-catalogue-details
   [{:keys [layer] {:keys [opacity]} :layer-state}]
   (let [{:keys [displayed-layer]} @(re-frame/subscribe [:map/national-layer])]
@@ -344,6 +360,6 @@
      {:on-mouse-over #(re-frame/dispatch [:map/update-preview-layer displayed-layer])
       :on-mouse-out  #(re-frame/dispatch [:map/update-preview-layer nil])
       :class         (str (when active? "active-layer") (when (seq tooltip) " has-tooltip"))}
-     [layer-catalogue-header props]
+     [main-national-layer-catalogue-header props]
      [b/collapse {:is-open (and active? expanded?)}
       [main-national-layer-catalogue-details props]]]))

--- a/frontend/src/cljs/imas_seamap/map/subs.cljs
+++ b/frontend/src/cljs/imas_seamap/map/subs.cljs
@@ -84,8 +84,7 @@
    :year            (get-in db [:map :national-layer-timeline-selected :year])
    :alternate-views (get-in db [:map :keyed-layers :national-layer-alternate-view])
    :alternate-view  (get-in db [:map :national-layer-alternate-view])
-   :displayed-layer (displayed-national-layer (:map db))
-   :tooltip         "Hey, listen!"})
+   :displayed-layer (displayed-national-layer (:map db))})
 
 (defn national-layer-state
   "National layer state is based on a mix of fields of the main national layer

--- a/frontend/src/cljs/imas_seamap/map/subs.cljs
+++ b/frontend/src/cljs/imas_seamap/map/subs.cljs
@@ -84,7 +84,8 @@
    :year            (get-in db [:map :national-layer-timeline-selected :year])
    :alternate-views (get-in db [:map :keyed-layers :national-layer-alternate-view])
    :alternate-view  (get-in db [:map :national-layer-alternate-view])
-   :displayed-layer (displayed-national-layer (:map db))})
+   :displayed-layer (displayed-national-layer (:map db))
+   :tooltip         "Hey, listen!"})
 
 (defn national-layer-state
   "National layer state is based on a mix of fields of the main national layer

--- a/frontend/src/cljs/imas_seamap/specs/app_state.cljs
+++ b/frontend/src/cljs/imas_seamap/specs/app_state.cljs
@@ -50,6 +50,7 @@
 (s/def :map.layer/info_format_type integer?)
 (s/def :map.layer/keywords (s/nilable string?))
 (s/def :map.layer/style (s/nilable string?))
+(s/def :map.layer/tooltip (s/nilable string?))
 (s/def :map/layer
   (s/keys :req-un [:map.layer/name
                    :map.layer/server_url
@@ -63,7 +64,8 @@
                    :map.layer/server_type
                    :map.layer/info_format_type
                    :map.layer/keywords
-                   :map.layer/style]))
+                   :map.layer/style
+                   :map.layer/tooltip]))
 
 
 (s/def :map.base-layer/id integer?)

--- a/frontend/src/ui/css/layer-card.scss
+++ b/frontend/src/ui/css/layer-card.scss
@@ -7,6 +7,11 @@
     overflow: hidden;
 }
 
+.has-tooltip .layer-header-text {
+    color: #3681b7;
+    font-style: italic;
+}
+
 .active-layer .layer-header-text {
     color: #0F9960;
     font-style: italic;


### PR DESCRIPTION
[ISA-296](https://jira.its.utas.edu.au/browse/ISA-296)

Layers can have tooltips now.

Tooltips highlight layers in the catalogue with blue text and italics:
![Screen Shot 2022-10-04 at 2 52 15 pm](https://user-images.githubusercontent.com/50224230/193741564-394773a7-c421-4dba-83f2-c7243c0f0b56.png)

Hovering over the header will display the tooltip:
![Screen Shot 2022-10-04 at 2 54 21 pm](https://user-images.githubusercontent.com/50224230/193741625-dfeba033-ee15-40ce-af35-be9a2f5d37ae.png)

The national layer also has tooltips for its current state if it displays an alternate view or year:
![Screen Shot 2022-10-04 at 4 31 18 pm](https://user-images.githubusercontent.com/50224230/193741857-2dc17c31-84c1-461a-8eea-df3c35be175f.png)

