### PR TITLE
UX Sweep: Story Maps

### DIFF
--- a/frontend/src/cljs/imas_seamap/events.cljs
+++ b/frontend/src/cljs/imas_seamap/events.cljs
@@ -196,7 +196,7 @@
     {:db         db
      :dispatch-n (conj
                   (mapv #(vector :map.layer/get-legend %) (init-layer-legend-status layers legend-ids))
-                  [:map/update-map-view (if (seq startup-layers) {:bounds (:bounding_box (first startup-layers))} {:zoom zoom :center center})]
+                  [:map/update-map-view {:zoom zoom :center center}]
                   [:map/popup-closed])}))
 
 (defn re-boot [{:keys [db]} _]

--- a/frontend/src/cljs/imas_seamap/story_maps/views.cljs
+++ b/frontend/src/cljs/imas_seamap/story_maps/views.cljs
@@ -33,6 +33,8 @@
     {:icon     "search"
      :text     "Show me"
      :intent   "primary"
+     :class    "show-me"
+     :large    true
      :on-click #(re-frame/dispatch [:get-save-state shortcode [:merge-state]])}]])
 
 (defn featured-map-drawer []

--- a/frontend/src/cljs/imas_seamap/story_maps/views.cljs
+++ b/frontend/src/cljs/imas_seamap/story_maps/views.cljs
@@ -46,7 +46,7 @@
      :hasBackdrop false
      :className   "featured-map-drawer"}
     [:<>
-     [:div content]
+     [:div.summary content]
      (for [{:keys [subtitle] :as map-link-val} map-links]
        ^{:key subtitle}
        [map-link map-link-val])]]))

--- a/frontend/src/cljs/imas_seamap/story_maps/views.cljs
+++ b/frontend/src/cljs/imas_seamap/story_maps/views.cljs
@@ -47,8 +47,8 @@
      :onClose     #(re-frame/dispatch [:sm.featured-map/open false])
      :hasBackdrop false
      :className   "featured-map-drawer"}
-    [:<>
-     [:div.summary content]
+    [:div.summary content]
+    [:div.map-links
      (map-indexed
       (fn [index map-link-val]
         ^{:key index}

--- a/frontend/src/cljs/imas_seamap/story_maps/views.cljs
+++ b/frontend/src/cljs/imas_seamap/story_maps/views.cljs
@@ -25,9 +25,9 @@
        ^{:key (str id)}
        [featured-map story-map])]))
 
-(defn- map-link [{:keys [subtitle description shortcode] :as _map-link}]
+(defn- map-link [{:keys [index] {:keys [subtitle description shortcode] :as _map-link} :map-link}]
   [:div.map-link
-   [:div.subtitle subtitle]
+   [:div.subtitle (str index ".) " subtitle)]
    [:div.description description]
    [b/button
     {:icon     "search"
@@ -47,6 +47,8 @@
      :className   "featured-map-drawer"}
     [:<>
      [:div.summary content]
-     (for [{:keys [subtitle] :as map-link-val} map-links]
-       ^{:key subtitle}
-       [map-link map-link-val])]]))
+     (map-indexed
+      (fn [index map-link-val]
+        ^{:key index}
+        [map-link {:map-link map-link-val :index (inc index)}])
+      map-links)]]))

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -9,6 +9,8 @@ $seamap-color-lightest: white;
 $seamap-color-dark: rgb(45, 101, 154);
 $seamap-color-darker: rgb(17, 60, 108);
 
+$seamap-color-dark-darker: rgb(40, 93, 143);
+
 @import 'ui/css/wordpress';
 @import 'ui/css/floating-pills';
 @import 'ui/css/left-drawer';

--- a/frontend/src/ui/blueprint.scss
+++ b/frontend/src/ui/blueprint.scss
@@ -4,13 +4,12 @@ $seamap-color-lighter: rgb(200, 220, 240);
 $seamap-color-lightest: white;
 $seamap-color-dark: rgb(45, 101, 154);
 $seamap-color-darker: rgb(17, 60, 108);
-$seamap-color-darker-darker: rgb(13, 48, 87);
 
-$switch-checked-background-color: $seamap-color-darker;
-$switch-checked-background-color-hover: $seamap-color-darker-darker;
+$seamap-color-dark-darker: rgb(40, 93, 143);
 
 $pt-grid-size: 8px !default;
-$pt-link-color: $seamap-color-darker;
+$blue2: $seamap-color-dark-darker;
+$blue3: $seamap-color-dark;
 
 // $pt-font-size: 14px;
 // $pt-font-size-small: 12px;

--- a/frontend/src/ui/css/app.scss
+++ b/frontend/src/ui/css/app.scss
@@ -759,16 +759,34 @@ input.leaflet-control-layers-selector[type="radio"] {
     color: $seamap-color-darker;
 }
 
-.bp3-button {
+.bp3-button:not(.bp3-minimal) {
     border-radius: 0;
     font-size: 14px;
     font-weight: bold;
     padding: 7px 12px;
+
+    >.bp3-icon {
+        color: inherit;
+    }
+
+    &:not([class*="bp3-intent-"]) {
+        background-color: $seamap-color-dark;
+        color: $seamap-color-lightest;
+        &:hover {
+            background-color: $seamap-color-dark-darker;
+        }
+    }
+
     &.bp3-intent-primary,
-    &.bp3-intent-primary:hover {
+    &:not([class*="bp3-intent-"]) {
         background-image: none;
         box-shadow: none;
+        &:hover {
+            background-image: none;
+            box-shadow: none;
+        }
     }
+
     &.bp3-large {
         font-size: 15px;
         padding: 9px 13px;

--- a/frontend/src/ui/css/app.scss
+++ b/frontend/src/ui/css/app.scss
@@ -759,6 +759,18 @@ input.leaflet-control-layers-selector[type="radio"] {
     color: $seamap-color-darker;
 }
 
+.bp3-button {
+    border-radius: 0;
+    font-size: 14px;
+    font-weight: bold;
+    padding: 7px 12px;
+    &.bp3-intent-primary,
+    &.bp3-intent-primary:hover {
+        background-image: none;
+        box-shadow: none;
+    }
+}
+
 .leaflet-control-block {
     background-color: #fff;
 }

--- a/frontend/src/ui/css/app.scss
+++ b/frontend/src/ui/css/app.scss
@@ -769,6 +769,14 @@ input.leaflet-control-layers-selector[type="radio"] {
         background-image: none;
         box-shadow: none;
     }
+    &.bp3-large {
+        font-size: 15px;
+        padding: 9px 13px;
+        .bp3-icon svg {
+            height: 20px;
+            width: 20px;
+        }
+    }
 }
 
 .leaflet-control-block {

--- a/frontend/src/ui/css/story-maps.scss
+++ b/frontend/src/ui/css/story-maps.scss
@@ -42,20 +42,12 @@
 }
 
 .map-link {
-    max-width: 720px;
-    padding: 8px 12px;
-    border: 2px solid black;
-    position: relative;
-    margin: 20px 0;
+    padding: 18px 26px 10px 26px;
+    border-bottom: 2px solid $seamap-color-medium;
 }
 
 .map-link .subtitle {
-    padding: 0 8px;
-    position: absolute;
-    top: -10px;
-    background-color: white;
 }
 
 .map-link .description {
-    margin: 6px 0 8px 0;
 }

--- a/frontend/src/ui/css/story-maps.scss
+++ b/frontend/src/ui/css/story-maps.scss
@@ -44,9 +44,16 @@
 .map-link {
     padding: 18px 26px 10px 26px;
     border-bottom: 2px solid $seamap-color-medium;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
 }
 
 .map-link .subtitle {
+    color: $seamap-color-dark;
+    font-size: 21px;
+    font-weight: bold;
 }
 
 .map-link .description {

--- a/frontend/src/ui/css/story-maps.scss
+++ b/frontend/src/ui/css/story-maps.scss
@@ -41,6 +41,22 @@
     font-size: 26px;
 }
 
+.featured-map-drawer .drawer-children {
+    display: flex;
+    flex-direction: column;
+    overflow-y: hidden;
+    >* {
+        min-height: 0;
+        &:last-child {
+            flex: 1;
+        }
+    }
+}
+
+.map-links {
+    overflow-y: auto;
+}
+
 .map-link {
     padding: 18px 26px 10px 26px;
     border-bottom: 2px solid $seamap-color-medium;

--- a/frontend/src/ui/css/story-maps.scss
+++ b/frontend/src/ui/css/story-maps.scss
@@ -47,7 +47,7 @@
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    gap: 8px;
+    gap: 10px;
 }
 
 .map-link .subtitle {
@@ -57,4 +57,9 @@
 }
 
 .map-link .description {
+    font-size: 15px;
+}
+
+.map-link .show-me {
+    margin-left: auto;
 }

--- a/frontend/src/ui/css/story-maps.scss
+++ b/frontend/src/ui/css/story-maps.scss
@@ -34,8 +34,11 @@
     font-size: 16px;
 }
 
-.featured-map-drawer .drawer-children {
-    padding: 20px 16px;
+.featured-map-drawer .summary {
+    background-color: $seamap-color-dark;
+    color: $seamap-color-lightest;
+    padding: 22px 28px;
+    font-size: 26px;
 }
 
 .map-link {


### PR DESCRIPTION
(Probably should be done after #151)

Doing a UX sweep on the story maps drawer to closely match Nat's design.
Nat's design:
![Screen Shot 2022-11-11 at 3 54 13 pm](https://user-images.githubusercontent.com/50224230/201266727-bd88e79e-2339-4db8-b3ca-941996085970.png)

Seamap app:
![Screen Shot 2022-11-11 at 3 53 28 pm](https://user-images.githubusercontent.com/50224230/201266780-c955f94d-08d3-4949-a5ce-b0023e72db11.png)

While Blueprint allows the use of variables to tweak a few aspects of an application, I've noticed that it's not perfect and that they don't have free customisation over all the aspects we need. It'd probably be best to organise the I've added CSS responsible for overriding Blueprint into its own file. 