### PR TITLE
Django: jump to next major LTS (4.2)

### DIFF
--- a/backend/base_requirements.txt
+++ b/backend/base_requirements.txt
@@ -1,5 +1,5 @@
 cycler==0.11.0
-Django==3.2.25
+Django==4.2.13
 django-cors-headers==3.4.0
 django-extensions==3.0.3
 mssql-django==1.5


### PR DESCRIPTION
No refactorings or fixes needed so far