### PR TITLE
ISA-603: TMA Google Analytics report

### DIFF
--- a/frontend/src/cljs/imas_seamap/analytics.cljs
+++ b/frontend/src/cljs/imas_seamap/analytics.cljs
@@ -17,44 +17,51 @@
   {:event_category "layers"
    :event_action   "add-layer"
    :event_label    (:layer_name layer)
-   :layer_name     (:layer_name layer)})
+   :layer_name     (:layer_name layer)
+   :layer_display_name (:name layer)})
 
 (defmethod format-event :map/remove-layer [[_ layer :as _event-v]]
   {:event_category "layers"
    :event_action   "remove-layer"
    :event_label    (:layer_name layer)
-   :layer_name     (:layer_name layer)})
+   :layer_name     (:layer_name layer)
+   :layer_display_name (:name layer)})
 
 (defmethod format-event :map.layer/metadata-click [[_ {:keys [link layer]} :as _event-v]]
   {:event_category "layers"
    :event_action   "metadata-click"
    :event_label    (:layer_name layer)
    :layer_name     (:layer_name layer)
+   :layer_display_name (:name layer)
    :metadata_link  link})
 
 (defmethod format-event :map/pan-to-layer [[_ layer :as _event-v]]
   {:event_category "layers"
    :event_action   "pan-layer"
    :event_label    (:layer_name layer)
-   :layer_name     (:layer_name layer)})
+   :layer_name     (:layer_name layer)
+   :layer_display_name (:name layer)})
 
 (defmethod format-event :map/toggle-layer-visibility [[_ layer :as _event-v]]
   {:event_category "layers"
    :event_action   "toggle-layer-visibility"
    :event_label    (:layer_name layer)
-   :layer_name     (:layer_name layer)})
+   :layer_name     (:layer_name layer)
+   :layer_display_name (:name layer)})
 
 (defmethod format-event :map.layer/load-error [[_ layer :as _event-v]]
   {:event_category "layers"
    :event_action   "layer-load-error"
    :event_label    (:layer_name layer)
-   :layer_name     (:layer_name layer)})
+   :layer_name     (:layer_name layer)
+   :layer_display_name (:name layer)})
 
 (defmethod format-event :download-click [[_ {:keys [link layer type]} :as _event-v]]
   {:event_category "layers"
    :event_action   "download-click"
    :event_label    (:layer_name layer)
    :layer_name     (:layer_name layer)
+   :layer_display_name (:name layer)
    :download_link  link
    :download_type  type})
 

--- a/frontend/src/cljs/imas_seamap/analytics.cljs
+++ b/frontend/src/cljs/imas_seamap/analytics.cljs
@@ -65,6 +65,11 @@
    :download_link  link
    :download_type  type})
 
+(defmethod format-event :sm/featured-map [[_ {:keys [title] :as _story-map} :as _event-v]]
+  {:event_action   "sm/featured-map"
+   :event_label    title
+   :featured_map   title})
+
 (defmethod format-event :default [[id & _args :as _event-v]]
   {:event_category "general"
    :event_action   (event->action id)})

--- a/frontend/src/cljs/imas_seamap/tas_marine_atlas/core.cljs
+++ b/frontend/src/cljs/imas_seamap/tas_marine_atlas/core.cljs
@@ -221,7 +221,9 @@
    :map/toggle-layer
    :map/toggle-layer-visibility
    :transect.plot/toggle-visibility
-   :transect/query])
+   :transect/query
+   :data-in-region/get
+   :sm/featured-map])
 
 (def standard-interceptors
   [(when ^boolean goog.DEBUG (debug-excluding


### PR DESCRIPTION
[ISA-603: TMA Google Analytics report](https://utas.atlassian.net/browse/ISA-603)

Some changes to analytics to accomodate for the new metrics that TMA want to track in the Google Analytics reports.

Added new `layer_display_name` property to layer events, since layer events for non-WMS layers won't really have a `layer_name` property to distinguish the layers with.