### PR TITLE
Experiment: configuration-driven deployments

### DIFF
--- a/frontend/docs/configuration-driven-refactor-proposal.md
+++ b/frontend/docs/configuration-driven-refactor-proposal.md
@@ -1,0 +1,789 @@
+# Configuration-Driven Architecture Refactor Proposal
+
+## Current State Analysis
+
+### Deployments
+
+The codebase supports **4 deployments**, each with its own `core.cljs` entry point:
+
+| Deployment | Entry Point | CSS Class |
+|------------|-------------|-----------|
+| Seamap Australia | `imas_seamap/core.cljs` | `seamap` |
+| Tasmania Marine Atlas (TMA) | `imas_seamap/tas_marine_atlas/core.cljs` | `tas-marine-atlas` |
+| Seamap Antarctica | `imas_seamap/seamap_antarctica/core.cljs` | `seamap` |
+| Futures of Seafood | `imas_seamap/futuresofseafood/core.cljs` | `futures-of-seafood` |
+
+### Current Patterns
+
+1. **Handler Registry** - Each `core.cljs` defines a `config-handlers` map with `:subs` and `:events`
+2. **Flag Propagation** - The `tma?` boolean propagates through 3+ levels of components
+3. **Component Replacement** - Each deployment has its own `layout-app` in a custom `views.cljs`
+4. **Schema Variants** - Separate `db.cljs` files define different state shapes
+
+### Feature Variations by Deployment
+
+| Feature | Australia | TMA | Antarctica | FoS |
+|---------|-----------|-----|------------|-----|
+| State-of-Knowledge | ✓ | ✗ | ✓ | ✗ |
+| Data-in-Region | ✗ | ✓ | ✗ | ✗ |
+| Featured Maps | ✓ | ✓ | ✗ | ✗ |
+| Floating Pills | ✓ | ✗ | ✓ | ✗ |
+| Plot Component | ✓ | ✗ | ✗ | ✓ |
+| Custom CRS | ✗ | ✗ | ✓ (EPSG:3031) | ✗ |
+| Data Providers | ✓ | ✗ | ✗ | ✗ |
+| Transect Control | ✓ | ✗ | ✗ | ✓ |
+
+### Current Problems
+
+The main issue is **variant parent components**. When a child component 2-3 levels deep needs to behave differently:
+
+1. The `tma?` flag must be passed through every intermediate component
+2. Parent components that don't use the flag still need to accept and forward it
+3. Adding a new variation requires modifying multiple files
+4. Each deployment maintains its own `views.cljs` with a full `layout-app` copy
+
+Example of current flag propagation in `views.cljs`:
+```clojure
+;; Level 1: left-drawer calls
+[left-drawer-catalogue true]
+
+;; Level 2: left-drawer-catalogue passes to layer-catalogue
+(defn left-drawer-catalogue [tma?]
+  [layer-catalogue :main catalogue-layers {...} tma?])
+
+;; Level 3: layer-catalogue passes to layer-card
+;; Level 4: layer-card uses it for tooltip text
+```
+
+---
+
+## Proposed Configuration-Driven Architecture
+
+### 1. Unified Deployment Configuration Schema
+
+Create a single configuration file that declares all deployment differences:
+
+```clojure
+;; src/cljs/imas_seamap/config/deployments.cljs
+
+(def seamap-australia
+  {:id          :seamap-australia
+   :css-class   "seamap"
+
+   ;; Branding
+   :branding    {:logo   "img/Seamap2_V2_RGB.png"
+                 :title  "Seamap Australia"
+                 :url    "https://seamapaustralia.org"}
+
+   ;; Map configuration
+   :map         {:crs    :epsg-3857
+                 :center [-28.0 134.0]
+                 :zoom   5}
+
+   ;; Feature flags (declarative set)
+   :features    #{:state-of-knowledge
+                  :featured-maps
+                  :floating-pills
+                  :plot-component
+                  :transect-control
+                  :data-providers
+                  :data-download}
+
+   ;; Right drawer slot mappings
+   :drawers     {:state-of-knowledge :sok/panel
+                 :story-map          :featured-map/drawer}
+
+   ;; Left drawer tabs (ordered)
+   :tabs        [:catalogue :active-layers :featured-maps]
+
+   ;; Map controls (ordered)
+   :controls    [:menu :settings :zoom :print :omnisearch
+                 :transect :region :share :reset :shortcuts :help]})
+
+(def tas-marine-atlas
+  {:id          :tas-marine-atlas
+   :css-class   "tas-marine-atlas"
+
+   :branding    {:logo   "img/TMA_Banner_size_website.png"
+                 :title  "Tasmania Marine Atlas"
+                 :url    "https://tasmarineatlas.org"}
+
+   :map         {:crs    :epsg-3857
+                 :center [-42.20 146.74]
+                 :zoom   7}
+
+   :features    #{:featured-maps
+                  :data-in-region}  ;; No state-of-knowledge
+
+   :drawers     {:story-map      :featured-map/drawer
+                 :data-in-region :data-in-region/panel}
+
+   :tabs        [:catalogue :active-layers :featured-maps]
+
+   :controls    [:menu :settings :zoom :print :omnisearch
+                 :region :share :reset :shortcuts :help]})
+
+(def seamap-antarctica
+  {:id          :seamap-antarctica
+   :css-class   "seamap"
+
+   :branding    {:logo   "img/SeaMapAntarctica_Logo_RGB_3000px.png"
+                 :title  "Seamap Antarctica"
+                 :url    "https://seamapantarctica.org"}
+
+   :map         {:crs    :epsg-3031  ;; Antarctic polar projection
+                 :center [-80 -90]
+                 :zoom   2}
+
+   :features    #{:state-of-knowledge
+                  :floating-pills
+                  :boundaries-pill
+                  :zones-pill}
+
+   :drawers     {:state-of-knowledge :sok/panel}
+
+   :tabs        [:catalogue :active-layers]  ;; No featured maps
+
+   :controls    [:menu :settings :zoom :print :omnisearch
+                 :region :share :reset :shortcuts :help]})
+
+(def futures-of-seafood
+  {:id          :futures-of-seafood
+   :css-class   "futures-of-seafood"
+
+   :branding    {:logo   "img/Futures-of-Seafood-Logo.png"
+                 :title  "Futures of Seafood"
+                 :url    "https://futuresofseafood.org"}
+
+   :map         {:crs    :epsg-3857
+                 :center [-28.0 134.0]
+                 :zoom   5}
+
+   :features    #{:plot-component
+                  :transect-control}
+
+   :drawers     {}
+
+   :tabs        [:catalogue :active-layers]
+
+   :controls    [:menu :settings :zoom :print :omnisearch
+                 :transect :region :share :reset :shortcuts :help]})
+
+(def deployments
+  {:seamap-australia   seamap-australia
+   :tas-marine-atlas   tas-marine-atlas
+   :seamap-antarctica  seamap-antarctica
+   :futures-of-seafood futures-of-seafood})
+```
+
+### 2. Feature-Gated Component Rendering
+
+Replace flag propagation with subscription-based feature checks:
+
+```clojure
+;; src/cljs/imas_seamap/subs/features.cljs
+
+(re-frame/reg-sub
+ :deployment/config
+ (fn [db _]
+   (get db :config)))
+
+(re-frame/reg-sub
+ :feature/enabled?
+ :<- [:deployment/config]
+ (fn [config [_ feature-key]]
+   (contains? (:features config) feature-key)))
+
+(re-frame/reg-sub
+ :feature/all
+ :<- [:deployment/config]
+ (fn [config _]
+   (:features config)))
+
+;; Convenience macro for components
+(defn feature? [feature-key]
+  @(re-frame/subscribe [:feature/enabled? feature-key]))
+```
+
+Usage in components (no more `tma?` parameter):
+
+```clojure
+;; Before (current)
+(defn layer-card [{:keys [layer tma?]}]
+  [:div.layer-card
+   [layer-card-content layer]
+   [layer-control
+    {:tooltip (if tma? "Layer info" "Layer info / Download data")}]])
+
+;; After (proposed)
+(defn layer-card [{:keys [layer]}]
+  (let [show-download? (feature? :data-download)]
+    [:div.layer-card
+     [layer-card-content layer]
+     [layer-control
+      {:tooltip (if show-download?
+                  "Layer info / Download data"
+                  "Layer info")}]]))
+```
+
+### 3. Slot-Based Layout System
+
+Replace multiple `layout-app` variants with a single configurable layout:
+
+```clojure
+;; src/cljs/imas_seamap/views/layout.cljs
+
+(defn layout-app []
+  (let [config @(re-frame/subscribe [:deployment/config])]
+    [:div {:class (:css-class config)}
+     ;; Core content
+     [content-wrapper]
+
+     ;; Configurable panels
+     [left-drawer {:tabs (:tabs config)
+                   :branding (:branding config)}]
+     [right-drawer {:slots (:drawers config)}]
+
+     ;; Configurable controls
+     [controls-panel {:controls (:controls config)}]
+
+     ;; Feature-gated components
+     (when (feature? :floating-pills)
+       [floating-pills])
+     (when (feature? :plot-component)
+       [plot-component])
+
+     ;; Always present
+     [helper-overlay]
+     [welcome-dialogue]
+     [settings-overlay]
+     [info-card]
+     [loading-display]]))
+
+(defn left-drawer [{:keys [tabs branding]}]
+  [:div.left-drawer
+   [branding-header branding]
+   [tab-container
+    (for [tab tabs]
+      ^{:key tab}
+      [(resolve-tab tab)])]])
+
+(defn right-drawer [{:keys [slots]}]
+  (let [active-drawer @(re-frame/subscribe [:ui/right-drawer])]
+    (when-let [component-key (get slots active-drawer)]
+      [(resolve-component component-key)])))
+
+(defn controls-panel [{:keys [controls]}]
+  [:div.leaflet-control-container
+   (for [control controls]
+     ^{:key control}
+     [(resolve-control control)])])
+```
+
+### 4. Component Registry
+
+Register components by keyword for dynamic resolution:
+
+```clojure
+;; src/cljs/imas_seamap/registry/components.cljs
+
+(def component-registry
+  {;; Right drawer panels
+   :sok/panel              sok/state-of-knowledge-panel
+   :featured-map/drawer    featured-map-drawer
+   :data-in-region/panel   data-in-region-panel
+   :dynamic-pill/drawer    dynamic-pill-drawer
+
+   ;; Plot components
+   :transect/plot          plot-component})
+
+(def tab-registry
+  {:catalogue     left-drawer-catalogue
+   :active-layers left-drawer-active-layers
+   :featured-maps left-drawer-featured-maps})
+
+(def control-registry
+  {:menu       menu-button
+   :settings   settings-button
+   :zoom       zoom-control
+   :print      print-control
+   :omnisearch omnisearch-control
+   :transect   transect-control
+   :region     region-control
+   :share      share-control
+   :reset      reset-control
+   :shortcuts  shortcuts-control
+   :help       help-control})
+
+(defn resolve-component [k]
+  (or (get component-registry k)
+      (throw (ex-info "Unknown component" {:key k}))))
+
+(defn resolve-tab [k]
+  (or (get tab-registry k)
+      (throw (ex-info "Unknown tab" {:key k}))))
+
+(defn resolve-control [k]
+  (or (get control-registry k)
+      (throw (ex-info "Unknown control" {:key k}))))
+```
+
+### 5. Feature-Based Handler Registration
+
+Extend the existing `config-handlers` pattern to be feature-driven:
+
+```clojure
+;; src/cljs/imas_seamap/handlers/registry.cljs
+
+(def base-handlers
+  "Handlers required by all deployments"
+  {:subs   {...}
+   :events {...}})
+
+(def feature-handlers
+  "Handlers registered only when feature is enabled"
+  {:state-of-knowledge
+   {:subs   {:sok/habitat-statistics    sok-subs/habitat-statistics
+             :sok/bathymetry-statistics sok-subs/bathymetry-statistics
+             :sok/boundaries            sok-subs/boundaries
+             ...}
+    :events {:sok/open                  sok-events/open
+             :sok/close                 sok-events/close
+             ...}}
+
+   :data-in-region
+   {:subs   {:data-in-region/data       dir-subs/data-in-region}
+    :events {:data-in-region/open       dir-events/open
+             :data-in-region/get        dir-events/get-data
+             ...}}
+
+   :featured-maps
+   {:subs   {:featured-maps/all         fm-subs/all-maps}
+    :events {:featured-maps/load        fm-events/load
+             ...}}})
+
+(defn register-for-features! [features]
+  (register-handlers! base-handlers)
+  (doseq [feature features]
+    (when-let [handlers (get feature-handlers feature)]
+      (register-handlers! handlers))))
+```
+
+### 6. Unified Entry Point
+
+Single `core.cljs` that reads deployment from build configuration:
+
+```clojure
+;; src/cljs/imas_seamap/core.cljs
+
+(ns imas-seamap.core
+  (:require [imas-seamap.config.deployments :as deployments]
+            [imas-seamap.handlers.registry :as registry]
+            [imas-seamap.views.layout :as layout]))
+
+(defn ^:export init
+  [deployment-id api-url-base media-url-base wordpress-url-base img-url-base]
+  (let [deployment-key (keyword deployment-id)
+        config         (get deployments/deployments deployment-key)]
+
+    (when-not config
+      (throw (ex-info "Unknown deployment" {:id deployment-id})))
+
+    ;; Register handlers based on features
+    (registry/register-for-features! (:features config))
+
+    ;; Boot with configuration
+    (re-frame/dispatch-sync
+     [:boot {:config           config
+             :api-url-base     api-url-base
+             :media-url-base   media-url-base
+             :wordpress-url-base wordpress-url-base
+             :img-url-base     img-url-base}])
+
+    (dev-setup)
+    (mount-root)))
+
+(defn mount-root []
+  (re-frame/clear-subscription-cache!)
+  (rdom/render [layout/layout-app]
+               (.getElementById js/document "app")))
+```
+
+---
+
+## Migration Path
+
+### Phase 1: Extract Configuration (Low Risk)
+
+1. Create `config/deployments.cljs` with configuration maps
+2. Document current feature sets for each deployment
+3. No changes to existing code - configuration is additive
+
+### Phase 2: Add Feature Subscriptions (Low Risk)
+
+1. Implement `:feature/enabled?` subscription
+2. Add `(feature? ...)` helper function
+3. Store config in app-db during boot
+4. Existing code continues to work
+
+### Phase 3: Migrate Leaf Components (Medium Risk)
+
+1. Start with leaf components that use `tma?`
+2. Replace `tma?` checks with `(feature? :feature-key)` calls
+3. Remove `tma?` parameter from component signatures
+4. Work upward through component tree
+
+Key files to migrate:
+- `map/layer_views.cljs` - `layer-card`, `layer-catalogue-controls`
+- `views.cljs` - `left-drawer-catalogue`, `left-drawer-active-layers`
+
+### Phase 4: Unify Layouts (Medium Risk)
+
+1. Create slot-based `layout-app` in new namespace
+2. Implement component/tab/control registries
+3. Migrate one deployment at a time:
+   - Start with simplest (Futures of Seafood)
+   - Then TMA
+   - Then Antarctica
+   - Finally Seamap Australia
+
+### Phase 5: Consolidate Entry Points (Higher Risk)
+
+1. Unify all `core.cljs` files into single entry point
+2. Update build configuration to pass deployment ID
+3. Remove deployment-specific `core.cljs` files
+4. Remove deployment-specific `views.cljs` files
+
+---
+
+## Benefits
+
+1. **No more variant parents** - Components check features directly via subscriptions
+2. **Declarative** - Adding a feature to a deployment = adding a keyword to a set
+3. **Single source of truth** - All deployment differences visible in one file
+4. **Testable** - Can test any component with any feature combination
+5. **Extensible** - New deployments = new config map, minimal code changes
+6. **Reduced duplication** - One `layout-app`, not four
+
+## Trade-offs
+
+1. **Runtime overhead** - Feature checks on every render (mitigated by re-frame's subscription caching)
+2. **Migration effort** - Gradual refactor required across many files
+3. **Indirection** - Component resolution via registry is less explicit than direct requires
+4. **Learning curve** - Team needs to understand new patterns
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Breaking existing deployments | Migrate one deployment at a time, keep old code working |
+| Performance regression | Profile before/after, re-frame subscriptions are cached |
+| Lost type safety | Use spec to validate configuration maps |
+| Merge conflicts during migration | Coordinate with team, avoid parallel work on same files |
+
+---
+
+## Files to Create
+
+```
+src/cljs/imas_seamap/
+├── config/
+│   └── deployments.cljs      # All deployment configurations
+├── registry/
+│   └── components.cljs       # Component/tab/control registries
+├── subs/
+│   └── features.cljs         # Feature flag subscriptions
+├── handlers/
+│   └── registry.cljs         # Feature-based handler registration
+└── views/
+    └── layout.cljs           # Unified slot-based layout
+```
+
+## Files to Eventually Remove
+
+After full migration:
+- `tas_marine_atlas/core.cljs`
+- `tas_marine_atlas/views.cljs`
+- `seamap_antarctica/core.cljs`
+- `seamap_antarctica/views.cljs` (partial - keep map CRS config)
+- `futuresofseafood/core.cljs`
+- `futuresofseafood/views.cljs`
+
+---
+
+---
+
+## Branding Configuration
+
+### Current Branding Implementation
+
+Branding is currently spread across multiple locations:
+
+| Element | Location | How It Varies |
+|---------|----------|---------------|
+| Color palette | `src/index.scss` (lines 79-153) | SCSS variables per deployment |
+| CSS class | Each `views.cljs` layout-app | `.seamap`, `.tas-marine-atlas`, `.futures-of-seafood` |
+| Drawer class | Each `views.cljs` left-drawer | `.seamap-drawer`, `.tas-marine-atlas-drawer`, `.fos-drawer` |
+| Logo image | Each `views.cljs` left-drawer | Different image paths |
+| Logo link | Each `views.cljs` left-drawer | Different URLs |
+| Welcome text | Each `views.cljs` welcome-dialogue | Completely different content |
+| Control labels | Scattered in components | e.g., "Find Data in Region" vs "Select region" |
+
+### Proposed Branding Configuration Schema
+
+Extend the deployment config to include comprehensive branding:
+
+```clojure
+(def seamap-australia
+  {:id          :seamap-australia
+   :css-class   "seamap"
+   :drawer-class "seamap-drawer"
+
+   :branding
+   {:logo        {:src    "img/Seamap2_V2_RGB.png"
+                  :alt    "Seamap Australia"
+                  :height 96}
+    :url         "https://seamapaustralia.org"
+    :title       "Seamap Australia"
+
+    ;; Welcome dialogue content (hiccup or content key)
+    :welcome     {:title   "Welcome to Seamap Australia."
+                  :content :welcome/seamap-australia}
+
+    ;; Configurable labels for controls/UI elements
+    :labels      {:region-control    "Select region"
+                  :transect-control  "Draw transect"
+                  :layer-info        "Layer info / Download data"}
+
+    ;; External links
+    :links       {:main-site   "https://seamapaustralia.org"
+                  :help        "https://seamapaustralia.org/help"
+                  :contact     "https://seamapaustralia.org/contact"}}
+
+   ;; Color overrides (applied as CSS custom properties)
+   ;; Only specify overrides - base theme provides defaults
+   :colors      {}  ;; Uses default seamap colors
+
+   ;; ... rest of config
+   })
+
+(def tas-marine-atlas
+  {:id          :tas-marine-atlas
+   :css-class   "tas-marine-atlas"
+   :drawer-class "tas-marine-atlas-drawer"
+
+   :branding
+   {:logo        {:src    "img/TMA_Banner_size_website.png"
+                  :alt    "Tasmania Marine Atlas"
+                  :height 86}
+    :url         "https://tasmarineatlas.org"
+    :title       "Tasmania's Marine Atlas"
+
+    :welcome     {:title   "Welcome to Tasmania's Marine Atlas."
+                  :content :welcome/tas-marine-atlas}  ;; References content registry
+
+    :labels      {:region-control   "Find Data in Region"
+                  :transect-control "Measure"
+                  :layer-info       "Layer info"}
+
+    :links       {:main-site    "https://tasmarineatlas.org"
+                  :sea-country  "https://storymaps.arcgis.com/stories/22672ae2d60f424f8d1e024232cfa885"}}
+
+   :colors      {:color-1 "rgb(18, 37, 55)"
+                 :color-2 "rgb(11, 80, 113)"
+                 :color-8 "rgb(98, 191, 236)"}
+
+   ;; ...
+   })
+
+(def futures-of-seafood
+  {:id          :futures-of-seafood
+   :css-class   "futures-of-seafood"
+   :drawer-class "fos-drawer"
+
+   :branding
+   {:logo        {:src    "img/Futures-of-Seafood-Logo-Reverse-400x218.png"
+                  :alt    "Futures of Seafood"
+                  :height 86}
+    :url         "https://futuresofseafood.com.au"
+    :title       "Futures of Seafood"
+
+    :welcome     {:title   "Welcome to Futures of Seafood."
+                  :content :welcome/default}
+
+    :labels      {:region-control   "Select region"
+                  :transect-control "Draw transect"
+                  :layer-info       "Layer info"}}
+
+   :colors      {:color-2          "#062440"
+                 :color-highlight-1 "#00b0a5"
+                 :color-7          "white"}
+
+   ;; ...
+   })
+```
+
+### Content Registry for Welcome Dialogues
+
+Store rich content separately and reference by key:
+
+```clojure
+;; src/cljs/imas_seamap/config/content.cljs
+
+(def welcome-content
+  {:welcome/seamap-australia
+   [:div.overview
+    [:p "Seamap Australia is a nationally synthesised product of
+         seafloor habitat data collected from various stakeholders
+         around Australia..."]
+    [:p.citation
+     "Lucieer V, Walsh P, Flukes E, Butler C, Proctor R, Johnson C (2017). "
+     [:em "Seamap Australia - a national seafloor habitat classification scheme"]
+     ". Institute for Marine and Antarctic Studies (IMAS)..."]]
+
+   :welcome/tas-marine-atlas
+   [:div.overview
+    [:p "The waters and coastlines represented in the Tasmania's Marine
+         Atlas are of significance to Tasmanian Aboriginal people..."]
+    [:p "Any absence of information about Tasmanian Aboriginal people's
+         connection to Sea Country..."]
+    [:p "Learn more about Sea Country and Tasmanian Aboriginal People "
+     [:a {:href "https://storymaps.arcgis.com/stories/22672ae2d60f424f8d1e024232cfa885"
+          :target "_blank"} "here"] "."]]
+
+   :welcome/default
+   [:div.overview
+    [:p "Welcome to this marine data portal."]]})
+
+(defn get-content [content-key]
+  (get welcome-content content-key))
+```
+
+### Applying Colors via CSS Custom Properties
+
+Instead of hardcoding colors in SCSS, apply them dynamically:
+
+```clojure
+;; src/cljs/imas_seamap/views/branding.cljs
+
+(defn color-style-element
+  "Generates a <style> element with CSS custom properties for the deployment"
+  []
+  (let [colors @(re-frame/subscribe [:branding/colors])]
+    (when (seq colors)
+      [:style
+       (str ":root {\n"
+            (str/join "\n"
+              (for [[k v] colors]
+                (str "  --" (name k) ": " v ";")))
+            "\n}")])))
+
+;; In layout-app:
+(defn layout-app []
+  (let [config @(re-frame/subscribe [:deployment/config])]
+    [:div {:class (:css-class config)}
+     [color-style-element]  ;; Injects color overrides
+     ;; ... rest of layout
+     ]))
+```
+
+Alternatively, keep the SCSS variables but generate deployment-specific CSS at build time.
+
+### Branding Subscriptions
+
+```clojure
+;; src/cljs/imas_seamap/subs/branding.cljs
+
+(re-frame/reg-sub
+ :branding/config
+ :<- [:deployment/config]
+ (fn [config _]
+   (:branding config)))
+
+(re-frame/reg-sub
+ :branding/logo
+ :<- [:branding/config]
+ (fn [branding _]
+   (:logo branding)))
+
+(re-frame/reg-sub
+ :branding/label
+ :<- [:branding/config]
+ (fn [branding [_ label-key]]
+   (get-in branding [:labels label-key])))
+
+(re-frame/reg-sub
+ :branding/colors
+ :<- [:deployment/config]
+ (fn [config _]
+   (:colors config)))
+
+(re-frame/reg-sub
+ :branding/welcome
+ :<- [:branding/config]
+ (fn [branding _]
+   (:welcome branding)))
+```
+
+### Using Branding in Components
+
+```clojure
+;; Left drawer header with configurable logo
+(defn branding-header []
+  (let [{:keys [src alt height]} @(re-frame/subscribe [:branding/logo])
+        url @(re-frame/subscribe [:branding/url])]
+    [:div.branding-header
+     [:a {:href url :target "_blank"}
+      [:img {:src src :alt alt :style {:height height}}]]]))
+
+;; Control with configurable label
+(defn region-control []
+  (let [label @(re-frame/subscribe [:branding/label :region-control])]
+    [control-button
+     {:icon     :select-region
+      :tooltip  label
+      :on-click #(dispatch [:region/start-selection])}]))
+
+;; Welcome dialogue with configurable content
+(defn welcome-dialogue []
+  (let [open?   @(re-frame/subscribe [:welcome-layer/open?])
+        {:keys [title content]} @(re-frame/subscribe [:branding/welcome])
+        body    (if (keyword? content)
+                  (content/get-content content)
+                  content)]
+    [b/dialogue
+     {:title    title
+      :is-open  open?
+      :on-close #(dispatch [:welcome-layer/close])}
+     [:div.bp3-dialog-body body]]))
+```
+
+### Summary: Branding Handled by Configuration
+
+| Branding Element | Configuration Location | How It's Applied |
+|------------------|----------------------|------------------|
+| Logo image | `:branding :logo :src` | Subscription → `<img>` component |
+| Logo link | `:branding :url` | Subscription → `<a href>` |
+| Logo height | `:branding :logo :height` | Subscription → inline style |
+| Welcome title | `:branding :welcome :title` | Subscription → dialogue title |
+| Welcome content | `:branding :welcome :content` | Content registry lookup |
+| Control labels | `:branding :labels :*` | Subscription per control |
+| External links | `:branding :links :*` | Subscription per link |
+| Color overrides | `:colors` | CSS custom properties (dynamic or build-time) |
+| CSS class | `:css-class` | Applied to root element |
+| Drawer class | `:drawer-class` | Applied to left-drawer |
+
+This approach means:
+- **No hardcoded strings** in component code
+- **All branding visible** in deployment config
+- **New deployment** = new config map with branding section
+- **Content changes** don't require code changes (just config/content updates)
+
+---
+
+## Next Steps
+
+1. Review this proposal with the team
+2. Decide on migration timeline and phases
+3. Start with Phase 1 (configuration extraction) as it's additive and low-risk
+4. Set up feature flags in CI to test all deployments

--- a/frontend/docs/configuration-driven-refactor-proposal.md
+++ b/frontend/docs/configuration-driven-refactor-proposal.md
@@ -787,3 +787,859 @@ This approach means:
 2. Decide on migration timeline and phases
 3. Start with Phase 1 (configuration extraction) as it's additive and low-risk
 4. Set up feature flags in CI to test all deployments
+
+---
+
+## Database Schema Initialization
+
+### Current State
+
+Each deployment has its own `db.cljs` file with subtle but important differences:
+
+| Schema Difference | Australia | TMA | Antarctica | FoS |
+|-------------------|-----------|-----|------------|-----|
+| Map center | `[-27.82, 132.13]` | `[-42.20, 146.74]` | `[-80, -90]` | (uses main) |
+| Map zoom | `4` | `7` | `2` | (uses main) |
+| `:state-of-knowledge` | ✓ | ✗ | ✓ | ✗ |
+| `:data-in-region` | ✗ | ✓ | ✗ | ✗ |
+| `:display :welcome-overlay` | `false` | `true` | `false` | (uses main) |
+| `:display :catalogue :region` | ✗ | ✓ | ✗ | ✗ |
+| URL paths for SOK | ✓ | ✗ | ✓ | ✗ |
+| URL path for `:data-in-region` | ✗ | ✓ | ✗ | ✗ |
+
+### Proposed Solution
+
+#### Add `:initial-state` to Deployment Config
+
+Extend the deployment configuration to include state initialization overrides:
+
+```clojure
+;; src/cljs/imas_seamap/config/deployments.cljs
+
+(def seamap-australia
+  {:id          :seamap-australia
+   :css-class   "seamap"
+
+   ;; ... (branding, features, etc. as before)
+
+   ;; Map initialization
+   :map         {:crs    :epsg-3857
+                 :center [-27.819644755 132.133333]
+                 :zoom   4}
+
+   ;; Feature-specific state initialization
+   :initial-state
+   {:display {:welcome-overlay false}  ;; Override default
+    :state-of-knowledge
+    {:boundaries {:active-boundary nil
+                  :active-boundary-layer nil
+                  :amp   {:active-network nil
+                          :active-park    nil
+                          :active-zone    nil
+                          :active-zone-iucn nil
+                          :active-zone-id nil}
+                  :imcra {:active-provincial-bioregion nil
+                          :active-mesoscale-bioregion  nil}
+                  :meow  {:active-realm     nil
+                          :active-province  nil
+                          :active-ecoregion nil}}
+     :statistics {:habitat {:results [] :loading? false :show-layers? false}
+                  :bathymetry {:results [] :loading? false :show-layers? false}
+                  :habitat-observations {:global-archive nil
+                                        :sediment       nil
+                                        :squidle        nil
+                                        :loading?       false
+                                        :show-layers?   false}}}}
+
+   ;; Feature-specific URL paths
+   :url-paths {:amp-boundaries        "habitat/ampboundaries"
+               :imcra-boundaries      "habitat/imcraboundaries"
+               :meow-boundaries       "habitat/meowboundaries"
+               :habitat-statistics    "habitat/habitatstatistics"
+               :bathymetry-statistics "habitat/bathymetrystatistics"
+               :habitat-observations  "habitat/habitatobservations"
+               :region-reports        "regionreports/"
+               :region-report-pages   "region-reports/"}})
+
+(def tas-marine-atlas
+  {:id          :tas-marine-atlas
+   :css-class   "tas-marine-atlas"
+
+   ;; ... (branding, features, etc.)
+
+   :map         {:crs    :epsg-3857
+                 :center [-42.20157676555315 146.74253188097842]
+                 :zoom   7}
+
+   :initial-state
+   {:display {:welcome-overlay true   ;; TMA shows welcome by default
+              :catalogue {:main   {:tab "cat" :expanded #{}}
+                          :region {:tab "cat" :expanded #{}}}}  ;; TMA has region catalogue
+    :data-in-region {:data     nil
+                     :query-id nil}}
+
+   :url-paths {:data-in-region "habitat/datainregion"}})
+
+(def seamap-antarctica
+  {:id          :seamap-antarctica
+   :css-class   "seamap"
+
+   ;; ... (branding, features, etc.)
+
+   :map         {:crs    :epsg-3031  ;; Antarctic polar projection
+                 :center [-80 -90]
+                 :zoom   2}
+
+   :initial-state
+   {:display {:welcome-overlay false}
+    :state-of-knowledge  ;; Same as Australia
+    {:boundaries {:active-boundary nil
+                  ;; ... (same structure)
+                  }
+     :statistics {;; ... (same structure)
+                  }}}
+
+   :url-paths  ;; Same SOK paths as Australia
+   {:amp-boundaries        "habitat/ampboundaries"
+    ;; ... (same as Australia)
+    }})
+```
+
+#### Unified `db.cljs` with Base Schema
+
+Create a single `db.cljs` that provides the base schema, which gets merged with deployment-specific state:
+
+```clojure
+;; src/cljs/imas_seamap/db.cljs
+
+(defn base-db
+  "Returns the base database schema with common defaults.
+   Deployment-specific overrides are merged in during boot."
+  []
+  {:initialised     false
+   :map             {:center          [0 0]     ;; Will be overridden by deployment config
+                     :initial-bounds? true
+                     :size            {}
+                     :zoom            1          ;; Will be overridden by deployment config
+                     :zoom-cutover    10
+                     :bounds          {}
+                     :categories      []
+                     :layers          []
+                     :base-layers     []
+                     :base-layer-groups []
+                     :grouped-base-layers []
+                     :active-base-layer nil
+                     :organisations   []
+                     :active-layers   []
+                     :hidden-layers   #{}
+                     :preview-layer   nil
+                     :viewport-only?  false
+                     :keyed-layers    {}
+                     :rich-layers     {:rich-layers  []
+                                       :states       {}
+                                       :async-datas  {}
+                                       :layer-lookup {}}
+                     :legends         {}
+                     :controls        {:transect false
+                                       :download nil}}
+   :site-configuration nil
+   :story-maps      {:featured-maps []
+                     :featured-map  nil}
+   :layer-state     {:loading-state {}
+                     :tile-count    {}
+                     :error-count   {}
+                     :legend-shown  #{}
+                     :opacity       {}}
+   :filters         {:layers       ""
+                     :other-layers ""}
+   :transect        {:query      nil
+                     :show?      false
+                     :habitat    nil
+                     :bathymetry nil}
+   :region-stats    {:habitat-layer nil}
+   :habitat-colours {}
+   :habitat-titles  {}
+   :display         {:mouse-pos             {}
+                     :help-overlay          false
+                     :welcome-overlay       false  ;; Default: closed
+                     :settings-overlay      false
+                     :left-drawer           true
+                     :left-drawer-tab       "catalogue"
+                     :layers-search-omnibar false
+                     :catalogue             {:main {:tab      "cat"
+                                                    :expanded #{}}}
+                     :sidebar               {:collapsed false
+                                             :selected  "tab-activelayers"}
+                     :right-sidebars        []
+                     :open-pill             nil
+                     :outage-message-open?  false}
+   :dynamic-pills   {:dynamic-pills []
+                     :states        {}
+                     :async-datas   {}}
+   :autosave?       false
+   :config          {:url-paths  ;; Base URL paths - deployment-specific paths are merged
+                     {:site-configuration "siteconfiguration/"
+                      :layer              "layers/"
+                      :base-layer         "baselayers/"
+                      :base-layer-group   "baselayergroups/"
+                      :organisation       "organisations/"
+                      :classification     "classifications/"
+                      :region-stats       "habitat/regions/"
+                      :descriptor         "descriptors/"
+                      :save-state         "savestates"
+                      :category           "categories/"
+                      :keyed-layers       "keyedlayers/"
+                      :rich-layers        "richlayers/"
+                      :dynamic-pills      "dynamicpills/"
+                      :layer-legend       "layerlegend/"
+                      :cql-filter-values  "habitat/cqlfiltervalues"
+                      :dynamic-pill-region-control-values "habitat/dynamicpillregioncontrolvalues"
+                      :layer-previews     "layer_previews/"
+                      :story-maps         "wp-json/wp/v2/story_map?acf_format=standard"}
+                     :urls      nil
+                     :url-base  {:api-url-base       "http://localhost:8000/api/"
+                                 :media-url-base     "http://localhost:8000/media/"
+                                 :wordpress-url-base "http://localhost:8888/"
+                                 :img-url-base       "/img/"}}})
+
+(defn merge-deployment-state
+  "Deep merges deployment-specific state overrides into base schema"
+  [base-db deployment-config]
+  (let [{:keys [initial-state url-paths map]} deployment-config]
+    (-> base-db
+        ;; Merge map config
+        (assoc-in [:map :center] (:center map))
+        (assoc-in [:map :zoom] (:zoom map))
+        ;; Merge deployment-specific state
+        (merge-with (fn [base override]
+                      (if (map? base)
+                        (merge base override)
+                        override))
+                    initial-state)
+        ;; Merge deployment-specific URL paths
+        (update-in [:config :url-paths]
+                   merge url-paths))))
+
+(defn default-db
+  "Returns the complete database schema for a deployment.
+   Must be called with deployment config after handlers are registered."
+  [deployment-config]
+  (merge-deployment-state (base-db) deployment-config))
+```
+
+#### Update `:boot` Event Handler
+
+Modify the boot event to use the deployment config for initialization:
+
+```clojure
+;; src/cljs/imas_seamap/events.cljs
+
+(re-frame/reg-event-fx
+ :boot
+ [(re-frame/inject-cofx :save-code)
+  (re-frame/inject-cofx :hash-code)
+  (re-frame/inject-cofx :local-storage/get [:seamap-app-state])]
+ (fn [{:keys [db]} [_ {:keys [config api-url-base media-url-base
+                               wordpress-url-base img-url-base]}]]
+   (let [initial-db (db/default-db config)]  ;; Use config to generate initial state
+     {:db (-> initial-db
+              (assoc :config config)  ;; Store deployment config
+              (assoc-in [:config :url-base :api-url-base] api-url-base)
+              (assoc-in [:config :url-base :media-url-base] media-url-base)
+              (assoc-in [:config :url-base :wordpress-url-base] wordpress-url-base)
+              (assoc-in [:config :url-base :img-url-base] img-url-base))
+      :dispatch-n [[:construct-urls]
+                   [:ui/show-loading]
+                   ;; ... rest of boot sequence
+                   ]})))
+```
+
+### Benefits
+
+1. **Single source of truth** - Base schema in one place, overrides declarative
+2. **Eliminates duplicate db.cljs files** - All deployments share base schema
+3. **Feature-driven state** - Only features that are enabled get state sections
+4. **Testable** - Can test state initialization for any deployment config
+
+### Migration Notes
+
+- Keep existing deployment `db.cljs` files initially for reference
+- Validate merged state matches original state for each deployment
+- Use clojure.spec to validate state shape after merge
+
+---
+
+## Build Configuration Changes
+
+### Current State
+
+The `shadow-cljs.edn` currently compiles all 4 entry points into a single bundle:
+
+```clojure
+:modules {:app {:entries [imas-seamap.core
+                          imas-seamap.futuresofseafood.core
+                          imas-seamap.seamap-antarctica.core
+                          imas-seamap.tas-marine-atlas.core]}}
+```
+
+Each deployment's `index.html` selects which init function to call via Ansible templating.
+
+### Proposed Changes
+
+#### Option A: Keep Single Bundle (Recommended for Phase 1-4)
+
+During migration phases 1-4, keep the existing build configuration to minimize risk:
+
+```clojure
+;; shadow-cljs.edn - NO CHANGES during migration
+
+:modules {:app {:entries [imas-seamap.core
+                          imas-seamap.futuresofseafood.core
+                          imas-seamap.seamap-antarctica.core
+                          imas-seamap.tas-marine-atlas.core]}}
+```
+
+**Rationale**: All code is already being shipped to all deployments anyway. Keeping the multi-entry setup allows gradual migration without affecting deployments that haven't migrated yet.
+
+#### Option B: Unified Entry Point (Phase 5 - After Full Migration)
+
+Once all deployments use the unified `core.cljs`, simplify to a single entry point:
+
+```clojure
+;; shadow-cljs.edn - AFTER Phase 5 migration complete
+
+:builds {:dev {:target           :browser
+               :output-dir       "resources/public/js/"
+               :asset-path       "js"
+               :closure-defines  {goog.DEBUG true
+                                  "re_frame.trace.trace_enabled_QMARK_" true}
+               :modules          {:app {:entries [imas-seamap.core]}}  ;; Single entry
+               :compiler-options {:pretty-print true}
+               :devtools
+               {:preloads         [devtools.preload
+                                   imas-seamap.specs.preload]}}
+
+         :min {:target            :browser
+               :closure-defines   {goog.DEBUG false}
+               :output-dir        "resources/public/js/"
+               :asset-path        "js"
+               :module-hash-names true
+               :build-options     {:manifest-name "manifest.json"}
+               :modules           {:app {:entries [imas-seamap.core]}}}  ;; Single entry
+
+         :mindev {:target            :browser
+                  :output-dir        "resources/public/js/"
+                  :asset-path        "js"
+                  :closure-defines   {goog.DEBUG false}
+                  :module-hash-names true
+                  :build-options     {:manifest-name "manifest.json"}
+                  :modules           {:app {:entries [imas-seamap.core]}}  ;; Single entry
+                  :compiler-options  {:pseudo-names true
+                                      :source-map   true}}}}
+```
+
+#### Option C: Per-Deployment Bundles (Advanced - Optional)
+
+If you want deployment-specific bundles (smaller payload, deployment isolation), create separate builds:
+
+```clojure
+;; shadow-cljs.edn - Advanced configuration (optional)
+
+:builds {:seamap-australia
+         {:target            :browser
+          :output-dir        "resources/public/js/seamap-australia"
+          :asset-path        "js/seamap-australia"
+          :closure-defines   {goog.DEBUG false
+                              imas-seamap.config/DEPLOYMENT :seamap-australia}
+          :module-hash-names true
+          :modules           {:app {:entries [imas-seamap.core]}}}
+
+         :tas-marine-atlas
+         {:target            :browser
+          :output-dir        "resources/public/js/tas-marine-atlas"
+          :asset-path        "js/tas-marine-atlas"
+          :closure-defines   {goog.DEBUG false
+                              imas-seamap.config/DEPLOYMENT :tas-marine-atlas}
+          :module-hash-names true
+          :modules           {:app {:entries [imas-seamap.core]}}}
+
+         ;; ... repeat for antarctica and fos
+         }
+```
+
+This requires separate `index.html` files per deployment or build-time templating.
+
+### Recommendation
+
+Use **Option A** during migration, then switch to **Option B** after Phase 5 completion. Only consider Option C if bundle size becomes a concern (unlikely since features are already conditionally loaded).
+
+---
+
+## Index.html Updates
+
+### Current State
+
+Single `index.html` with Ansible-managed block that swaps init calls:
+
+```html
+<script>
+// BEGIN ANSIBLE MANAGED BLOCK
+const
+  api_url_base = "http://localhost:8000/api/",
+  media_url_base = "http://localhost:8000/media/",
+  wordpress_url_base = "http://localhost:8888/",
+  img_url_base = "/img/";
+ imas_seamap.futuresofseafood.core.init(api_url_base, media_url_base, wordpress_url_base, img_url_base);
+     /* imas_seamap.core.init(api_url_base, media_url_base, wordpress_url_base, img_url_base); */
+// END ANSIBLE MANAGED BLOCK
+</script>
+```
+
+### Proposed Changes
+
+#### Phase 1-4: Dual Support (Both Old and New)
+
+Keep existing Ansible templating but extend it to support both patterns:
+
+```html
+<script>
+// BEGIN ANSIBLE MANAGED BLOCK: Deployment Configuration
+const
+  deployment_id = "futures-of-seafood",  // <-- Ansible template variable: {{ deployment_id }}
+  api_url_base = "http://localhost:8000/api/",      // <-- {{ api_url_base }}
+  media_url_base = "http://localhost:8000/media/",  // <-- {{ media_url_base }}
+  wordpress_url_base = "http://localhost:8888/",     // <-- {{ wordpress_url_base }}
+  img_url_base = "/img/";                            // <-- {{ img_url_base }}
+
+// Check if unified init is available (migrated deployments)
+if (typeof imas_seamap.core.init_unified === 'function') {
+  imas_seamap.core.init_unified(deployment_id, api_url_base, media_url_base, wordpress_url_base, img_url_base);
+} else {
+  // Fallback to deployment-specific init (old deployments)
+  {% if deployment == "seamap-australia" %}
+  imas_seamap.core.init(api_url_base, media_url_base, wordpress_url_base, img_url_base);
+  {% elif deployment == "tas-marine-atlas" %}
+  imas_seamap.tas_marine_atlas.core.init(api_url_base, media_url_base, wordpress_url_base, img_url_base);
+  {% elif deployment == "seamap-antarctica" %}
+  imas_seamap.seamap_antarctica.core.init(api_url_base, media_url_base, wordpress_url_base, img_url_base);
+  {% elif deployment == "futures-of-seafood" %}
+  imas_seamap.futuresofseafood.core.init(api_url_base, media_url_base, wordpress_url_base, img_url_base);
+  {% endif %}
+}
+// END ANSIBLE MANAGED BLOCK
+</script>
+```
+
+This allows gradual migration - unmigrated deployments continue using their specific init, while migrated ones use the unified init.
+
+#### Phase 5: Fully Unified (After Migration Complete)
+
+Once all deployments are migrated, simplify to single init call:
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>{{ site_title }}</title>  <!-- Ansible template variable -->
+    <meta charset='utf-8'>
+    <link rel="stylesheet" href="css/blueprint.css" />
+    <link rel="stylesheet" href="https://unpkg.com/@blueprintjs/select@3.19.1/lib/css/blueprint-select.css" />
+    <link rel="stylesheet" href="https://unpkg.com/@blueprintjs/icons@3.27.0/lib/css/blueprint-icons.css" />
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css" />
+    <link rel="stylesheet" href="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.css" />
+    <link rel="stylesheet" href="https://unpkg.com/leaflet-sidebar-v2@1.0.0/css/leaflet-sidebar.min.css" />
+    <link rel="stylesheet" href="css/style.npm-packaged.css" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <div id="toaster"></div>
+    <script src="https://use.fontawesome.com/d25c01a5e8.js"></script>
+    <script src="js/app.js"></script>
+    <script>
+// BEGIN ANSIBLE MANAGED BLOCK: Deployment Configuration
+const deploymentConfig = {
+  deployment_id: "{{ deployment }}",           // e.g., "seamap-australia"
+  api_url_base: "{{ api_url_base }}",         // e.g., "https://seamapaustralia.org/api/"
+  media_url_base: "{{ media_url_base }}",     // e.g., "https://seamapaustralia.org/media/"
+  wordpress_url_base: "{{ wordpress_url_base }}", // e.g., "https://seamapaustralia.org/"
+  img_url_base: "{{ img_url_base }}"          // e.g., "/img/"
+};
+
+imas_seamap.core.init(
+  deploymentConfig.deployment_id,
+  deploymentConfig.api_url_base,
+  deploymentConfig.media_url_base,
+  deploymentConfig.wordpress_url_base,
+  deploymentConfig.img_url_base
+);
+// END ANSIBLE MANAGED BLOCK
+    </script>
+  </body>
+</html>
+```
+
+### Ansible Template Variables
+
+Update your Ansible playbook to define deployment-specific variables:
+
+```yaml
+# ansible/vars/seamap-australia.yml
+deployment: seamap-australia
+site_title: Seamap Australia
+api_url_base: https://seamapaustralia.org/api/
+media_url_base: https://seamapaustralia.org/media/
+wordpress_url_base: https://seamapaustralia.org/
+img_url_base: /img/
+
+# ansible/vars/tas-marine-atlas.yml
+deployment: tas-marine-atlas
+site_title: Tasmania's Marine Atlas
+api_url_base: https://tasmarineatlas.org/api/
+media_url_base: https://tasmarineatlas.org/media/
+wordpress_url_base: https://tasmarineatlas.org/
+img_url_base: /img/
+
+# ... (repeat for other deployments)
+```
+
+### Alternative: Multiple index.html Files (If No Ansible)
+
+If not using Ansible, maintain separate HTML files:
+
+```
+resources/public/
+├── index.html                          # Development/default
+├── index-seamap-australia.html
+├── index-tas-marine-atlas.html
+├── index-seamap-antarctica.html
+└── index-futures-of-seafood.html
+```
+
+Each with hardcoded deployment ID:
+
+```html
+<!-- index-seamap-australia.html -->
+<script>
+imas_seamap.core.init(
+  "seamap-australia",
+  "https://seamapaustralia.org/api/",
+  "https://seamapaustralia.org/media/",
+  "https://seamapaustralia.org/",
+  "/img/"
+);
+</script>
+```
+
+---
+
+## Testing Strategy
+
+### Current State
+
+No formal test infrastructure exists. Testing is likely manual across deployments.
+
+### Proposed Testing Approach
+
+#### 4.1 Unit Tests for Configuration System
+
+Create tests for the core configuration and feature system:
+
+```clojure
+;; test/cljs/imas_seamap/config/deployments_test.cljs
+
+(ns imas-seamap.config.deployments-test
+  (:require [cljs.test :refer-macros [deftest testing is]]
+            [imas-seamap.config.deployments :as deployments]))
+
+(deftest all-deployments-have-required-keys
+  (doseq [[id config] deployments/deployments]
+    (testing (str "Deployment " id " has required config keys")
+      (is (keyword? (:id config)))
+      (is (string? (:css-class config)))
+      (is (map? (:branding config)))
+      (is (map? (:map config)))
+      (is (set? (:features config)))
+      (is (map? (:drawers config)))
+      (is (vector? (:tabs config)))
+      (is (vector? (:controls config))))))
+
+(deftest feature-sets-are-valid
+  (let [valid-features #{:state-of-knowledge :data-in-region :featured-maps
+                         :floating-pills :plot-component :transect-control
+                         :data-providers :data-download :boundaries-pill
+                         :zones-pill}]
+    (doseq [[id config] deployments/deployments]
+      (testing (str "Deployment " id " only uses valid features")
+        (is (every? valid-features (:features config)))))))
+
+(deftest map-config-is-valid
+  (doseq [[id config] deployments/deployments]
+    (testing (str "Deployment " id " has valid map config")
+      (let [{:keys [crs center zoom]} (:map config)]
+        (is (keyword? crs))
+        (is (vector? center))
+        (is (= 2 (count center)))
+        (is (number? (first center)))
+        (is (number? (second center)))
+        (is (number? zoom))
+        (is (>= zoom 1))))))
+```
+
+#### 4.2 Database Initialization Tests
+
+Validate that merged state matches expected structure:
+
+```clojure
+;; test/cljs/imas_seamap/db_test.cljs
+
+(ns imas-seamap.db-test
+  (:require [cljs.test :refer-macros [deftest testing is]]
+            [imas-seamap.db :as db]
+            [imas-seamap.config.deployments :as deployments]))
+
+(deftest base-db-has-required-structure
+  (let [base (db/base-db)]
+    (is (false? (:initialised base)))
+    (is (map? (:map base)))
+    (is (map? (:display base)))
+    (is (map? (:config base)))))
+
+(deftest deployment-merge-preserves-base-structure
+  (doseq [[id config] deployments/deployments]
+    (testing (str "Deployment " id " merge preserves base structure")
+      (let [merged (db/default-db config)]
+        (is (map? (:map merged)))
+        (is (map? (:display merged)))
+        (is (= (:center (:map config))
+               (get-in merged [:map :center])))
+        (is (= (:zoom (:map config))
+               (get-in merged [:map :zoom])))))))
+
+(deftest feature-specific-state-only-for-enabled-features
+  (let [sok-config (get deployments/deployments :seamap-australia)
+        dir-config (get deployments/deployments :tas-marine-atlas)
+        sok-db (db/default-db sok-config)
+        dir-db (db/default-db dir-config)]
+
+    (testing "SOK deployment has SOK state"
+      (is (contains? sok-db :state-of-knowledge))
+      (is (map? (:state-of-knowledge sok-db))))
+
+    (testing "TMA deployment has data-in-region state"
+      (is (contains? dir-db :data-in-region))
+      (is (map? (:data-in-region dir-db))))))
+```
+
+#### 4.3 Visual Regression Testing
+
+Use a tool like Percy.io or BackstopJS for visual regression testing:
+
+```json
+// backstop.json
+{
+  "id": "seamap_visual_regression",
+  "viewports": [
+    {"label": "desktop", "width": 1920, "height": 1080}
+  ],
+  "scenarios": [
+    {
+      "label": "Seamap Australia - Homepage",
+      "url": "http://localhost:3451?deployment=seamap-australia",
+      "selectors": ["#app"],
+      "delay": 2000
+    },
+    {
+      "label": "TAS Marine Atlas - Homepage",
+      "url": "http://localhost:3451?deployment=tas-marine-atlas",
+      "selectors": ["#app"],
+      "delay": 2000
+    },
+    {
+      "label": "Seamap Antarctica - Homepage",
+      "url": "http://localhost:3451?deployment=seamap-antarctica",
+      "selectors": ["#app"],
+      "delay": 2000
+    },
+    {
+      "label": "Futures of Seafood - Homepage",
+      "url": "http://localhost:3451?deployment=futures-of-seafood",
+      "selectors": ["#app"],
+      "delay": 2000
+    }
+  ],
+  "paths": {
+    "bitmaps_reference": "test/visual/reference",
+    "bitmaps_test": "test/visual/test",
+    "html_report": "test/visual/report",
+    "ci_report": "test/visual/ci_report"
+  }
+}
+```
+
+#### 4.4 Feature Flag Tests
+
+Test that components correctly respond to feature flags:
+
+```clojure
+;; test/cljs/imas_seamap/subs/features_test.cljs
+
+(ns imas-seamap.subs.features-test
+  (:require [cljs.test :refer-macros [deftest testing is]]
+            [re-frame.core :as re-frame]
+            [imas-seamap.subs.features]))
+
+(deftest feature-enabled-subscription
+  (testing "Returns true when feature is enabled"
+    (re-frame/reg-cofx
+     :test-db
+     (fn [cofx _]
+       (assoc cofx :db {:config {:features #{:state-of-knowledge :featured-maps}}})))
+
+    (let [result (re-frame/subscribe [:feature/enabled? :state-of-knowledge])]
+      (is (true? @result)))
+
+    (let [result (re-frame/subscribe [:feature/enabled? :data-in-region])]
+      (is (false? @result)))))
+```
+
+#### 4.5 Migration Testing Checklist
+
+Create a checklist for testing each deployment during migration:
+
+```markdown
+## Deployment Migration Testing Checklist
+
+Test on: [ ] Local  [ ] Staging  [ ] Production
+
+### Visual Tests
+- [ ] Logo displays correctly
+- [ ] Color scheme matches original
+- [ ] Welcome dialogue shows correct content
+- [ ] Left drawer tabs are correct
+- [ ] Map controls appear in correct positions
+
+### Functional Tests
+- [ ] Map loads at correct center/zoom
+- [ ] Can add/remove layers
+- [ ] Can toggle layer visibility
+- [ ] Feature-specific panels work (SOK/Data-in-Region/etc)
+- [ ] Omnisearch functions correctly
+- [ ] Transect tool works (if enabled)
+- [ ] Region selection works
+- [ ] Featured maps load (if enabled)
+- [ ] Print function works
+- [ ] Share function works
+- [ ] Settings overlay opens
+- [ ] Help overlay opens
+
+### Data Tests
+- [ ] Layers load from correct API endpoints
+- [ ] Feature data loads correctly
+- [ ] State persistence works (autosave/load)
+- [ ] URL parameters work correctly
+
+### Browser Tests
+Test on:
+- [ ] Chrome
+- [ ] Firefox
+- [ ] Safari
+- [ ] Edge
+
+### Performance Tests
+- [ ] Initial load time < 3s
+- [ ] Layer toggle responsive
+- [ ] No console errors
+- [ ] No memory leaks over 5min session
+```
+
+#### 4.6 Continuous Integration Setup
+
+Add to CI pipeline (GitHub Actions example):
+
+```yaml
+# .github/workflows/test.yml
+name: Test All Deployments
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup Node
+      uses: actions/setup-node@v2
+      with:
+        node-version: '16'
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Run ClojureScript unit tests
+      run: npx shadow-cljs compile test && node out/test.js
+
+    - name: Build all deployments
+      run: npx shadow-cljs release min
+
+    - name: Start dev server
+      run: npx shadow-cljs start dev-http &
+
+    - name: Wait for server
+      run: npx wait-on http://localhost:3451
+
+    - name: Run visual regression tests
+      run: npm run test:visual
+
+    - name: Upload visual diffs
+      if: failure()
+      uses: actions/upload-artifact@v2
+      with:
+        name: visual-diffs
+        path: test/visual/
+```
+
+#### 4.7 Manual Testing Protocol
+
+For each migration phase, follow this protocol:
+
+1. **Pre-Migration Baseline**
+   - Capture screenshots of all deployments
+   - Document current behavior
+   - Note any existing bugs
+
+2. **During Migration**
+   - Test migrated deployment in isolation
+   - Compare with baseline screenshots
+   - Verify feature flags work as expected
+
+3. **Post-Migration Verification**
+   - Full smoke test of all deployments
+   - Cross-browser testing
+   - Performance profiling
+
+4. **Rollback Plan**
+   - Keep old code branches
+   - Document rollback procedure
+   - Test rollback process before deployment
+
+### Testing Timeline
+
+| Phase | Testing Focus | Risk Level |
+|-------|---------------|------------|
+| Phase 1: Extract Config | Config structure validation | Low |
+| Phase 2: Add Subscriptions | Subscription tests, no visual changes | Low |
+| Phase 3: Migrate Components | Component tests, visual regression | Medium |
+| Phase 4: Unify Layouts | Full integration tests, all deployments | Medium |
+| Phase 5: Single Entry Point | Build validation, deployment tests | Higher |
+
+### Test Automation Tools
+
+Recommended tools:
+
+- **Unit Tests**: shadow-cljs built-in test runner
+- **Visual Regression**: BackstopJS or Percy.io
+- **E2E Tests**: Playwright or Cypress
+- **Performance**: Lighthouse CI
+- **Accessibility**: axe-core

--- a/frontend/docs/configuration-refactor-remaining-tasks.md
+++ b/frontend/docs/configuration-refactor-remaining-tasks.md
@@ -1,0 +1,443 @@
+# Configuration-Driven Refactor: Remaining Tasks
+
+## Status Summary
+
+### ✅ Completed Phases
+
+- **Phase 1: Extract Configuration** - All deployment configs, content registry created
+- **Phase 2: Feature Subscriptions** - Feature flags and branding subscriptions implemented
+- **Phase 3: Migrate Leaf Components** - Eliminated `tma?` parameter from all leaf components
+- **Test Harness** - Automated tests and deployment switcher UI created
+
+### 🔄 Current Status
+
+Ready for manual testing of the configuration system using the deployment switcher.
+
+### 📋 Remaining Work
+
+1. **Manual Testing** (Next immediate step)
+2. **Phase 4: Unify Layouts**
+3. **Phase 5: Consolidate Entry Points**
+
+---
+
+## Task 1: Manual Testing of Configuration System
+
+**Priority**: HIGH - Must complete before Phase 4
+
+**Objective**: Verify the configuration system works correctly across all 4 deployments.
+
+### Steps
+
+1. **Start the development server:**
+   ```bash
+   cd /home/mark/Condense/Seamap/frontend
+   npx shadow-cljs watch dev
+   ```
+
+2. **Open the application:**
+   - Navigate to `http://localhost:3451`
+   - Look for blue settings icon in top-right corner
+
+3. **Test each deployment:**
+   Use the deployment switcher to test each configuration:
+
+   **For Seamap Australia:**
+   - [ ] Logo displays: "Seamap2_V2_RGB.png"
+   - [ ] Layer info tooltip: "Layer info / Download data"
+   - [ ] Region control label: "Select region"
+   - [ ] Features enabled: state-of-knowledge, featured-maps, floating-pills, plot-component
+   - [ ] Map centers at: [-27.82, 132.13], zoom 4
+   - [ ] CRS: EPSG:3857
+
+   **For TAS Marine Atlas:**
+   - [ ] Logo displays: "TMA-blue.png"
+   - [ ] Layer info tooltip: "Layer info" (no download)
+   - [ ] Region control label: "Find Data in Region"
+   - [ ] Features enabled: data-in-region, featured-maps, floating-pills
+   - [ ] Custom colors applied (dark blue header)
+   - [ ] Map centers at: [-42.5, 146.5], zoom 7
+   - [ ] CRS: EPSG:3857
+
+   **For Seamap Antarctica:**
+   - [ ] Logo displays: "SeaMapAntarctica_Logo_RGB_3000px.png"
+   - [ ] Features enabled: state-of-knowledge, floating-pills
+   - [ ] Features disabled: featured-maps, data-in-region
+   - [ ] Map centers at: [-80, -90], zoom 2
+   - [ ] CRS: EPSG:3031 (Antarctic polar projection)
+
+   **For Futures of Seafood:**
+   - [ ] Logo displays: "Futures-of-Seafood-Logo-Reverse-400x218.png"
+   - [ ] Features enabled: plot-component, transect-control
+   - [ ] Features disabled: floating-pills, featured-maps
+   - [ ] Map centers at: [-42.5, 147], zoom 7
+   - [ ] CRS: EPSG:3857
+
+4. **Test subscription tester:**
+   - [ ] Use the subscription tester in the switcher panel
+   - [ ] Test `:feature/enabled?` with various feature keys
+   - [ ] Test `:branding/label` with various label keys
+   - [ ] Verify results match expected configuration
+
+5. **Check browser console:**
+   - [ ] No errors during deployment switching
+   - [ ] No warnings about missing subscriptions
+
+### Reference Documentation
+
+- Full testing guide: `docs/testing-configuration-system.md`
+- Feature matrix: See table at end of `testing-configuration-system.md`
+
+### Success Criteria
+
+- All 4 deployments load without errors
+- Feature flags work correctly for each deployment
+- Branding (logos, labels) displays correctly
+- Map configuration applies correctly
+- No `tma?` related errors in console
+
+---
+
+## Task 2: Phase 4 - Unify Layouts
+
+**Priority**: MEDIUM - Start after testing complete
+
+**Objective**: Create a single unified layout that works for all deployments instead of 4 separate layout files.
+
+### Current State
+
+Currently have 4 separate layout files:
+- `src/cljs/imas_seamap/views.cljs` (Seamap Australia)
+- `src/cljs/imas_seamap/tas_marine_atlas/views.cljs` (TMA)
+- `src/cljs/imas_seamap/seamap_antarctica/views.cljs` (Antarctica)
+- `src/cljs/imas_seamap/futuresofseafood/views.cljs` (FoS)
+
+### Target State
+
+Single unified `layout-app` in `src/cljs/imas_seamap/views.cljs` that uses:
+- Slot-based component system
+- Configuration-driven component registration
+- Feature flags to determine which components render
+
+### Implementation Steps
+
+#### Step 4.1: Create Component Registry
+
+Create `src/cljs/imas_seamap/config/components.cljs`:
+
+```clojure
+(ns imas-seamap.config.components
+  "Registry of all available layout components")
+
+(def component-registry
+  "Maps component keys to their implementations"
+  {:drawer/catalogue         #'imas-seamap.views/left-drawer-catalogue
+   :drawer/active-layers     #'imas-seamap.views/left-drawer-active-layers
+   :drawer/featured-maps     #'imas-seamap.views/featured-maps-tab
+   :control/transect         #'imas-seamap.views/transect-control
+   :control/region           #'imas-seamap.views/region-control
+   :control/print            #'imas-seamap.views/print-control
+   ;; ... etc
+   })
+
+(defn get-component [component-key]
+  "Get a component implementation by key"
+  (get component-registry component-key))
+```
+
+#### Step 4.2: Add Component Slots to Deployment Config
+
+Update `src/cljs/imas_seamap/config/deployments.cljs`:
+
+```clojure
+(def seamap-australia
+  {;; ... existing config ...
+   :layout {:left-drawer {:tabs [:catalogue :active-layers :featured-maps]}
+            :right-drawer {:components [:state-of-knowledge :featured-map-drawer]}
+            :footer {:components [:plot-component]}
+            :controls [:menu :settings :zoom :print :omnisearch :transect :region]}})
+```
+
+#### Step 4.3: Create Slot-Based Layout
+
+Update `src/cljs/imas_seamap/views.cljs`:
+
+```clojure
+(defn layout-app []
+  (let [layout-config @(re-frame/subscribe [:layout/config])]
+    [:div#main-wrapper
+     [:div#content-wrapper
+      [map-component]
+
+      ;; Render footer components based on config
+      (when-let [footer-components (:footer layout-config)]
+        [:footer
+         (for [component-key footer-components]
+           ^{:key component-key}
+           [(components/get-component component-key)])])]
+
+     ;; Common components (always present)
+     [welcome-dialogue]
+     [settings-overlay]
+     [info-card]
+     [loading-display]
+
+     ;; Drawer components based on config
+     [left-drawer layout-config]
+     [right-drawer]
+     [custom-leaflet-controls]]))
+```
+
+#### Step 4.4: Migrate TMA-Specific Styles
+
+Move TMA-specific CSS classes to use deployment-based CSS class:
+
+```scss
+// Instead of hardcoded .tas-marine-atlas
+[class*="tma-"] .some-component { ... }
+```
+
+#### Step 4.5: Remove Old Layout Files
+
+After verifying unified layout works:
+- Keep `src/cljs/imas_seamap/views.cljs` as the single source
+- Delete deployment-specific layout files (or mark as deprecated)
+
+### Files to Modify
+
+- `src/cljs/imas_seamap/config/deployments.cljs` - Add `:layout` configuration
+- `src/cljs/imas_seamap/config/components.cljs` - NEW: Component registry
+- `src/cljs/imas_seamap/views.cljs` - Update to slot-based layout
+- `src/cljs/imas_seamap/subs/branding.cljs` - Add `:layout/config` subscription
+- Layout files in subdirectories - Remove or deprecate
+
+### Testing Phase 4
+
+After implementation:
+- [ ] All 4 deployments still load correctly
+- [ ] Layout components appear in correct slots
+- [ ] No duplicate code between deployment layouts
+- [ ] Feature-specific components only appear when enabled
+
+---
+
+## Task 3: Phase 5 - Consolidate Entry Points
+
+**Priority**: LOW - Final cleanup phase
+
+**Objective**: Move from 4 separate build targets to a single entry point with runtime deployment selection.
+
+### Current State
+
+Currently have 4 shadow-cljs build targets:
+- `:dev` → Seamap Australia
+- `:tma` → TAS Marine Atlas
+- `:antarctica` → Seamap Antarctica
+- `:futuresofseafood` → Futures of Seafood
+
+### Target State
+
+Single `:app` build target that determines deployment at runtime.
+
+### Implementation Steps
+
+#### Step 5.1: Create Deployment Detection
+
+Create `src/cljs/imas_seamap/deployment.cljs`:
+
+```clojure
+(ns imas-seamap.deployment
+  "Runtime deployment detection"
+  (:require [imas-seamap.config.deployments :as deployments]))
+
+(defn detect-deployment []
+  "Detect which deployment to use based on URL or environment"
+  (let [hostname (.-hostname js/location)]
+    (cond
+      (re-find #"tasmarineatlas" hostname)    :tas-marine-atlas
+      (re-find #"antarctica" hostname)        :seamap-antarctica
+      (re-find #"futuresofseafood" hostname)  :futures-of-seafood
+      :else                                   :seamap-australia)))
+
+(defn get-deployment-config []
+  "Get the deployment config for the current environment"
+  (deployments/get-deployment (detect-deployment)))
+```
+
+#### Step 5.2: Update shadow-cljs.edn
+
+```clojure
+{:builds
+ {:app {:target :browser
+        :output-dir "resources/public/js"
+        :asset-path "/js"
+        :modules {:main {:init-fn imas-seamap.core/init}}
+        :dev {:compiler-options {:closure-defines {goog.DEBUG true}}}
+        :release {:compiler-options {:optimizations :advanced}}}}}
+```
+
+#### Step 5.3: Update Core Init
+
+Update `src/cljs/imas_seamap/core.cljs`:
+
+```clojure
+(defn ^:export init []
+  (let [deployment-config (deployment/get-deployment-config)]
+    (re-frame/dispatch-sync [:boot
+                             (get-api-url)
+                             (get-media-url)
+                             (get-wordpress-url)
+                             "/img/"
+                             deployment-config])
+    (reagent/render [views/layout-app]
+                    (js/document.getElementById "app"))))
+```
+
+#### Step 5.4: Update index.html
+
+Single `resources/public/index.html` that loads the unified app:
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Seamap</title>
+  <link rel="stylesheet" href="/css/app.css">
+</head>
+<body>
+  <div id="app"></div>
+  <script src="/js/main.js"></script>
+</body>
+</html>
+```
+
+#### Step 5.5: Update Backend Deployment
+
+Update database schema to store deployment configs:
+
+```sql
+-- Migration: Add deployment column to appropriate table
+ALTER TABLE your_app_table ADD COLUMN deployment VARCHAR(50) DEFAULT 'seamap-australia';
+```
+
+Update Django views to pass deployment info to frontend.
+
+### Files to Modify
+
+- `shadow-cljs.edn` - Consolidate build targets
+- `src/cljs/imas_seamap/deployment.cljs` - NEW: Runtime detection
+- `src/cljs/imas_seamap/core.cljs` - Update init to use detection
+- `resources/public/index.html` - Single unified HTML
+- Backend deployment configs - Update to pass deployment ID
+
+### Testing Phase 5
+
+- [ ] Single build produces working app for all deployments
+- [ ] URL-based detection works correctly
+- [ ] All environment variables load correctly
+- [ ] Build size hasn't increased significantly
+
+---
+
+## Optional: Database Schema Changes
+
+**If needed for multi-tenancy:**
+
+### Add Deployment Tracking
+
+```sql
+-- Track which deployment a user/session is using
+CREATE TABLE deployment_sessions (
+  id SERIAL PRIMARY KEY,
+  session_id VARCHAR(255) NOT NULL,
+  deployment_id VARCHAR(50) NOT NULL,
+  created_at TIMESTAMP DEFAULT NOW()
+);
+
+-- Add deployment field to relevant tables
+ALTER TABLE user_preferences ADD COLUMN deployment VARCHAR(50);
+ALTER TABLE saved_maps ADD COLUMN deployment VARCHAR(50);
+```
+
+### Backend API Changes
+
+Update Django views to:
+1. Accept deployment parameter
+2. Filter data by deployment where appropriate
+3. Return deployment-specific URLs and assets
+
+---
+
+## Success Criteria for Complete Migration
+
+### Functionality
+- [ ] All 4 deployments work correctly
+- [ ] No `tma?` or deployment-specific boolean flags remain
+- [ ] Feature flags control all deployment differences
+- [ ] Single codebase, single build (or minimal builds)
+
+### Code Quality
+- [ ] No code duplication between deployments
+- [ ] Clear separation of config from code
+- [ ] Easy to add new deployments
+- [ ] All tests passing
+
+### Documentation
+- [ ] Configuration system documented
+- [ ] Deployment guide updated
+- [ ] Component registry documented
+- [ ] Migration notes for future developers
+
+### Performance
+- [ ] Build time not significantly increased
+- [ ] Runtime performance unchanged
+- [ ] Bundle size not significantly larger
+
+---
+
+## Notes and Considerations
+
+### Adding New Deployments
+
+After migration complete, adding a new deployment should be:
+
+1. Create deployment config in `deployments.cljs`
+2. Add welcome content to `content.cljs`
+3. Add logo/assets to `resources/public/img/`
+4. Add detection logic to `deployment.cljs` (Phase 5)
+5. Update CSS if custom colors needed
+
+No code changes required!
+
+### Backward Compatibility
+
+During migration:
+- Keep old entry points working until Phase 5
+- Maintain fallback behavior if config not loaded
+- Don't break existing saved URLs or bookmarks
+
+### Risk Mitigation
+
+- Test each phase thoroughly before proceeding
+- Keep git commits small and focused
+- Maintain feature branch until fully tested
+- Have rollback plan for production deployment
+
+---
+
+## Questions to Resolve
+
+- [ ] How should production deployment detect which config to use?
+- [ ] Should deployment config come from backend API or be embedded?
+- [ ] Do we need user-selectable deployments or always automatic?
+- [ ] Should saved map states include deployment information?
+
+---
+
+## Reference Documents
+
+- Main proposal: `docs/configuration-driven-refactor-proposal.md`
+- Testing guide: `docs/testing-configuration-system.md`
+- Configuration files: `src/cljs/imas_seamap/config/`
+- Test suite: `test/cljs/imas_seamap/config_test.cljs`

--- a/frontend/docs/handler-registration-options.md
+++ b/frontend/docs/handler-registration-options.md
@@ -108,74 +108,6 @@ The proposal's section 5 suggests feature-based registration, but several altern
 
 ---
 
-## Option 1.5: Symbol-Based Lazy Resolution
-
-**Concept**: Like Option 1, but use symbols instead of direct function references to defer namespace loading until actually needed.
-
-```clojure
-;; src/cljs/imas_seamap/handlers/registry.cljs
-(ns imas-seamap.handlers.registry
-  (:require [imas-seamap.core :as core]))
-  ;; NOTE: No requires for feature modules!
-
-(def feature-handler-modules
-  "Maps feature flags to handler function symbols"
-  {:state-of-knowledge 'imas-seamap.state-of-knowledge.registry/handlers
-   :data-in-region     'imas-seamap.tas-marine-atlas.data-in-region.registry/handlers
-   :featured-maps      'imas-seamap.story-maps.registry/handlers})
-
-(defn register-for-features!
-  "Registers handlers for enabled features"
-  [features base-handlers]
-  ;; Register base handlers (always needed)
-  (core/register-handlers! base-handlers)
-
-  ;; Lazily load and register feature-specific handlers
-  (doseq [feature features]
-    (when-let [handler-sym (get feature-handler-modules feature)]
-      (try
-        (js/console.log "Loading and registering handlers for feature:" feature)
-        ;; requiring-resolve loads the namespace (if not loaded) and resolves the symbol
-        (let [handler-fn (requiring-resolve handler-sym)]
-          (core/register-handlers! (handler-fn)))
-        (catch js/Error e
-          (js/console.error "Failed to load handlers for feature" feature e))))))
-```
-
-**How It Works:**
-
-1. **Symbols instead of requires** - `'imas-seamap.state-of-knowledge.registry/handlers` is just data (a symbol), not a reference that forces namespace loading
-2. **`requiring-resolve` at runtime** - When a feature is enabled, `requiring-resolve` will:
-   - Require the namespace if not already loaded (triggers evaluation)
-   - Resolve the symbol to the actual function
-   - Return the function so we can call it
-3. **Truly lazy** - Feature namespaces only evaluate when their feature is enabled
-
-**Pros:**
-- ✅ **Deferred namespace evaluation** - code only runs for enabled features
-- ✅ **Faster boot time** - don't pay eval cost for unused features
-- ✅ **Clean separation** - each feature owns its handlers
-- ✅ **No handler code in configs** - keeps deployment configs declarative
-- ✅ **Simple to understand** - just a map of symbols
-
-**Cons:**
-- ❌ **Bundle size unchanged** - all compiled JS still in bundle (see concerns below)
-- ❌ **No compile-time checking** - typo in symbol = runtime error
-- ❌ **IDE can't navigate** - tooling won't jump from symbol to definition
-- ❌ **Requires ClojureScript 1.10.844+** - for `requiring-resolve`
-
-**When to Use:**
-- You have clear feature boundaries with significant handler code
-- Some deployments use very different feature sets
-- Boot time optimization is valuable
-- You're comfortable with symbol-based indirection
-
-**Compilation Concerns:**
-
-⚠️ **Advanced compilation may remove unreferenced code**. See "Dead Code Elimination Concerns" section below for details and workarounds.
-
----
-
 ## Option 2: Component Self-Registration Pattern
 
 **Concept**: Components register their own handlers when first rendered using React lifecycle hooks.
@@ -398,94 +330,7 @@ Components still use Option 2's self-registration pattern.
 
 ---
 
-## Dead Code Elimination Concerns (Option 1.5)
-
-When using symbol-based lazy resolution, there's a potential concern with ClojureScript's advanced compilation: **the Google Closure Compiler might remove code that's never directly referenced**.
-
-### The Problem
-
-If a namespace is only referenced through a symbol (like `'imas-seamap.state-of-knowledge.registry/handlers`) and never through a direct `(:require ...)` form, the Closure Compiler's dead code elimination might:
-
-1. **Remove the entire namespace** - if no direct references exist
-2. **Tree-shake functions** - if they appear unused
-3. **Optimize away code** - that looks unreachable
-
-This would cause `requiring-resolve` to fail at runtime with "No such namespace" errors.
-
-### The Reality
-
-**In practice, this is usually not a problem** because:
-
-1. **Feature namespaces typically have side effects** - They require other namespaces (events, subs), which keeps them in the dependency graph
-2. **View components require them** - If your views require the registry namespaces anywhere, they're in the bundle
-3. **ClojureScript analyzer is smart** - It tracks namespace dependencies across the entire codebase
-
-### Workarounds If Needed
-
-If you encounter issues with code being eliminated, here are solutions:
-
-#### 1. Add Sentinel Requires (Simplest)
-
-Add dummy requires in a central location to ensure namespaces are compiled in:
-
-```clojure
-;; src/cljs/imas_seamap/handlers/registry.cljs
-(ns imas-seamap.handlers.registry
-  (:require [imas-seamap.core :as core]
-            ;; Sentinel requires - forces namespaces into bundle
-            ;; (marked with :refer [] to avoid warnings about unused requires)
-            [imas-seamap.state-of-knowledge.registry :refer []]
-            [imas-seamap.tas-marine-atlas.data-in-region.registry :refer []]
-            [imas-seamap.story-maps.registry :refer []]))
-
-(def feature-handler-modules
-  {:state-of-knowledge 'imas-seamap.state-of-knowledge.registry/handlers
-   :data-in-region     'imas-seamap.tas-marine-atlas.data-in-region.registry/handlers
-   :featured-maps      'imas-seamap.story-maps.registry/handlers})
-```
-
-This keeps the symbol-based approach while guaranteeing the namespaces are in the bundle.
-
-#### 2. Use Compiler Hints
-
-Configure `:advanced` compilation to preserve namespaces:
-
-```clojure
-;; project.clj or shadow-cljs.edn
-{:compiler {:optimizations :advanced
-            :externs ["externs.js"]
-            ;; Prevent removal of dynamic namespaces
-            :pseudo-names true}}
-```
-
-Note: This is less precise and may keep more code than needed.
-
-#### 3. Test With Advanced Compilation
-
-Always test with `:advanced` optimization before deployment:
-
-```bash
-# shadow-cljs
-shadow-cljs release app
-
-# lein
-lein cljsbuild once min
-```
-
-Runtime errors about missing namespaces indicate dead code elimination issues.
-
-### Recommendation
-
-**Start with Option 1.5 without sentinel requires**. In most real-world ClojureScript applications, the namespaces will be in the bundle anyway because:
-- View components transitively depend on them
-- The analyzer tracks all namespace dependencies
-- Feature code has side effects that keep it in the dependency graph
-
-**If you see runtime errors**, add sentinel requires as shown above. This is a minimal, zero-runtime-cost solution that explicitly tells the compiler "keep these namespaces."
-
----
-
-## Recommendation: **Option 1 or 1.5 (Feature-Based Handler Modules)**
+## Recommendation: **Option 1 (Feature-Based Handler Modules)**
 
 Given the constraints and architecture, both **Option 1** and **Option 1.5** are good choices:
 
@@ -495,13 +340,7 @@ Given the constraints and architecture, both **Option 1** and **Option 1.5** are
 - Boot time is not a concern
 - You want direct function references (better IDE support)
 
-### Choose Option 1.5 if:
-- You have multiple large feature modules
-- Different deployments use significantly different features
-- Boot time optimization matters (mobile users, slower devices)
-- You're comfortable with symbol-based indirection
-
-Both options share the same core benefits:
+This has the core benefits:
 
 1. **Keeps configs clean** - No handler registration details in deployment configs
 2. **Simple mental model** - "This feature uses these handlers"

--- a/frontend/docs/handler-registration-options.md
+++ b/frontend/docs/handler-registration-options.md
@@ -1,0 +1,552 @@
+# Handler Registration Options for Configuration-Driven Architecture
+
+**Context**: Exploring approaches for conditionally registering re-frame subscriptions and event handlers based on which components are actually used in a deployment.
+
+**Goal**: Register handlers only for components that are enabled, without putting handler registration details directly in deployment configurations.
+
+---
+
+## The Challenge
+
+Looking at the current code, each deployment has a large `config-handlers` map (100+ handlers). Many handlers are shared across deployments, but some are feature-specific:
+- `:sok/*` handlers (12+) only used by Australia/Antarctica
+- `:data-in-region/*` handlers (3) only used by TMA
+- `:sm/*` handlers (2) only used by deployments with featured maps
+
+The proposal's section 5 suggests feature-based registration, but several alternative approaches are worth considering.
+
+---
+
+## Option 1: Feature-Based Handler Modules (Refinement of Proposal)
+
+**Concept**: Group handlers by feature into separate modules that export a registration function.
+
+```clojure
+;; src/cljs/imas_seamap/state_of_knowledge/registry.cljs
+(ns imas-seamap.state-of-knowledge.registry
+  (:require [imas-seamap.state-of-knowledge.events :as sok-events]
+            [imas-seamap.state-of-knowledge.subs :as sok-subs]))
+
+(defn handlers
+  "Returns handlers map for state-of-knowledge feature"
+  []
+  {:subs   {:sok/habitat-statistics               sok-subs/habitat-statistics
+            :sok/habitat-statistics-download-url   sok-subs/habitat-statistics-download-url
+            :sok/bathymetry-statistics             sok-subs/bathymetry-statistics
+            :sok/bathymetry-statistics-download-url sok-subs/bathymetry-statistics-download-url
+            :sok/habitat-observations              sok-subs/habitat-observations
+            :sok/amp-boundaries                    sok-subs/amp-boundaries
+            :sok/imcra-boundaries                  sok-subs/imcra-boundaries
+            :sok/meow-boundaries                   sok-subs/meow-boundaries
+            :sok/valid-boundaries                  sok-subs/valid-boundaries
+            :sok/boundaries                        sok-subs/boundaries
+            :sok/active-boundary                   sok-subs/active-boundary
+            :sok/active-boundaries?                sok-subs/active-boundaries?
+            :sok/active-zones?                     sok-subs/active-zones?
+            :sok/open?                             sok-subs/open?
+            :sok/boundary-layer-filter             sok-subs/boundary-layer-filter-fn
+            :sok/region-report-url                 sok-subs/region-report-url}
+
+   :events {:sok/update-amp-boundaries            sok-events/update-amp-boundaries
+            :sok/update-imcra-boundaries          sok-events/update-imcra-boundaries
+            :sok/update-meow-boundaries           sok-events/update-meow-boundaries
+            ;; ... all other SOK events
+            }})
+```
+
+```clojure
+;; src/cljs/imas_seamap/tas_marine_atlas/data_in_region/registry.cljs
+(ns imas-seamap.tas-marine-atlas.data-in-region.registry
+  (:require [imas-seamap.tas-marine-atlas.events :as tma-events]
+            [imas-seamap.tas-marine-atlas.subs :as tma-subs]))
+
+(defn handlers []
+  {:subs   {:data-in-region/data tma-subs/data-in-region}
+   :events {:data-in-region/open [tma-events/data-in-region-open]
+            :data-in-region/get  [tma-events/get-data-in-region]
+            :data-in-region/got  tma-events/got-data-in-region}})
+```
+
+```clojure
+;; src/cljs/imas_seamap/handlers/registry.cljs
+(ns imas-seamap.handlers.registry
+  (:require [imas-seamap.core :as core]
+            ;; Require ALL feature modules upfront (but don't register yet)
+            [imas-seamap.state-of-knowledge.registry :as sok-registry]
+            [imas-seamap.tas-marine-atlas.data-in-region.registry :as dir-registry]
+            [imas-seamap.story-maps.registry :as sm-registry]))
+
+(def feature-handler-modules
+  "Maps feature flags to handler registration functions"
+  {:state-of-knowledge sok-registry/handlers
+   :data-in-region     dir-registry/handlers
+   :featured-maps      sm-registry/handlers})
+
+(defn register-for-features!
+  "Registers handlers for enabled features"
+  [features base-handlers]
+  ;; Register base handlers (always needed)
+  (core/register-handlers! base-handlers)
+
+  ;; Register feature-specific handlers
+  (doseq [feature features]
+    (when-let [handler-fn (get feature-handler-modules feature)]
+      (js/console.log "Registering handlers for feature:" feature)
+      (core/register-handlers! (handler-fn)))))
+```
+
+**Pros:**
+- Clean separation of concerns - each feature owns its handlers
+- Easy to find all handlers for a feature
+- No handler code in deployment configs
+- Still requires all namespaces (no lazy loading)
+
+**Cons:**
+- Still loads all handler code even if not used
+- Requires new file per feature module
+- Some duplication with existing events/subs namespaces
+
+---
+
+## Option 1.5: Symbol-Based Lazy Resolution
+
+**Concept**: Like Option 1, but use symbols instead of direct function references to defer namespace loading until actually needed.
+
+```clojure
+;; src/cljs/imas_seamap/handlers/registry.cljs
+(ns imas-seamap.handlers.registry
+  (:require [imas-seamap.core :as core]))
+  ;; NOTE: No requires for feature modules!
+
+(def feature-handler-modules
+  "Maps feature flags to handler function symbols"
+  {:state-of-knowledge 'imas-seamap.state-of-knowledge.registry/handlers
+   :data-in-region     'imas-seamap.tas-marine-atlas.data-in-region.registry/handlers
+   :featured-maps      'imas-seamap.story-maps.registry/handlers})
+
+(defn register-for-features!
+  "Registers handlers for enabled features"
+  [features base-handlers]
+  ;; Register base handlers (always needed)
+  (core/register-handlers! base-handlers)
+
+  ;; Lazily load and register feature-specific handlers
+  (doseq [feature features]
+    (when-let [handler-sym (get feature-handler-modules feature)]
+      (try
+        (js/console.log "Loading and registering handlers for feature:" feature)
+        ;; requiring-resolve loads the namespace (if not loaded) and resolves the symbol
+        (let [handler-fn (requiring-resolve handler-sym)]
+          (core/register-handlers! (handler-fn)))
+        (catch js/Error e
+          (js/console.error "Failed to load handlers for feature" feature e))))))
+```
+
+**How It Works:**
+
+1. **Symbols instead of requires** - `'imas-seamap.state-of-knowledge.registry/handlers` is just data (a symbol), not a reference that forces namespace loading
+2. **`requiring-resolve` at runtime** - When a feature is enabled, `requiring-resolve` will:
+   - Require the namespace if not already loaded (triggers evaluation)
+   - Resolve the symbol to the actual function
+   - Return the function so we can call it
+3. **Truly lazy** - Feature namespaces only evaluate when their feature is enabled
+
+**Pros:**
+- ✅ **Deferred namespace evaluation** - code only runs for enabled features
+- ✅ **Faster boot time** - don't pay eval cost for unused features
+- ✅ **Clean separation** - each feature owns its handlers
+- ✅ **No handler code in configs** - keeps deployment configs declarative
+- ✅ **Simple to understand** - just a map of symbols
+
+**Cons:**
+- ❌ **Bundle size unchanged** - all compiled JS still in bundle (see concerns below)
+- ❌ **No compile-time checking** - typo in symbol = runtime error
+- ❌ **IDE can't navigate** - tooling won't jump from symbol to definition
+- ❌ **Requires ClojureScript 1.10.844+** - for `requiring-resolve`
+
+**When to Use:**
+- You have clear feature boundaries with significant handler code
+- Some deployments use very different feature sets
+- Boot time optimization is valuable
+- You're comfortable with symbol-based indirection
+
+**Compilation Concerns:**
+
+⚠️ **Advanced compilation may remove unreferenced code**. See "Dead Code Elimination Concerns" section below for details and workarounds.
+
+---
+
+## Option 2: Component Self-Registration Pattern
+
+**Concept**: Components register their own handlers when first rendered using React lifecycle hooks.
+
+```clojure
+;; src/cljs/imas_seamap/state_of_knowledge/views.cljs
+(ns imas-seamap.state-of-knowledge.views
+  (:require [reagent.core :as r]
+            [re-frame.core :as re-frame]
+            [imas-seamap.state-of-knowledge.handlers :as handlers]))
+
+(defonce ^:private handlers-registered? (atom false))
+
+(defn ensure-handlers-registered!
+  "Idempotent handler registration - safe to call multiple times"
+  []
+  (when-not @handlers-registered?
+    (js/console.log "Registering state-of-knowledge handlers")
+    (handlers/register!)  ;; Calls re-frame/reg-sub and reg-event-fx
+    (reset! handlers-registered? true)))
+
+(defn state-of-knowledge-panel []
+  (r/with-let [_ (ensure-handlers-registered!)]
+    (let [boundaries @(re-frame/subscribe [:sok/boundaries])
+          habitat-stats @(re-frame/subscribe [:sok/habitat-statistics])]
+      ;; ... component rendering
+      )))
+```
+
+```clojure
+;; src/cljs/imas_seamap/state_of_knowledge/handlers.cljs
+(ns imas-seamap.state-of-knowledge.handlers
+  (:require [re-frame.core :as re-frame]
+            [imas-seamap.state-of-knowledge.events :as events]
+            [imas-seamap.state-of-knowledge.subs :as subs]))
+
+(defn register!
+  "Register all state-of-knowledge handlers"
+  []
+  ;; Register subscriptions
+  (re-frame/reg-sub :sok/habitat-statistics subs/habitat-statistics)
+  (re-frame/reg-sub :sok/bathymetry-statistics subs/bathymetry-statistics)
+  ;; ... more subs
+
+  ;; Register events
+  (re-frame/reg-event-fx :sok/get-habitat-statistics events/get-habitat-statistics)
+  (re-frame/reg-event-fx :sok/get-bathymetry-statistics events/get-bathymetry-statistics)
+  ;; ... more events
+  )
+```
+
+**Pros:**
+- True lazy registration - only when component actually renders
+- Component ownership is explicit
+- No central registry needed
+- Works well with code splitting
+
+**Cons:**
+- Handlers registered at render time (slight perf hit on first render)
+- Need atom to track registration state
+- Less declarative than upfront registration
+- Harder to see all handlers at a glance
+
+---
+
+## Option 3: Lazy Namespace Loading with Auto-Registration
+
+**Concept**: Use namespace side-effects to auto-register when required.
+
+```clojure
+;; src/cljs/imas_seamap/state_of_knowledge/handlers.cljs
+(ns imas-seamap.state-of-knowledge.handlers
+  (:require [re-frame.core :as re-frame]
+            [imas-seamap.state-of-knowledge.events :as events]
+            [imas-seamap.state-of-knowledge.subs :as subs]))
+
+;; Auto-register handlers when namespace is loaded
+(re-frame/reg-sub :sok/habitat-statistics subs/habitat-statistics)
+(re-frame/reg-sub :sok/bathymetry-statistics subs/bathymetry-statistics)
+;; ... all subs
+
+(re-frame/reg-event-fx :sok/get-habitat-statistics events/get-habitat-statistics)
+;; ... all events
+
+(js/console.log "State-of-knowledge handlers registered")
+```
+
+```clojure
+;; In component namespace - just require the handlers
+(ns imas-seamap.state-of-knowledge.views
+  (:require [imas-seamap.state-of-knowledge.handlers]))  ;; Side-effect: registers handlers
+```
+
+**Pros:**
+- Simplest code - just require the namespace
+- Automatic registration
+- Works with ClojureScript's namespace system
+
+**Cons:**
+- Relies on side-effects (less explicit)
+- Harder to control registration timing
+- All handler code must be loaded when namespace is required
+- Can't easily conditionally register
+
+---
+
+## Option 4: Manifest-Based Registration
+
+**Concept**: Components declare their handler dependencies in metadata, central registry handles registration.
+
+```clojure
+;; src/cljs/imas_seamap/registry/component_manifests.cljs
+(ns imas-seamap.registry.component-manifests)
+
+(def manifests
+  "Component handler dependency manifests"
+
+  {:sok/panel
+   {:requires-handlers #{:state-of-knowledge}
+    :component-ns      'imas-seamap.state-of-knowledge.views}
+
+   :data-in-region/panel
+   {:requires-handlers #{:data-in-region}
+    :component-ns      'imas-seamap.tas-marine-atlas.data-in-region.views}
+
+   :featured-map/drawer
+   {:requires-handlers #{:featured-maps}
+    :component-ns      'imas-seamap.story-maps.views}})
+```
+
+```clojure
+;; src/cljs/imas_seamap/views/layout.cljs
+(ns imas-seamap.views.layout
+  (:require [imas-seamap.registry.components :as components]
+            [imas-seamap.registry.component-manifests :as manifests]
+            [imas-seamap.handlers.registry :as handler-registry]))
+
+(defonce ^:private loaded-handlers (atom #{}))
+
+(defn ensure-handlers-for-component!
+  "Ensures handlers are registered for a component before rendering"
+  [component-key]
+  (when-let [manifest (get manifests/manifests component-key)]
+    (doseq [handler-set (:requires-handlers manifest)]
+      (when-not (contains? @loaded-handlers handler-set)
+        (handler-registry/register-feature! handler-set)
+        (swap! loaded-handlers conj handler-set)))))
+
+(defn right-drawer []
+  (let [active-drawer @(re-frame/subscribe [:ui/right-drawer])
+        config @(re-frame/subscribe [:deployment/config])
+        component-key (get-in config [:drawers active-drawer])]
+
+    (when component-key
+      (ensure-handlers-for-component! component-key)  ;; Lazy load handlers
+      [(components/resolve-component component-key)])))
+```
+
+**Pros:**
+- Declarative dependencies
+- Central visibility of what depends on what
+- Lazy registration when component actually used
+- Easy to audit and optimize
+
+**Cons:**
+- Extra layer of indirection
+- Manifest must be kept in sync with actual dependencies
+- More complex setup
+
+---
+
+## Option 5: Hybrid - Feature Flags + Just-In-Time Registration
+
+**Concept**: Use deployment feature flags to pre-load feature namespaces, but defer actual registration until component render.
+
+```clojure
+;; src/cljs/imas_seamap/core.cljs
+(defn init [api-url-base media-url-base wordpress-url-base img-url-base deployment-id]
+  (let [deployment-config (deployments/get-deployment (keyword deployment-id))]
+
+    ;; Register base handlers (always needed)
+    (register-handlers! base-handlers)
+
+    ;; Pre-require feature namespaces based on feature flags
+    ;; (This loads the code but doesn't register handlers yet)
+    (when (contains? (:features deployment-config) :state-of-knowledge)
+      (require 'imas-seamap.state-of-knowledge.handlers))
+
+    (when (contains? (:features deployment-config) :data-in-region)
+      (require 'imas-seamap.tas-marine-atlas.data-in-region.handlers))
+
+    ;; ... boot continues
+    ))
+```
+
+Components still use Option 2's self-registration pattern.
+
+**Pros:**
+- Only loads handler code for enabled features
+- Registration deferred until actually needed
+- Best of both worlds for code splitting
+
+**Cons:**
+- Most complex approach
+- Dynamic require in ClojureScript can be tricky
+- Two-phase loading (require + register)
+
+---
+
+## Comparison Matrix
+
+| Approach | Code Loaded | Registration Timing | Complexity | Visibility | Recommendation |
+|----------|-------------|---------------------|------------|------------|----------------|
+| **Option 1: Feature Modules** | All upfront | Boot time | Low | High | Simple & clear |
+| **Option 1.5: Symbol-Based Lazy** | On feature enable | Boot time | Low-Med | Medium | ⭐ **Best for lazy loading** |
+| **Option 2: Self-Registration** | On component use | First render | Medium | Medium | Good for code splitting |
+| **Option 3: Namespace Side-Effects** | When required | Namespace load | Low | Low | Avoid - too implicit |
+| **Option 4: Manifest-Based** | On component use | First render | High | High | Overkill for this use case |
+| **Option 5: Hybrid** | Feature-gated + JIT | First render | High | Medium | Only if bundle size critical |
+
+---
+
+## Dead Code Elimination Concerns (Option 1.5)
+
+When using symbol-based lazy resolution, there's a potential concern with ClojureScript's advanced compilation: **the Google Closure Compiler might remove code that's never directly referenced**.
+
+### The Problem
+
+If a namespace is only referenced through a symbol (like `'imas-seamap.state-of-knowledge.registry/handlers`) and never through a direct `(:require ...)` form, the Closure Compiler's dead code elimination might:
+
+1. **Remove the entire namespace** - if no direct references exist
+2. **Tree-shake functions** - if they appear unused
+3. **Optimize away code** - that looks unreachable
+
+This would cause `requiring-resolve` to fail at runtime with "No such namespace" errors.
+
+### The Reality
+
+**In practice, this is usually not a problem** because:
+
+1. **Feature namespaces typically have side effects** - They require other namespaces (events, subs), which keeps them in the dependency graph
+2. **View components require them** - If your views require the registry namespaces anywhere, they're in the bundle
+3. **ClojureScript analyzer is smart** - It tracks namespace dependencies across the entire codebase
+
+### Workarounds If Needed
+
+If you encounter issues with code being eliminated, here are solutions:
+
+#### 1. Add Sentinel Requires (Simplest)
+
+Add dummy requires in a central location to ensure namespaces are compiled in:
+
+```clojure
+;; src/cljs/imas_seamap/handlers/registry.cljs
+(ns imas-seamap.handlers.registry
+  (:require [imas-seamap.core :as core]
+            ;; Sentinel requires - forces namespaces into bundle
+            ;; (marked with :refer [] to avoid warnings about unused requires)
+            [imas-seamap.state-of-knowledge.registry :refer []]
+            [imas-seamap.tas-marine-atlas.data-in-region.registry :refer []]
+            [imas-seamap.story-maps.registry :refer []]))
+
+(def feature-handler-modules
+  {:state-of-knowledge 'imas-seamap.state-of-knowledge.registry/handlers
+   :data-in-region     'imas-seamap.tas-marine-atlas.data-in-region.registry/handlers
+   :featured-maps      'imas-seamap.story-maps.registry/handlers})
+```
+
+This keeps the symbol-based approach while guaranteeing the namespaces are in the bundle.
+
+#### 2. Use Compiler Hints
+
+Configure `:advanced` compilation to preserve namespaces:
+
+```clojure
+;; project.clj or shadow-cljs.edn
+{:compiler {:optimizations :advanced
+            :externs ["externs.js"]
+            ;; Prevent removal of dynamic namespaces
+            :pseudo-names true}}
+```
+
+Note: This is less precise and may keep more code than needed.
+
+#### 3. Test With Advanced Compilation
+
+Always test with `:advanced` optimization before deployment:
+
+```bash
+# shadow-cljs
+shadow-cljs release app
+
+# lein
+lein cljsbuild once min
+```
+
+Runtime errors about missing namespaces indicate dead code elimination issues.
+
+### Recommendation
+
+**Start with Option 1.5 without sentinel requires**. In most real-world ClojureScript applications, the namespaces will be in the bundle anyway because:
+- View components transitively depend on them
+- The analyzer tracks all namespace dependencies
+- Feature code has side effects that keep it in the dependency graph
+
+**If you see runtime errors**, add sentinel requires as shown above. This is a minimal, zero-runtime-cost solution that explicitly tells the compiler "keep these namespaces."
+
+---
+
+## Recommendation: **Option 1 or 1.5 (Feature-Based Handler Modules)**
+
+Given the constraints and architecture, both **Option 1** and **Option 1.5** are good choices:
+
+### Choose Option 1 if:
+- Simplicity is paramount
+- All features' handler code is relatively small
+- Boot time is not a concern
+- You want direct function references (better IDE support)
+
+### Choose Option 1.5 if:
+- You have multiple large feature modules
+- Different deployments use significantly different features
+- Boot time optimization matters (mobile users, slower devices)
+- You're comfortable with symbol-based indirection
+
+Both options share the same core benefits:
+
+1. **Keeps configs clean** - No handler registration details in deployment configs
+2. **Simple mental model** - "This feature uses these handlers"
+3. **Easy migration** - Extract handlers from existing `config-handlers` maps into feature modules
+4. **Good visibility** - Easy to see what handlers each feature needs
+5. **Works with existing code** - Fits naturally with current `register-handlers!` pattern
+
+### Implementation Steps
+
+1. Create `registry.cljs` files for each major feature:
+   - `state_of_knowledge/registry.cljs`
+   - `tas_marine_atlas/data_in_region/registry.cljs`
+   - `story_maps/registry.cljs`
+
+2. Extract feature-specific handlers from `core.cljs` into these registries
+
+3. Update core init to use feature-based registration:
+
+```clojure
+(defn init [... deployment-id]
+  (let [deployment-config (deployments/get-deployment (keyword deployment-id))]
+    (handler-registry/register-for-features!
+      (:features deployment-config)
+      base-handlers)
+    ;; ... rest of boot
+    ))
+```
+
+4. Base handlers remain in `core.cljs` as a large map (or extracted to `handlers/base.cljs`)
+
+---
+
+## Alternative Consideration: Option 2 for Specific Cases
+
+While Option 1 is best for the general case, **Option 2 (Component Self-Registration)** could be useful for:
+- Very large features with many handlers (100+)
+- Features that are rarely used even when enabled
+- Code that you want to split into separate bundles
+
+These could be handled on a case-by-case basis while using Option 1 for most features.
+
+---
+
+## Notes
+
+- All options assume the existing feature flag system in deployment configs is preserved
+- The goal is to avoid putting handler registration *details* in configs, not to avoid referencing features
+- Option 1 strikes the best balance between simplicity, visibility, and keeping configs declarative

--- a/frontend/docs/testing-configuration-system.md
+++ b/frontend/docs/testing-configuration-system.md
@@ -1,0 +1,350 @@
+# Testing the Configuration-Driven Architecture
+
+This guide explains how to test the configuration system implemented in Phases 1-3.
+
+## Overview
+
+The configuration-driven architecture allows switching between deployments at runtime by loading different deployment configs. This guide covers both automated and manual testing approaches.
+
+## Automated Tests
+
+### Running the Tests
+
+```bash
+# Run all tests (when test runner is configured)
+npx shadow-cljs compile test
+node out/test.js
+
+# Or use the REPL
+npx shadow-cljs cljs-repl dev
+```
+
+In the REPL:
+
+```clojure
+(require '[imas-seamap.config-test :as test])
+(test/run-all-tests-and-report)
+```
+
+### What the Tests Cover
+
+- **Phase 1 Tests**: Deployment configs exist and are valid
+- **Phase 2 Tests**: Feature and branding subscriptions work correctly
+- **Phase 3 Tests**: Component migrations eliminated `tma?` flag properly
+
+## Manual Testing in Browser
+
+### Option 1: Using the Deployment Switcher (Recommended)
+
+The deployment switcher is a dev-only UI component that allows switching between deployments.
+
+#### 1. Add the Switcher to Your Layout
+
+Edit `src/cljs/imas_seamap/views.cljs` (or your main layout file):
+
+```clojure
+(ns imas-seamap.views
+  (:require
+    ;; ... existing requires ...
+    [imas-seamap.dev.deployment-switcher :as dev-switcher]))
+
+(defn layout-app []
+  (let [;; ... existing code ...
+        ]
+    [:div#main-wrapper
+     ;; ... existing components ...
+
+     ;; Add the deployment switcher (only shows in dev mode)
+     [dev-switcher/switcher-panel]]))
+```
+
+#### 2. Add the CSS
+
+Add the suggested CSS from `deployment_switcher.cljs` to `src/ui/css/app.scss`.
+
+#### 3. Start the Dev Server
+
+```bash
+npx shadow-cljs watch dev
+```
+
+#### 4. Open the App
+
+Navigate to `http://localhost:3451` and you should see a floating settings icon in the top-right corner.
+
+#### 5. Test Deployment Switching
+
+1. Click the settings icon to open the switcher panel
+2. Click "Switch to This" on any deployment card
+3. The app will reload with the new configuration
+4. Verify the UI updates with the new branding and features
+
+### Option 2: REPL-Based Testing
+
+For more granular testing, use the REPL:
+
+#### 1. Start Shadow-CLJS with REPL
+
+```bash
+npx shadow-cljs watch dev
+# In another terminal:
+npx shadow-cljs cljs-repl dev
+```
+
+#### 2. Load a Deployment Config
+
+```clojure
+(require '[re-frame.core :as re-frame])
+(require '[imas-seamap.config.deployments :as deployments])
+
+;; Load Seamap Australia config
+(re-frame/dispatch-sync
+ [:boot
+  "http://localhost:8000/api/"
+  "http://localhost:8000/media/"
+  "http://localhost:8888/"
+  "/img/"
+  (deployments/get-deployment :seamap-australia)])
+```
+
+#### 3. Test Feature Subscriptions
+
+```clojure
+;; Check if a feature is enabled
+@(re-frame/subscribe [:feature/enabled? :state-of-knowledge])
+;; => true (for Australia)
+
+@(re-frame/subscribe [:feature/enabled? :data-in-region])
+;; => false (for Australia)
+
+;; Get all features
+@(re-frame/subscribe [:feature/all])
+;; => #{:state-of-knowledge :featured-maps :floating-pills ...}
+```
+
+#### 4. Test Branding Subscriptions
+
+```clojure
+;; Get logo info
+@(re-frame/subscribe [:branding/logo])
+;; => {:src "img/Seamap2_V2_RGB.png", :alt "Seamap Australia", :height 96}
+
+;; Get a specific label
+@(re-frame/subscribe [:branding/label :layer-info])
+;; => "Layer info / Download data" (for Australia)
+
+;; Get map config
+@(re-frame/subscribe [:map/crs])
+;; => :epsg-3857
+
+@(re-frame/subscribe [:map/initial-center])
+;; => [-27.819644755 132.133333]
+```
+
+#### 5. Switch to a Different Deployment
+
+```clojure
+;; Switch to TAS Marine Atlas
+(re-frame/dispatch-sync
+ [:boot
+  "http://localhost:8000/api/"
+  "http://localhost:8000/media/"
+  "http://localhost:8888/"
+  "/img/"
+  (deployments/get-deployment :tas-marine-atlas)])
+
+;; Verify the switch
+@(re-frame/subscribe [:deployment/id])
+;; => :tas-marine-atlas
+
+@(re-frame/subscribe [:feature/enabled? :data-in-region])
+;; => true (TMA has this feature)
+
+@(re-frame/subscribe [:branding/label :layer-info])
+;; => "Layer info" (TMA doesn't show download)
+
+@(re-frame/subscribe [:branding/label :region-control])
+;; => "Find Data in Region" (TMA-specific label)
+```
+
+## Testing Checklist
+
+Use this checklist to verify each deployment works correctly:
+
+### For Each Deployment
+
+- [ ] **Boot Process**
+  - [ ] App loads without errors
+  - [ ] Config is stored in app-db
+  - [ ] Deployment ID is correct
+
+- [ ] **Feature Flags**
+  - [ ] Correct features are enabled/disabled
+  - [ ] `:feature/enabled?` subscription works
+  - [ ] `:feature/all` returns correct set
+
+- [ ] **Branding**
+  - [ ] Logo displays correctly
+  - [ ] Title is correct
+  - [ ] Labels are deployment-specific
+  - [ ] Colors apply correctly (TMA/FoS)
+
+- [ ] **Map Configuration**
+  - [ ] Map centers at correct location
+  - [ ] Zoom level is correct
+  - [ ] CRS is correct (Antarctica uses :epsg-3031)
+
+- [ ] **Component Behavior**
+  - [ ] Layer info tooltip shows correct text
+  - [ ] Region control shows correct label
+  - [ ] Floating pills appear/disappear correctly
+  - [ ] Plot component appears/disappears correctly
+  - [ ] Featured maps tab appears/disappears correctly
+
+### Specific Test Cases
+
+#### Test Case 1: TMA vs Australia Layer Info
+
+**Setup**: Switch between TMA and Australia
+
+**Expected**:
+- **Australia**: Layer info tooltip says "Layer info / Download data"
+- **TMA**: Layer info tooltip says "Layer info"
+
+**Test**:
+```clojure
+;; Australia
+(re-frame/dispatch-sync [:boot ... (deployments/get-deployment :seamap-australia)])
+@(re-frame/subscribe [:branding/label :layer-info])
+;; => "Layer info / Download data"
+
+;; TMA
+(re-frame/dispatch-sync [:boot ... (deployments/get-deployment :tas-marine-atlas)])
+@(re-frame/subscribe [:branding/label :layer-info])
+;; => "Layer info"
+```
+
+#### Test Case 2: Feature-Specific Components
+
+**Setup**: Switch between deployments with different features
+
+**Expected**:
+- **Australia**: Has state-of-knowledge panel, floating pills, plot component
+- **TMA**: Has data-in-region panel, NO state-of-knowledge
+- **Antarctica**: Has state-of-knowledge, NO featured maps
+- **FoS**: Has plot component, NO floating pills
+
+**Test**:
+```clojure
+;; Check features for each deployment
+(doseq [deployment-id [:seamap-australia :tas-marine-atlas
+                       :seamap-antarctica :futures-of-seafood]]
+  (re-frame/dispatch-sync [:boot ... (deployments/get-deployment deployment-id)])
+  (println deployment-id "features:" @(re-frame/subscribe [:feature/all])))
+```
+
+#### Test Case 3: Antarctica CRS
+
+**Setup**: Switch to Antarctica
+
+**Expected**: Map uses Antarctic polar projection (EPSG:3031)
+
+**Test**:
+```clojure
+(re-frame/dispatch-sync [:boot ... (deployments/get-deployment :seamap-antarctica)])
+@(re-frame/subscribe [:map/crs])
+;; => :epsg-3031 (not :epsg-3857)
+
+@(re-frame/subscribe [:map/initial-center])
+;; => [-80 -90]
+```
+
+## Troubleshooting
+
+### Subscriptions Return nil
+
+**Problem**: All subscriptions return `nil`
+
+**Cause**: Deployment config not loaded into app-db
+
+**Solution**: Ensure `:boot` event is dispatched with config parameter:
+
+```clojure
+(re-frame/dispatch-sync
+ [:boot
+  "http://localhost:8000/api/"
+  "http://localhost:8000/media/"
+  "http://localhost:8888/"
+  "/img/"
+  (deployments/get-deployment :seamap-australia)])  ;; <-- Don't forget this!
+```
+
+### Components Still Using tma?
+
+**Problem**: Components still receiving `tma?` parameter
+
+**Cause**: Call sites haven't been updated yet
+
+**Solution**: Check that all component calls removed the parameter:
+
+```clojure
+;; WRONG
+[left-drawer-catalogue false]
+
+;; CORRECT
+[left-drawer-catalogue]
+```
+
+### Switcher Panel Not Showing
+
+**Problem**: Deployment switcher doesn't appear
+
+**Cause**: Either not in dev mode or not added to layout
+
+**Solution**:
+1. Check `config/debug?` is true
+2. Verify switcher is added to layout-app
+3. Check browser console for errors
+
+### Features Not Working
+
+**Problem**: Features behave inconsistently across deployments
+
+**Cause**: Components may still have hardcoded behavior
+
+**Solution**: Ensure all feature checks use subscriptions:
+
+```clojure
+;; WRONG
+(when tma? [some-component])
+
+;; CORRECT
+(when (features/feature? :some-feature) [some-component])
+```
+
+## Next Steps
+
+Once testing confirms:
+- ✅ All deployments load correctly
+- ✅ Feature flags work as expected
+- ✅ Branding is deployment-specific
+- ✅ Components render correctly
+- ✅ No `tma?` parameters remain
+
+You're ready to proceed to **Phase 4: Unify Layouts** where we'll:
+- Create a single slot-based `layout-app`
+- Create component registries
+- Consolidate all deployment-specific views
+
+## Reference: Deployment Feature Matrix
+
+| Feature | Australia | TMA | Antarctica | FoS |
+|---------|-----------|-----|------------|-----|
+| state-of-knowledge | ✓ | ✗ | ✓ | ✗ |
+| data-in-region | ✗ | ✓ | ✗ | ✗ |
+| featured-maps | ✓ | ✓ | ✗ | ✗ |
+| floating-pills | ✓ | ✓ | ✓ | ✗ |
+| plot-component | ✓ | ✗ | ✗ | ✓ |
+| transect-control | ✓ | ✗ | ✗ | ✓ |
+| data-providers | ✓ | ✗ | ✗ | ✗ |
+| data-download | ✓ | ✗ | ✗ | ✗ |

--- a/frontend/src/cljs/imas_seamap/blueprint.cljs
+++ b/frontend/src/cljs/imas_seamap/blueprint.cljs
@@ -42,6 +42,8 @@
 
 (def tab             (reagent/adapt-react-class Blueprint/Tab))
 
+(def tag             (reagent/adapt-react-class Blueprint/Tag))
+
 (def tooltip         (reagent/adapt-react-class Blueprint/Tooltip))
 
 (def tree            (reagent/adapt-react-class Blueprint/Tree))

--- a/frontend/src/cljs/imas_seamap/config/content.cljs
+++ b/frontend/src/cljs/imas_seamap/config/content.cljs
@@ -1,0 +1,85 @@
+;;; Seamap: view and interact with Australian coastal habitat data
+;;; Copyright (c) 2017, Institute of Marine & Antarctic Studies.  Written by Condense Pty Ltd.
+;;; Released under the Affero General Public Licence (AGPL) v3.  See LICENSE file for details.
+(ns imas-seamap.config.content
+  "Content registry for deployment-specific text and rich content.
+
+   This namespace stores rich content (like welcome dialogues) that would
+   otherwise be hardcoded in components. Content is stored as Reagent hiccup
+   and referenced by keyword from deployment configurations.")
+
+(def welcome-content
+  "Welcome dialogue content for each deployment"
+
+  {:welcome/seamap-australia
+   [:div.overview
+    "Seamap Australia is a nationally synthesised product of
+     seafloor habitat data collected from various stakeholders around
+     Australia. Source datasets were reclassified according to a
+     newly-developed national marine benthic habitat classification
+     scheme, and synthesised to produce a single standardised GIS
+     data layer of Australian benthic marine habitats."]
+
+   :welcome/tas-marine-atlas
+   [:div.overview
+    [:p
+     "The waters and coastlines represented in the Tasmania's Marine Atlas are of
+      significance to Tasmanian Aboriginal people. We recognise the deep history and
+      culture of the islands represented in this Atlas and acknowledge the traditional
+      owners and custodians of Country. We pay respect to Tasmanian Aboriginal people,
+      who have survived invasion and dispossession, and continue to maintain their
+      identity, culture and Indigenous rights and honour their Elders, past and
+      present."]
+    [:p
+     "Any absence of information about Tasmanian Aboriginal people's connection to Sea
+      Country in the Tasmania's Marine Atlas does not indicate an absence of
+      connection or significance. We respect the right of Tasmanian Aboriginal people
+      to self-determination and affirm their right to decide what information is
+      included in the Atlas."]
+    [:p
+     "Learn more about Sea Country and Tasmanian Aboriginal People "
+     [:a
+      {:href "https://storymaps.arcgis.com/stories/22672ae2d60f424f8d1e024232cfa885"
+       :target "_blank"}
+      "here"]
+     "."]]
+
+   :welcome/seamap-antarctica
+   [:div.overview
+    "Seamap Antarctica provides access to seafloor habitat data for the Antarctic region.
+     Explore benthic marine habitats and environmental data for Antarctic waters."]
+
+   :welcome/futures-of-seafood
+   [:div.overview
+    "Welcome to the Futures of Seafood interactive map. Explore seafood-related
+     data and information for Australian waters."]})
+
+(def citation-content
+  "Citation information for each deployment"
+
+  {:citation/seamap-australia
+   [:div.citation-section
+    [:p
+     "Please cite as "
+     [:span {:id "citation"}
+      "Lucieer V, Walsh P, Flukes E, Butler C, Proctor R, Johnson C (2017). "
+      [:i "Seamap Australia - a national seafloor habitat classification scheme."]
+      " Institute for Marine and Antarctic Studies (IMAS), University of Tasmania (UTAS)."]]
+    [:p
+     "Data contributors should be acknowledged, and datasets cited where appropriate,
+      which may include adding citations to lists of references and/or citing the data
+      in figure captions. Dataset citations are available from each dataset's metadata
+      (Available from layer info controls). Contributors of source datasets can be
+      viewed in the layer catalogue under the Classification tab of the left sidebar."]]})
+
+(defn get-content
+  "Retrieve content by keyword.
+   Returns nil if content key not found."
+  [content-key]
+  (get welcome-content content-key))
+
+(defn get-citation
+  "Retrieve citation content by keyword.
+   Returns nil if citation key not found."
+  [citation-key]
+  (get citation-content citation-key))

--- a/frontend/src/cljs/imas_seamap/config/deployments.cljs
+++ b/frontend/src/cljs/imas_seamap/config/deployments.cljs
@@ -44,18 +44,18 @@
                  :zoom   4}
 
    ;; Feature flags - which features are enabled for this deployment
-   :features    #{:state-of-knowledge
-                  :featured-maps
-                  :floating-pills
-                  :boundaries-pill
-                  :zones-pill
-                  :plot-component
-                  :transect-control
-                  :region-select
-                  :data-providers
-                  :data-download
-                  :settings
-                  :layer-preview}
+   :features    #{:feature/state-of-knowledge
+                  :feature/featured-maps
+                  :feature/floating-pills
+                  :feature/boundaries-pill
+                  :feature/zones-pill
+                  :feature/plot-component
+                  :feature/transect-control
+                  :feature/region-select
+                  :feature/data-providers
+                  :feature/data-download
+                  :feature/settings
+                  :feature/layer-preview}
 
    ;; Right drawer slot mappings (what can appear in the right drawer)
    :drawers     {:story-map          :featured-map/drawer
@@ -151,9 +151,9 @@
 
    ;; Feature flags - TMA has data-in-region instead of state-of-knowledge
    ;; Note: TMA does NOT have :settings feature enabled
-   :features    #{:featured-maps
-                  :data-in-region
-                  :floating-pills}
+   :features    #{:feature/featured-maps
+                  :feature/data-in-region
+                  :feature/floating-pills}
 
    ;; Right drawer slot mappings
    :drawers     {:story-map      :featured-map/drawer
@@ -214,13 +214,13 @@
                  :zoom   2}
 
    ;; Feature flags - Antarctica has state-of-knowledge and floating pills
-   :features    #{:state-of-knowledge
-                  :floating-pills
-                  :boundaries-pill
-                  :zones-pill
-                  :settings
-                  :region-select
-                  :layer-preview}
+   :features    #{:feature/state-of-knowledge
+                  :feature/floating-pills
+                  :feature/boundaries-pill
+                  :feature/zones-pill
+                  :feature/settings
+                  :feature/region-select
+                  :feature/layer-preview}
 
    ;; Right drawer slot mappings
    :drawers     {:state-of-knowledge :sok/panel}
@@ -312,11 +312,11 @@
                  :zoom   5}
 
    ;; Feature flags - minimal feature set
-   :features    #{:plot-component
-                  :transect-control
-                  :settings
-                  :region-select
-                  :layer-preview}
+   :features    #{:feature/plot-component
+                  :feature/transect-control
+                  :feature/settings
+                  :feature/region-select
+                  :feature/layer-preview}
 
    ;; Right drawer slot mappings (empty for FoS)
    :drawers     {}

--- a/frontend/src/cljs/imas_seamap/config/deployments.cljs
+++ b/frontend/src/cljs/imas_seamap/config/deployments.cljs
@@ -13,6 +13,8 @@
    - Initial state overrides
    - Deployment-specific URL paths")
 
+;;; FIXME: if features are name-spaced we can more-easily search for them, find all uses of eg ":feature/" etc
+
 ;;; =============================================================================
 ;;; SEAMAP AUSTRALIA
 ;;; =============================================================================
@@ -49,6 +51,7 @@
                   :zones-pill
                   :plot-component
                   :transect-control
+                  :region-select
                   :data-providers
                   :data-download
                   :settings
@@ -216,6 +219,7 @@
                   :boundaries-pill
                   :zones-pill
                   :settings
+                  :region-select
                   :layer-preview}
 
    ;; Right drawer slot mappings
@@ -311,6 +315,7 @@
    :features    #{:plot-component
                   :transect-control
                   :settings
+                  :region-select
                   :layer-preview}
 
    ;; Right drawer slot mappings (empty for FoS)

--- a/frontend/src/cljs/imas_seamap/config/deployments.cljs
+++ b/frontend/src/cljs/imas_seamap/config/deployments.cljs
@@ -63,6 +63,15 @@
    :controls    [:menu :settings :zoom :print :omnisearch
                  :transect :region :share :reset :shortcuts :help]
 
+   ;; Layout configuration (Phase 4: Unified layout)
+   :layout      {:left-drawer    {:tabs [:catalogue :active-layers :featured-maps]}
+                 :footer         [:footer/plot]
+                 :floating-pills [:pill/boundaries :pill/zones]
+                 :controls       [:control/menu :control/settings :control/zoom
+                                  :control/print :control/omnisearch :control/transect
+                                  :control/region :control/share :control/reset
+                                  :control/shortcuts :control/help]}
+
    ;; Feature-specific state initialization
    :initial-state
    {:display {:welcome-overlay false}
@@ -151,6 +160,15 @@
    :controls    [:menu :settings :zoom :print :omnisearch
                  :region :share :reset :shortcuts :help]
 
+   ;; Layout configuration (Phase 4: Unified layout)
+   :layout      {:left-drawer    {:tabs [:catalogue :active-layers :featured-maps]}
+                 :footer         []  ; No plot component for TMA
+                 :floating-pills []  ; TMA has floating-pills feature but no specific pills configured
+                 :controls       [:control/menu :control/settings :control/zoom
+                                  :control/print :control/omnisearch :control/region
+                                  :control/share :control/reset :control/shortcuts
+                                  :control/help]}
+
    ;; Feature-specific state initialization
    :initial-state
    {:display {:welcome-overlay true   ;; TMA shows welcome by default
@@ -204,6 +222,15 @@
    ;; Map controls
    :controls    [:menu :settings :zoom :print :omnisearch
                  :region :share :reset :shortcuts :help]
+
+   ;; Layout configuration (Phase 4: Unified layout)
+   :layout      {:left-drawer    {:tabs [:catalogue :active-layers]}
+                 :footer         []  ; No plot component
+                 :floating-pills [:pill/boundaries :pill/zones]
+                 :controls       [:control/menu :control/settings :control/zoom
+                                  :control/print :control/omnisearch :control/region
+                                  :control/share :control/reset :control/shortcuts
+                                  :control/help]}
 
    ;; Feature-specific state initialization (same as Australia)
    :initial-state
@@ -288,6 +315,15 @@
    ;; Map controls
    :controls    [:menu :settings :zoom :print :omnisearch
                  :transect :region :share :reset :shortcuts :help]
+
+   ;; Layout configuration (Phase 4: Unified layout)
+   :layout      {:left-drawer    {:tabs [:catalogue :active-layers]}
+                 :footer         [:footer/plot]
+                 :floating-pills []  ; No floating pills for FoS
+                 :controls       [:control/menu :control/settings :control/zoom
+                                  :control/print :control/omnisearch :control/transect
+                                  :control/region :control/share :control/reset
+                                  :control/shortcuts :control/help]}
 
    ;; Feature-specific state initialization (minimal)
    :initial-state

--- a/frontend/src/cljs/imas_seamap/config/deployments.cljs
+++ b/frontend/src/cljs/imas_seamap/config/deployments.cljs
@@ -50,7 +50,8 @@
                   :plot-component
                   :transect-control
                   :data-providers
-                  :data-download}
+                  :data-download
+                  :settings}
 
    ;; Right drawer slot mappings (what can appear in the right drawer)
    :drawers     {:story-map          :featured-map/drawer
@@ -145,6 +146,7 @@
                  :zoom   7}
 
    ;; Feature flags - TMA has data-in-region instead of state-of-knowledge
+   ;; Note: TMA does NOT have :settings feature enabled
    :features    #{:featured-maps
                   :data-in-region
                   :floating-pills}
@@ -211,7 +213,8 @@
    :features    #{:state-of-knowledge
                   :floating-pills
                   :boundaries-pill
-                  :zones-pill}
+                  :zones-pill
+                  :settings}
 
    ;; Right drawer slot mappings
    :drawers     {:state-of-knowledge :sok/panel}
@@ -304,7 +307,8 @@
 
    ;; Feature flags - minimal feature set
    :features    #{:plot-component
-                  :transect-control}
+                  :transect-control
+                  :settings}
 
    ;; Right drawer slot mappings (empty for FoS)
    :drawers     {}

--- a/frontend/src/cljs/imas_seamap/config/deployments.cljs
+++ b/frontend/src/cljs/imas_seamap/config/deployments.cljs
@@ -51,7 +51,8 @@
                   :transect-control
                   :data-providers
                   :data-download
-                  :settings}
+                  :settings
+                  :layer-preview}
 
    ;; Right drawer slot mappings (what can appear in the right drawer)
    :drawers     {:story-map          :featured-map/drawer
@@ -214,7 +215,8 @@
                   :floating-pills
                   :boundaries-pill
                   :zones-pill
-                  :settings}
+                  :settings
+                  :layer-preview}
 
    ;; Right drawer slot mappings
    :drawers     {:state-of-knowledge :sok/panel}
@@ -308,7 +310,8 @@
    ;; Feature flags - minimal feature set
    :features    #{:plot-component
                   :transect-control
-                  :settings}
+                  :settings
+                  :layer-preview}
 
    ;; Right drawer slot mappings (empty for FoS)
    :drawers     {}

--- a/frontend/src/cljs/imas_seamap/config/deployments.cljs
+++ b/frontend/src/cljs/imas_seamap/config/deployments.cljs
@@ -1,0 +1,326 @@
+;;; Seamap: view and interact with Australian coastal habitat data
+;;; Copyright (c) 2017, Institute of Marine & Antarctic Studies.  Written by Condense Pty Ltd.
+;;; Released under the Affero General Public Licence (AGPL) v3.  See LICENSE file for details.
+(ns imas-seamap.config.deployments
+  "Deployment configurations for all Seamap instances.
+
+   Each deployment configuration defines:
+   - Unique identifier and CSS class
+   - Branding (logo, title, colors, welcome content)
+   - Map configuration (CRS, center, zoom)
+   - Feature flags (which features are enabled)
+   - UI layout (tabs, drawers, controls)
+   - Initial state overrides
+   - Deployment-specific URL paths")
+
+;;; =============================================================================
+;;; SEAMAP AUSTRALIA
+;;; =============================================================================
+
+(def seamap-australia
+  {:id          :seamap-australia
+   :css-class   "seamap"
+   :drawer-class "seamap-drawer"
+
+   ;; Branding
+   :branding
+   {:logo        {:src    "img/Seamap2_V2_RGB.png"
+                  :alt    "Seamap Australia"
+                  :height 96}
+    :url         "https://seamapaustralia.org"
+    :title       "Seamap Australia"
+    :welcome     {:title   "Welcome to Seamap Australia."
+                  :content :welcome/seamap-australia}
+    :labels      {:region-control    "Select region"
+                  :transect-control  "Draw transect (habitat data) or take a measurement"
+                  :layer-info        "Layer info / Download data"}
+    :links       {:main-site "https://seamapaustralia.org"}}
+
+   ;; Map configuration
+   :map         {:crs    :epsg-3857
+                 :center [-27.819644755 132.133333]
+                 :zoom   4}
+
+   ;; Feature flags - which features are enabled for this deployment
+   :features    #{:state-of-knowledge
+                  :featured-maps
+                  :floating-pills
+                  :boundaries-pill
+                  :zones-pill
+                  :plot-component
+                  :transect-control
+                  :data-providers
+                  :data-download}
+
+   ;; Right drawer slot mappings (what can appear in the right drawer)
+   :drawers     {:story-map          :featured-map/drawer
+                 :state-of-knowledge :sok/panel}
+
+   ;; Left drawer tabs (ordered)
+   :tabs        [:catalogue :active-layers :featured-maps]
+
+   ;; Map controls (ordered, displayed in UI)
+   :controls    [:menu :settings :zoom :print :omnisearch
+                 :transect :region :share :reset :shortcuts :help]
+
+   ;; Feature-specific state initialization
+   :initial-state
+   {:display {:welcome-overlay false}
+    :state-of-knowledge
+    {:boundaries {:active-boundary nil
+                  :active-boundary-layer nil
+                  :amp   {:active-network   nil
+                          :active-park      nil
+                          :active-zone      nil
+                          :active-zone-iucn nil
+                          :active-zone-id   nil}
+                  :imcra {:active-provincial-bioregion nil
+                          :active-mesoscale-bioregion  nil}
+                  :meow  {:active-realm     nil
+                          :active-province  nil
+                          :active-ecoregion nil}}
+     :statistics {:habitat {:results      []
+                            :loading?     false
+                            :show-layers? false}
+                  :bathymetry {:results      []
+                               :loading?     false
+                               :show-layers? false}
+                  :habitat-observations {:global-archive nil
+                                        :sediment       nil
+                                        :squidle        nil
+                                        :loading?       false
+                                        :show-layers?   false}}}}
+
+   ;; Feature-specific URL paths
+   :url-paths {:amp-boundaries        "habitat/ampboundaries"
+               :imcra-boundaries      "habitat/imcraboundaries"
+               :meow-boundaries       "habitat/meowboundaries"
+               :habitat-statistics    "habitat/habitatstatistics"
+               :bathymetry-statistics "habitat/bathymetrystatistics"
+               :habitat-observations  "habitat/habitatobservations"
+               :region-reports        "regionreports/"
+               :region-report-pages   "region-reports/"}})
+
+;;; =============================================================================
+;;; TASMANIA MARINE ATLAS
+;;; =============================================================================
+
+(def tas-marine-atlas
+  {:id          :tas-marine-atlas
+   :css-class   "tas-marine-atlas"
+   :drawer-class "tas-marine-atlas-drawer"
+
+   ;; Branding
+   :branding
+   {:logo        {:src    "img/TMA_Banner_size_website.png"
+                  :alt    "Tasmania Marine Atlas"
+                  :height 86}
+    :url         "https://tasmarineatlas.org"
+    :title       "Tasmania's Marine Atlas"
+    :welcome     {:title   "Welcome to Tasmania's Marine Atlas."
+                  :content :welcome/tas-marine-atlas}
+    :labels      {:region-control   "Find Data in Region"
+                  :transect-control "Measure"
+                  :layer-info       "Layer info"}
+    :links       {:main-site    "https://tasmarineatlas.org"
+                  :sea-country  "https://storymaps.arcgis.com/stories/22672ae2d60f424f8d1e024232cfa885"}}
+
+   ;; Color overrides (TMA has custom color scheme)
+   :colors      {:color-1 "rgb(18, 37, 55)"
+                 :color-2 "rgb(11, 80, 113)"
+                 :color-8 "rgb(98, 191, 236)"}
+
+   ;; Map configuration
+   :map         {:crs    :epsg-3857
+                 :center [-42.20157676555315 146.74253188097842]
+                 :zoom   7}
+
+   ;; Feature flags - TMA has data-in-region instead of state-of-knowledge
+   :features    #{:featured-maps
+                  :data-in-region
+                  :floating-pills}
+
+   ;; Right drawer slot mappings
+   :drawers     {:story-map      :featured-map/drawer
+                 :data-in-region :data-in-region/panel}
+
+   ;; Left drawer tabs (ordered)
+   :tabs        [:catalogue :active-layers :featured-maps]
+
+   ;; Map controls (no transect control for TMA)
+   :controls    [:menu :settings :zoom :print :omnisearch
+                 :region :share :reset :shortcuts :help]
+
+   ;; Feature-specific state initialization
+   :initial-state
+   {:display {:welcome-overlay true   ;; TMA shows welcome by default
+              :catalogue {:main   {:tab "cat" :expanded #{}}
+                          :region {:tab "cat" :expanded #{}}}}
+    :data-in-region {:data     nil
+                     :query-id nil}}
+
+   ;; Feature-specific URL paths
+   :url-paths {:data-in-region "habitat/datainregion"}})
+
+;;; =============================================================================
+;;; SEAMAP ANTARCTICA
+;;; =============================================================================
+
+(def seamap-antarctica
+  {:id          :seamap-antarctica
+   :css-class   "seamap"
+   :drawer-class "seamap-drawer"
+
+   ;; Branding
+   :branding
+   {:logo        {:src    "img/SeaMapAntarctica_Logo_RGB_3000px.png"
+                  :alt    "Seamap Antarctica"
+                  :height 96}
+    :url         "https://seamapantarctica.org"
+    :title       "Seamap Antarctica"
+    :welcome     {:title   "Welcome to Seamap Antarctica."
+                  :content :welcome/seamap-antarctica}
+    :labels      {:region-control   "Select region"
+                  :transect-control "Take a measurement"
+                  :layer-info       "Layer info"}}
+
+   ;; Map configuration - Antarctic polar projection
+   :map         {:crs    :epsg-3031
+                 :center [-80 -90]
+                 :zoom   2}
+
+   ;; Feature flags - Antarctica has state-of-knowledge and floating pills
+   :features    #{:state-of-knowledge
+                  :floating-pills
+                  :boundaries-pill
+                  :zones-pill}
+
+   ;; Right drawer slot mappings
+   :drawers     {:state-of-knowledge :sok/panel}
+
+   ;; Left drawer tabs (no featured maps for Antarctica)
+   :tabs        [:catalogue :active-layers]
+
+   ;; Map controls
+   :controls    [:menu :settings :zoom :print :omnisearch
+                 :region :share :reset :shortcuts :help]
+
+   ;; Feature-specific state initialization (same as Australia)
+   :initial-state
+   {:display {:welcome-overlay false}
+    :state-of-knowledge
+    {:boundaries {:active-boundary nil
+                  :active-boundary-layer nil
+                  :amp   {:active-network   nil
+                          :active-park      nil
+                          :active-zone      nil
+                          :active-zone-iucn nil
+                          :active-zone-id   nil}
+                  :imcra {:active-provincial-bioregion nil
+                          :active-mesoscale-bioregion  nil}
+                  :meow  {:active-realm     nil
+                          :active-province  nil
+                          :active-ecoregion nil}}
+     :statistics {:habitat {:results      []
+                            :loading?     false
+                            :show-layers? false}
+                  :bathymetry {:results      []
+                               :loading?     false
+                               :show-layers? false}
+                  :habitat-observations {:global-archive nil
+                                        :sediment       nil
+                                        :squidle        nil
+                                        :loading?       false
+                                        :show-layers?   false}}}}
+
+   ;; Feature-specific URL paths (same as Australia)
+   :url-paths {:amp-boundaries        "habitat/ampboundaries"
+               :imcra-boundaries      "habitat/imcraboundaries"
+               :meow-boundaries       "habitat/meowboundaries"
+               :habitat-statistics    "habitat/habitatstatistics"
+               :bathymetry-statistics "habitat/bathymetrystatistics"
+               :habitat-observations  "habitat/habitatobservations"
+               :region-reports        "regionreports/"
+               :region-report-pages   "region-reports/"}})
+
+;;; =============================================================================
+;;; FUTURES OF SEAFOOD
+;;; =============================================================================
+
+(def futures-of-seafood
+  {:id          :futures-of-seafood
+   :css-class   "futures-of-seafood"
+   :drawer-class "fos-drawer"
+
+   ;; Branding
+   :branding
+   {:logo        {:src    "img/Futures-of-Seafood-Logo-Reverse-400x218.png"
+                  :alt    "Futures of Seafood"
+                  :height 86}
+    :url         "https://futuresofseafood.com.au"
+    :title       "Futures of Seafood"
+    :welcome     {:title   "Welcome to Futures of Seafood."
+                  :content :welcome/futures-of-seafood}
+    :labels      {:region-control   "Select region"
+                  :transect-control "Draw transect (habitat data) or take a measurement"
+                  :layer-info       "Layer info"}}
+
+   ;; Color overrides (FoS has custom color scheme)
+   :colors      {:color-2          "#062440"
+                 :color-highlight-1 "#00b0a5"
+                 :color-7          "white"}
+
+   ;; Map configuration (same as Australia)
+   :map         {:crs    :epsg-3857
+                 :center [-28.0 134.0]
+                 :zoom   5}
+
+   ;; Feature flags - minimal feature set
+   :features    #{:plot-component
+                  :transect-control}
+
+   ;; Right drawer slot mappings (empty for FoS)
+   :drawers     {}
+
+   ;; Left drawer tabs (basic catalogue and active layers only)
+   :tabs        [:catalogue :active-layers]
+
+   ;; Map controls
+   :controls    [:menu :settings :zoom :print :omnisearch
+                 :transect :region :share :reset :shortcuts :help]
+
+   ;; Feature-specific state initialization (minimal)
+   :initial-state
+   {:display {:welcome-overlay false}}
+
+   ;; Feature-specific URL paths (none specific to FoS)
+   :url-paths {}})
+
+;;; =============================================================================
+;;; DEPLOYMENT REGISTRY
+;;; =============================================================================
+
+(def deployments
+  "Registry of all deployment configurations, keyed by deployment ID"
+  {:seamap-australia   seamap-australia
+   :tas-marine-atlas   tas-marine-atlas
+   :seamap-antarctica  seamap-antarctica
+   :futures-of-seafood futures-of-seafood})
+
+;;; =============================================================================
+;;; HELPER FUNCTIONS
+;;; =============================================================================
+
+(defn get-deployment
+  "Get a deployment configuration by ID.
+   Throws an error if deployment ID is not found."
+  [deployment-id]
+  (or (get deployments deployment-id)
+      (throw (ex-info "Unknown deployment ID"
+                      {:deployment-id deployment-id
+                       :available-ids (keys deployments)}))))
+
+(defn feature-enabled?
+  "Check if a feature is enabled for a deployment"
+  [deployment-config feature-key]
+  (contains? (:features deployment-config) feature-key))

--- a/frontend/src/cljs/imas_seamap/config/examples.cljs
+++ b/frontend/src/cljs/imas_seamap/config/examples.cljs
@@ -1,0 +1,176 @@
+;;; Seamap: view and interact with Australian coastal habitat data
+;;; Copyright (c) 2017, Institute of Marine & Antarctic Studies.  Written by Condense Pty Ltd.
+;;; Released under the Affero General Public Licence (AGPL) v3.  See LICENSE file for details.
+(ns imas-seamap.config.examples
+  "Examples of how to use the new configuration-driven architecture.
+
+   This namespace demonstrates the patterns from Phases 1-2:
+   - How to access deployment configurations
+   - How to use feature flag subscriptions
+   - How to access branding information"
+  (:require [re-frame.core :as re-frame]
+            [imas-seamap.config.deployments :as deployments]
+            [imas-seamap.subs.features :as features]))
+
+;;; =============================================================================
+;;; PHASE 1: Accessing Deployment Configurations (compile-time)
+;;; =============================================================================
+
+(comment
+  ;; Get a specific deployment configuration
+  (def australia-config (deployments/get-deployment :seamap-australia))
+
+  ;; Check what features are enabled
+  (:features australia-config)
+  ;; => #{:state-of-knowledge :featured-maps :floating-pills ...}
+
+  ;; Check if a feature is enabled (compile-time)
+  (deployments/feature-enabled? australia-config :state-of-knowledge)
+  ;; => true
+
+  ;; Get branding information
+  (get-in australia-config [:branding :logo :src])
+  ;; => "img/Seamap2_V2_RGB.png"
+
+  ;; Get all deployments
+  deployments/deployments
+  ;; => {:seamap-australia {...} :tas-marine-atlas {...} ...}
+  )
+
+;;; =============================================================================
+;;; PHASE 2: Using Feature Subscriptions (runtime, in components)
+;;; =============================================================================
+
+(comment
+  ;; Example component using feature flags
+  (defn my-component []
+    (let [has-sok? @(re-frame/subscribe [:feature/enabled? :state-of-knowledge])
+          logo @(re-frame/subscribe [:branding/logo])
+          region-label @(re-frame/subscribe [:branding/label :region-control])]
+      [:div
+       [:h1 "Example Component"]
+
+       ;; Conditionally render based on feature flag
+       (when has-sok?
+         [:div "State of Knowledge feature is enabled!"])
+
+       ;; Use deployment-specific branding
+       [:img {:src (:src logo) :alt (:alt logo)}]
+       [:button region-label]]))
+
+  ;; Using the convenience helper function
+  (defn another-component []
+    [:div
+     ;; This is cleaner than using subscribe directly
+     (when (features/feature? :plot-component)
+       [plot-display])
+
+     (when (features/feature? :floating-pills)
+       [floating-pills])])
+
+  ;; Getting all enabled features
+  (defn debug-component []
+    (let [all-features @(re-frame/subscribe [:feature/all])
+          deployment-id @(re-frame/subscribe [:deployment/id])]
+      [:div
+       [:h2 "Current Deployment: " (name deployment-id)]
+       [:h3 "Enabled Features:"]
+       [:ul
+        (for [feature all-features]
+          ^{:key feature}
+          [:li (name feature)])]]))
+  )
+
+;;; =============================================================================
+;;; MIGRATION PATTERNS: Replacing tma? flag
+;;; =============================================================================
+
+(comment
+  ;; BEFORE (Phase 0 - current code):
+  (defn old-component [{:keys [layer tma?]}]
+    [:div.layer-card
+     [layer-control
+      {:tooltip (if tma? "Layer info" "Layer info / Download data")}]])
+
+  ;; AFTER (Phase 2 - using feature flags):
+  (defn new-component [{:keys [layer]}]
+    (let [label @(re-frame/subscribe [:branding/label :layer-info])]
+      [:div.layer-card
+       [layer-control {:tooltip label}]]))
+
+  ;; Or with the convenience helper:
+  (defn new-component-alt [{:keys [layer]}]
+    (let [show-download? (features/feature? :data-download)]
+      [:div.layer-card
+       [layer-control
+        {:tooltip (if show-download?
+                    "Layer info / Download data"
+                    "Layer info")}]]))
+  )
+
+;;; =============================================================================
+;;; TESTING: How to test with different configurations
+;;; =============================================================================
+
+(comment
+  ;; To test a component with a specific deployment config:
+  ;; 1. Dispatch :boot event with the deployment config
+  (re-frame/dispatch-sync
+   [:boot
+    "http://localhost:8000/api/"
+    "http://localhost:8000/media/"
+    "http://localhost:8888/"
+    "/img/"
+    (deployments/get-deployment :seamap-australia)])
+
+  ;; 2. Now all subscriptions will use Australia's config
+  @(re-frame/subscribe [:feature/enabled? :state-of-knowledge])
+  ;; => true
+
+  ;; 3. To test with a different deployment:
+  (re-frame/dispatch-sync
+   [:boot
+    "http://localhost:8000/api/"
+    "http://localhost:8000/media/"
+    "http://localhost:8888/"
+    "/img/"
+    (deployments/get-deployment :tas-marine-atlas)])
+
+  @(re-frame/subscribe [:feature/enabled? :state-of-knowledge])
+  ;; => false (TMA doesn't have state-of-knowledge)
+
+  @(re-frame/subscribe [:feature/enabled? :data-in-region])
+  ;; => true (TMA has data-in-region)
+  )
+
+;;; =============================================================================
+;;; VALIDATION: Check that all deployments have consistent configs
+;;; =============================================================================
+
+(defn validate-deployments
+  "Validates that all deployment configurations are properly structured.
+   Returns a vector of error messages, or empty vector if valid."
+  []
+  (let [required-keys #{:id :css-class :drawer-class :branding :map :features :drawers :tabs :controls}]
+    (reduce
+     (fn [errors [deployment-id config]]
+       (let [missing-keys (set/difference required-keys (set (keys config)))]
+         (if (seq missing-keys)
+           (conj errors (str "Deployment " deployment-id " is missing keys: " missing-keys))
+           errors)))
+     []
+     deployments/deployments)))
+
+(comment
+  ;; Run validation
+  (validate-deployments)
+  ;; => [] (empty means no errors)
+
+  ;; Check specific deployment features
+  (doseq [[id config] deployments/deployments]
+    (println id "has" (count (:features config)) "features:"))
+  ;; seamap-australia has 9 features
+  ;; tas-marine-atlas has 3 features
+  ;; seamap-antarctica has 4 features
+  ;; futures-of-seafood has 2 features
+  )

--- a/frontend/src/cljs/imas_seamap/core.cljs
+++ b/frontend/src/cljs/imas_seamap/core.cljs
@@ -24,6 +24,8 @@
             [imas-seamap.story-maps.subs :as smsubs]
             [imas-seamap.protocols]
             [imas-seamap.subs :as subs]
+            [imas-seamap.subs.features]  ;; Phase 2: Feature flag subscriptions
+            [imas-seamap.subs.branding]  ;; Phase 2: Branding subscriptions
             [imas-seamap.views :as views]
             [imas-seamap.config :as config]
             [imas-seamap.components :as components]))

--- a/frontend/src/cljs/imas_seamap/core.cljs
+++ b/frontend/src/cljs/imas_seamap/core.cljs
@@ -26,6 +26,7 @@
             [imas-seamap.subs :as subs]
             [imas-seamap.subs.features]  ;; Phase 2: Feature flag subscriptions
             [imas-seamap.subs.branding]  ;; Phase 2: Branding subscriptions
+            [imas-seamap.config.deployments]  ;; Phase 4: Deployment configurations
             [imas-seamap.views :as views]
             [imas-seamap.config :as config]
             [imas-seamap.components :as components]))
@@ -372,11 +373,40 @@
 (defn ^:export show-db []
   @re-frame.db/app-db)
 
-(defn ^:export init [api-url-base media-url-base wordpress-url-base img-url-base]
-  (register-handlers! config-handlers)
-  (re-frame/dispatch-sync [:boot api-url-base media-url-base wordpress-url-base img-url-base])
-  (dev-setup)
-  (mount-root))
+(defn ^:export init
+  "Initialize the application.
+
+   Parameters:
+   - api-url-base: Base URL for API endpoints
+   - media-url-base: Base URL for media files
+   - wordpress-url-base: Base URL for WordPress content
+   - img-url-base: Base URL for images
+   - deployment-id: (optional) Deployment identifier as string (e.g., 'seamap-australia')
+                    Defaults to 'seamap-australia' if not provided
+
+   Usage from HTML:
+     <script>
+       imas_seamap.core.init(
+         'http://localhost:8000/api/',
+         'http://localhost:8000/media/',
+         'http://localhost:8888/',
+         '/img/',
+         'seamap-australia'  // or 'tas-marine-atlas', 'seamap-antarctica', 'futures-of-seafood'
+       );
+     </script>"
+  ([api-url-base media-url-base wordpress-url-base img-url-base]
+   (init api-url-base media-url-base wordpress-url-base img-url-base "seamap-australia"))
+  ([api-url-base media-url-base wordpress-url-base img-url-base deployment-id]
+   (let [;; Convert deployment-id string to keyword
+         deployment-kw (keyword deployment-id)
+         ;; Load the deployment configuration
+         deployment-config (imas-seamap.config.deployments/get-deployment deployment-kw)]
+     (js/console.log ::deployment-config deployment-config)
+     (register-handlers! config-handlers)
+     ;; Pass deployment config to boot event
+     (re-frame/dispatch-sync [:boot api-url-base media-url-base wordpress-url-base img-url-base deployment-config])
+     (dev-setup)
+     (mount-root))))
 
 (defn ^:dev/after-load re-render
   []

--- a/frontend/src/cljs/imas_seamap/db.cljs
+++ b/frontend/src/cljs/imas_seamap/db.cljs
@@ -9,6 +9,7 @@
                      :initial-bounds? true
                      :size            {}
                      :zoom            4
+                     :crs             :epsg-3857     ; Default CRS (can be overridden by deployment config)
                      :zoom-cutover    10
                      :bounds          {}
                      :categories      []

--- a/frontend/src/cljs/imas_seamap/dev/deployment_switcher.cljs
+++ b/frontend/src/cljs/imas_seamap/dev/deployment_switcher.cljs
@@ -132,7 +132,7 @@
         [:h5 "Feature Test"]
         [:div.bp3-form-group
          [:label.bp3-label "Feature Key:"]
-         [b/input
+         [b/text-input
           {:value (name (:feature-key @test-state))
            :on-change #(swap! test-state assoc :feature-key
                               (keyword (.. % -target -value)))}]]
@@ -147,7 +147,7 @@
         [:h5 "Branding Label Test"]
         [:div.bp3-form-group
          [:label.bp3-label "Label Key:"]
-         [b/input
+         [b/text-input
           {:value (name (:label-key @test-state))
            :on-change #(swap! test-state assoc :label-key
                               (keyword (.. % -target -value)))}]]

--- a/frontend/src/cljs/imas_seamap/dev/deployment_switcher.cljs
+++ b/frontend/src/cljs/imas_seamap/dev/deployment_switcher.cljs
@@ -1,0 +1,328 @@
+;;; Seamap: view and interact with Australian coastal habitat data
+;;; Copyright (c) 2017, Institute of Marine & Antarctic Studies.  Written by Condense Pty Ltd.
+;;; Released under the Affero General Public Licence (AGPL) v3.  See LICENSE file for details.
+(ns imas-seamap.dev.deployment-switcher
+  "Development-only UI for testing the configuration-driven architecture.
+
+   Provides a floating panel that allows switching between deployments
+   and inspecting the current configuration state."
+  (:require [re-frame.core :as re-frame]
+            [reagent.core :as reagent]
+            [imas-seamap.blueprint :as b]
+            [imas-seamap.config.deployments :as deployments]
+            [imas-seamap.config :as config]))
+
+;;; =============================================================================
+;;; State
+;;; =============================================================================
+
+(defonce switcher-state
+  (reagent/atom {:open? false
+                 :show-details? false}))
+
+;;; =============================================================================
+;;; Helper Functions
+;;; =============================================================================
+
+(defn switch-deployment!
+  "Switch to a different deployment by re-booting the app with new config"
+  [deployment-id]
+  (let [config (deployments/get-deployment deployment-id)]
+    (re-frame/dispatch-sync
+     [:boot
+      "http://localhost:8000/api/"
+      "http://localhost:8000/media/"
+      "http://localhost:8888/"
+      "/img/"
+      config])
+    (js/console.log "Switched to deployment:" deployment-id)
+    ;; Force a page reload to ensure all components re-render with new config
+    (js/location.reload)))
+
+(defn get-feature-count [deployment-id]
+  (let [config (deployments/get-deployment deployment-id)]
+    (count (:features config))))
+
+;;; =============================================================================
+;;; UI Components
+;;; =============================================================================
+
+(defn- deployment-card
+  "Card showing deployment info and switch button"
+  [deployment-id]
+  (let [config (deployments/get-deployment deployment-id)
+        current-id @(re-frame/subscribe [:deployment/id])
+        is-current? (= deployment-id current-id)
+        feature-count (count (:features config))]
+    [b/card
+     {:class (str "deployment-card" (when is-current? " current"))}
+     [:div.deployment-header
+      [:h4 (:title (:branding config))]
+      (when is-current?
+        [b/tag {:intent "success" :minimal true} "CURRENT"])]
+
+     [:div.deployment-info
+      [:div.info-row
+       [:span.label "ID:"]
+       [:span.value (name deployment-id)]]
+      [:div.info-row
+       [:span.label "CSS Class:"]
+       [:span.value (:css-class config)]]
+      [:div.info-row
+       [:span.label "Features:"]
+       [:span.value feature-count]]
+      [:div.info-row
+       [:span.label "Map CRS:"]
+       [:span.value (name (:crs (:map config)))]]]
+
+     [b/button
+      {:text (if is-current? "Current Deployment" "Switch to This")
+       :intent (if is-current? "success" "primary")
+       :disabled is-current?
+       :fill true
+       :on-click #(switch-deployment! deployment-id)}]]))
+
+(defn- feature-list
+  "Display list of enabled features"
+  []
+  (let [features @(re-frame/subscribe [:feature/all])]
+    [:div.feature-list
+     [:h4 "Enabled Features (" (count features) ")"]
+     (if (seq features)
+       [:ul
+        (for [feature (sort features)]
+          ^{:key feature}
+          [:li
+           [b/tag {:minimal true :icon "tick"} (name feature)]])]
+       [:p.bp3-text-muted "No features enabled"])]))
+
+(defn- branding-info
+  "Display current branding information"
+  []
+  (let [logo @(re-frame/subscribe [:branding/logo])
+        title @(re-frame/subscribe [:branding/title])
+        css-class @(re-frame/subscribe [:branding/css-class])
+        colors @(re-frame/subscribe [:branding/colors])]
+    [:div.branding-info
+     [:h4 "Branding Configuration"]
+     [:div.info-row
+      [:span.label "Title:"]
+      [:span.value title]]
+     [:div.info-row
+      [:span.label "CSS Class:"]
+      [:span.value css-class]]
+     [:div.info-row
+      [:span.label "Logo:"]
+      [:span.value (:src logo)]]
+     (when (seq colors)
+       [:div.info-row
+        [:span.label "Custom Colors:"]
+        [:span.value (count colors) " overrides"]])]))
+
+(defn- subscription-tester
+  "Interactive subscription tester"
+  []
+  (let [test-state (reagent/atom {:feature-key :state-of-knowledge
+                                   :label-key :layer-info})]
+    (fn []
+      [:div.subscription-tester
+       [:h4 "Test Subscriptions"]
+
+       [:div.test-section
+        [:h5 "Feature Test"]
+        [:div.bp3-form-group
+         [:label.bp3-label "Feature Key:"]
+         [b/input
+          {:value (name (:feature-key @test-state))
+           :on-change #(swap! test-state assoc :feature-key
+                              (keyword (.. % -target -value)))}]]
+        [:div.test-result
+         [:strong "Result: "]
+         (let [enabled? @(re-frame/subscribe [:feature/enabled? (:feature-key @test-state)])]
+           [b/tag
+            {:intent (if enabled? "success" "danger")}
+            (str enabled?)])]]
+
+       [:div.test-section
+        [:h5 "Branding Label Test"]
+        [:div.bp3-form-group
+         [:label.bp3-label "Label Key:"]
+         [b/input
+          {:value (name (:label-key @test-state))
+           :on-change #(swap! test-state assoc :label-key
+                              (keyword (.. % -target -value)))}]]
+        [:div.test-result
+         [:strong "Result: "]
+         (let [label @(re-frame/subscribe [:branding/label (:label-key @test-state)])]
+           [:span.value (or label "(not found)")])]]])))
+
+(defn- switcher-panel-content
+  "Main content of the switcher panel"
+  []
+  [:div.deployment-switcher-content
+   [:div.section
+    [:h3 "Available Deployments"]
+    [:div.deployments-grid
+     (for [deployment-id [:seamap-australia :tas-marine-atlas
+                          :seamap-antarctica :futures-of-seafood]]
+       ^{:key deployment-id}
+       [deployment-card deployment-id])]]
+
+   (when (:show-details? @switcher-state)
+     [:<>
+      [:div.section
+       [feature-list]]
+
+      [:div.section
+       [branding-info]]
+
+      [:div.section
+       [subscription-tester]]])])
+
+(defn switcher-panel
+  "Main deployment switcher panel component"
+  []
+  (when config/debug?  ; Only show in dev mode
+    [:div.deployment-switcher
+     {:class (when (:open? @switcher-state) "open")}
+
+     ;; Toggle button
+     [:button.switcher-toggle
+      {:on-click #(swap! switcher-state update :open? not)
+       :title "Toggle Deployment Switcher"}
+      [b/icon {:icon (if (:open? @switcher-state) "cross" "settings")
+               :size 20}]]
+
+     ;; Panel
+     (when (:open? @switcher-state)
+       [b/card {:class "switcher-panel" :elevation 3}
+        [:div.panel-header
+         [:h2 "Deployment Switcher"]
+         [:div.header-actions
+          [b/switch
+           {:checked (:show-details? @switcher-state)
+            :label "Show Details"
+            :on-change #(swap! switcher-state update :show-details? not)}]
+          [b/button
+           {:icon "cross"
+            :minimal true
+            :on-click #(swap! switcher-state assoc :open? false)}]]]
+
+        [switcher-panel-content]])]))
+
+;;; =============================================================================
+;;; Styles (to be added to app.scss)
+;;; =============================================================================
+
+(def suggested-css
+  "/* Deployment Switcher Styles (add to src/ui/css/app.scss) */
+.deployment-switcher {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  z-index: 10000;
+}
+
+.deployment-switcher .switcher-toggle {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 50px;
+  height: 50px;
+  background: #137CBD;
+  color: white;
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+  transition: transform 0.2s;
+}
+
+.deployment-switcher .switcher-toggle:hover {
+  transform: scale(1.1);
+}
+
+.deployment-switcher .switcher-panel {
+  position: fixed;
+  top: 80px;
+  right: 20px;
+  width: 800px;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
+.deployment-switcher .panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+  border-bottom: 1px solid #e1e8ed;
+  padding-bottom: 10px;
+}
+
+.deployment-switcher .header-actions {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.deployment-switcher .deployments-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 15px;
+}
+
+.deployment-switcher .deployment-card {
+  padding: 15px;
+}
+
+.deployment-switcher .deployment-card.current {
+  border: 2px solid #0F9960;
+}
+
+.deployment-switcher .deployment-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.deployment-switcher .deployment-info .info-row {
+  display: flex;
+  justify-content: space-between;
+  padding: 5px 0;
+  font-size: 0.9em;
+}
+
+.deployment-switcher .deployment-info .label {
+  font-weight: 600;
+  color: #5C7080;
+}
+
+.deployment-switcher .section {
+  margin-top: 20px;
+  padding-top: 20px;
+  border-top: 1px solid #e1e8ed;
+}
+
+.deployment-switcher .feature-list ul {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.deployment-switcher .test-section {
+  margin: 10px 0;
+  padding: 10px;
+  background: #f5f8fa;
+  border-radius: 3px;
+}
+
+.deployment-switcher .test-result {
+  margin-top: 10px;
+  padding: 10px;
+  background: white;
+  border-radius: 3px;
+}")

--- a/frontend/src/cljs/imas_seamap/dev/deployment_switcher.cljs
+++ b/frontend/src/cljs/imas_seamap/dev/deployment_switcher.cljs
@@ -35,9 +35,7 @@
       "http://localhost:8888/"
       "/img/"
       config])
-    (js/console.log "Switched to deployment:" deployment-id)
-    ;; Force a page reload to ensure all components re-render with new config
-    (js/location.reload)))
+    (js/console.log "Switched to deployment:" deployment-id)))
 
 (defn get-feature-count [deployment-id]
   (let [config (deployments/get-deployment deployment-id)]

--- a/frontend/src/cljs/imas_seamap/events.cljs
+++ b/frontend/src/cljs/imas_seamap/events.cljs
@@ -212,9 +212,10 @@
                                     :media-url-base     media-url-base
                                     :wordpress-url-base wordpress-url-base
                                     :img-url-base       img-url-base})
-                         ;; Apply map configuration from deployment
+                         ;; Apply map configuration from deployment (center, zoom, and CRS)
                          (assoc-in [:map :center] (get-in deployment-config [:map :center]))
-                         (assoc-in [:map :zoom] (get-in deployment-config [:map :zoom])))
+                         (assoc-in [:map :zoom] (get-in deployment-config [:map :zoom]))
+                         (assoc-in [:map :crs] (get-in deployment-config [:map :crs])))
                      ;; Backward compatible: use default-db without config (old approach)
                      (assoc-in db/default-db [:config :url-base]
                                {:api-url-base       api-url-base

--- a/frontend/src/cljs/imas_seamap/events.cljs
+++ b/frontend/src/cljs/imas_seamap/events.cljs
@@ -211,7 +211,10 @@
                                    {:api-url-base       api-url-base
                                     :media-url-base     media-url-base
                                     :wordpress-url-base wordpress-url-base
-                                    :img-url-base       img-url-base}))
+                                    :img-url-base       img-url-base})
+                         ;; Apply map configuration from deployment
+                         (assoc-in [:map :center] (get-in deployment-config [:map :center]))
+                         (assoc-in [:map :zoom] (get-in deployment-config [:map :zoom])))
                      ;; Backward compatible: use default-db without config (old approach)
                      (assoc-in db/default-db [:config :url-base]
                                {:api-url-base       api-url-base

--- a/frontend/src/cljs/imas_seamap/events.cljs
+++ b/frontend/src/cljs/imas_seamap/events.cljs
@@ -202,18 +202,28 @@
       :story-maps-url              (str wordpress-url-base story-maps)
       :region-report-pages-url     (str wordpress-url-base region-report-pages)})))
 
-(defn boot [{:keys [save-code hash-code] {:keys [seamap-app-state]} :local-storage/get} [_ api-url-base media-url-base wordpress-url-base img-url-base]]
-  {:db         (assoc-in
-                db/default-db [:config :url-base]
-                {:api-url-base       api-url-base
-                 :media-url-base     media-url-base
-                 :wordpress-url-base wordpress-url-base
-                 :img-url-base       img-url-base})
-   :async-flow (cond ; Choose async boot flow based on what information we have for the DB:
-                 (seq save-code)    (boot-flow-save-state save-code)    ; A shortform save-code that can be used to query for a hash-code
-                 (seq hash-code)    (boot-flow-hash-state hash-code)    ; A hash-code that can be decoded into th DB's initial state
-                 (seq seamap-app-state) (boot-flow-hash-state seamap-app-state) ; Same as hash-code, except that we use the one stored in local storage
-                 :else              (boot-flow))})                      ; No information, so we start with an empty DB
+(defn boot [{:keys [save-code hash-code] {:keys [seamap-app-state]} :local-storage/get} [_ api-url-base media-url-base wordpress-url-base img-url-base & [deployment-config]]]
+  (let [initial-db (if deployment-config
+                     ;; Phase 2: Store deployment config if provided (new unified approach)
+                     (-> db/default-db
+                         (assoc :deployment-config deployment-config)
+                         (assoc-in [:config :url-base]
+                                   {:api-url-base       api-url-base
+                                    :media-url-base     media-url-base
+                                    :wordpress-url-base wordpress-url-base
+                                    :img-url-base       img-url-base}))
+                     ;; Backward compatible: use default-db without config (old approach)
+                     (assoc-in db/default-db [:config :url-base]
+                               {:api-url-base       api-url-base
+                                :media-url-base     media-url-base
+                                :wordpress-url-base wordpress-url-base
+                                :img-url-base       img-url-base}))]
+    {:db         initial-db
+     :async-flow (cond ; Choose async boot flow based on what information we have for the DB:
+                   (seq save-code)    (boot-flow-save-state save-code)    ; A shortform save-code that can be used to query for a hash-code
+                   (seq hash-code)    (boot-flow-hash-state hash-code)    ; A hash-code that can be decoded into th DB's initial state
+                   (seq seamap-app-state) (boot-flow-hash-state seamap-app-state) ; Same as hash-code, except that we use the one stored in local storage
+                   :else              (boot-flow))}))                      ; No information, so we start with an empty DB
 
 (defn merge-state
   "Takes a hash-code and merges it into the current application state."

--- a/frontend/src/cljs/imas_seamap/futuresofseafood/core.cljs
+++ b/frontend/src/cljs/imas_seamap/futuresofseafood/core.cljs
@@ -21,6 +21,8 @@
             [imas-seamap.map.subs :as msubs]
             [imas-seamap.protocols]
             [imas-seamap.subs :as subs]
+            [imas-seamap.subs.features]  ;; Phase 2: Feature flag subscriptions
+            [imas-seamap.subs.branding]  ;; Phase 2: Branding subscriptions
             [imas-seamap.futuresofseafood.views :as views]
             [imas-seamap.config :as config]
             [imas-seamap.components :as components]))

--- a/frontend/src/cljs/imas_seamap/futuresofseafood/views.cljs
+++ b/frontend/src/cljs/imas_seamap/futuresofseafood/views.cljs
@@ -44,7 +44,7 @@
         :class "catalogue"
         :title (reagent/as-element
                 [b/tooltip {:content "All available map layers"} "Catalogue"])
-        :panel (reagent/as-element [views/left-drawer-catalogue false])}]
+        :panel (reagent/as-element [views/left-drawer-catalogue])}]
 
       [b/tab
        {:id    "active-layers"
@@ -53,7 +53,7 @@
                  [:<> "Active Layers"
                   (when (seq active-layers)
                     [:div.notification-bubble (count active-layers)])]])
-        :panel (reagent/as-element [views/left-drawer-active-layers false])}]]]))
+        :panel (reagent/as-element [views/left-drawer-active-layers])}]]]))
 
 
 (defn layout-app []

--- a/frontend/src/cljs/imas_seamap/futuresofseafood/views.cljs
+++ b/frontend/src/cljs/imas_seamap/futuresofseafood/views.cljs
@@ -67,7 +67,7 @@
         catalogue-open?    @(re-frame/subscribe [:left-drawer/open?])
         right-drawer-open? (seq @(re-frame/subscribe [:ui/right-sidebar]))
         loading?           @(re-frame/subscribe [:app/loading?])
-        has-layer-preview? @(re-frame/subscribe [:feature/enabled? :layer-preview])]
+        has-layer-preview? @(re-frame/subscribe [:feature/enabled? :feature/layer-preview])]
     [:div#main-wrapper.futures-of-seafood ;{:on-key-down handle-keydown :on-key-up handle-keyup}
      {:class (str (when catalogue-open? " catalogue-open") (when right-drawer-open? " right-drawer-open") (when loading? " loading"))}
      [:div#content-wrapper

--- a/frontend/src/cljs/imas_seamap/futuresofseafood/views.cljs
+++ b/frontend/src/cljs/imas_seamap/futuresofseafood/views.cljs
@@ -14,13 +14,17 @@
 (defn left-drawer []
   (let [open? @(re-frame/subscribe [:left-drawer/open?])
         tab   @(re-frame/subscribe [:left-drawer/tab])
-        {:keys [active-layers]} @(re-frame/subscribe [:map/layers])]
+        {:keys [active-layers]} @(re-frame/subscribe [:map/layers])
+        ;; Use branding subscriptions instead of hard-coded values
+        logo @(re-frame/subscribe [:branding/logo])
+        brand-url @(re-frame/subscribe [:branding/url])
+        drawer-class @(re-frame/subscribe [:branding/drawer-class])]
     [components/drawer
      {:title
       [:<>
        [:div
-        [:a {:href "https://futuresofseafood.com.au/"}
-         [:img {:src "img/Futures-of-Seafood-Logo-Reverse-400x218.png"}]]]
+        [:a {:href brand-url}
+         [:img {:src (:src logo) :alt (:alt logo)}]]]
        [b/button
         {:icon     "double-chevron-left"
          :minimal  true
@@ -29,7 +33,7 @@
       :size        "368px"
       :isOpen      open?
       :onClose     #(re-frame/dispatch [:left-drawer/close])
-      :className   "left-drawer fos-drawer"
+      :className   (str "left-drawer " drawer-class)
       :isCloseButtonShown false
       :hasBackdrop false}
      [b/tabs

--- a/frontend/src/cljs/imas_seamap/futuresofseafood/views.cljs
+++ b/frontend/src/cljs/imas_seamap/futuresofseafood/views.cljs
@@ -66,7 +66,8 @@
         _ #_{:keys [handle-keydown handle-keyup]} (use-hotkeys hot-keys)
         catalogue-open?    @(re-frame/subscribe [:left-drawer/open?])
         right-drawer-open? (seq @(re-frame/subscribe [:ui/right-sidebar]))
-        loading?           @(re-frame/subscribe [:app/loading?])]
+        loading?           @(re-frame/subscribe [:app/loading?])
+        has-layer-preview? @(re-frame/subscribe [:feature/enabled? :layer-preview])]
     [:div#main-wrapper.futures-of-seafood ;{:on-key-down handle-keydown :on-key-up handle-keyup}
      {:class (str (when catalogue-open? " catalogue-open") (when right-drawer-open? " right-drawer-open") (when loading? " loading"))}
      [:div#content-wrapper
@@ -111,4 +112,5 @@
      [:div.custom-leaflet-controls.leaflet-top.leaflet-right.leaflet-touch
       {:style {:font "12px/1.5 \"Helvetica Neue\", Arial, Helvetica, sans-serif"}} ; font style for Leaflet map-component - needs to be inherited into custom controls
       [views/layers-control]]
-     [views/layer-preview @(re-frame/subscribe [:ui/preview-layer-url])]]))
+     (when has-layer-preview?
+       [views/layer-preview @(re-frame/subscribe [:ui/preview-layer-url])])]))

--- a/frontend/src/cljs/imas_seamap/interop/leaflet.cljs
+++ b/frontend/src/cljs/imas_seamap/interop/leaflet.cljs
@@ -51,6 +51,16 @@
        :origin     #js[-30635955.4472718 30635955.4472718]
        :bounds     (L/bounds #js[-4898635.244666547 -4903364.755333453] #js[4898864.755333463 4898864.755333455])}))
 
+(defn crs-from-keyword
+  "Convert a CRS keyword (e.g., :epsg-3857, :epsg-3031) to a Leaflet CRS object"
+  [crs-kw]
+  (case crs-kw
+    :epsg-4326 crs-epsg4326
+    :epsg-3857 crs-epsg3857
+    :epsg-3031 crs-epsg3031
+    ;; Default to EPSG:3857 if unknown
+    crs-epsg3857))
+
 (def tile-layer          (r/adapt-react-class ReactLeaflet/TileLayer))
 ;; (def wms-layer           (r/adapt-react-class ReactLeaflet/WMSTileLayer))
 (def wms-layer           (r/adapt-react-class

--- a/frontend/src/cljs/imas_seamap/map/layer_views.cljs
+++ b/frontend/src/cljs/imas_seamap/map/layer_views.cljs
@@ -5,6 +5,7 @@
             [imas-seamap.components :as components]
             [clojure.string :as string]
             [imas-seamap.utils :refer [first-where round-to-nearest]]
+            [imas-seamap.subs.features]  ; Phase 3: feature flag subscriptions
             #_[debux.cs.core :refer [dbg] :include-macros true]))
 
 (defn- layer-status-icons
@@ -139,23 +140,24 @@
 (defn- layer-card-controls
   "To the right of the layer name. Basic controls for the layer, like getting info
    and disabling the layer."
-  [{:keys [layer tma?] {:keys [visible?]} :layer-state}]
-  [:div.layer-controls
-   
-   [layer-card-control
-    {:tooltip  (if visible? "Hide layer" "Show layer")
-     :icon     (if visible? "eye-on" "eye-off")
-     :on-click #(re-frame/dispatch [:map/toggle-layer-visibility layer])}]
-   
-   [layer-card-control
-    {:tooltip  (if tma? "Layer info" "Layer info / Download data")
-     :icon     "info-sign"
-     :on-click #(re-frame/dispatch [:map.layer/show-info layer])}]
+  [{:keys [layer] {:keys [visible?]} :layer-state}]
+  (let [layer-info-label @(re-frame/subscribe [:branding/label :layer-info])]
+    [:div.layer-controls
 
-   [layer-card-control
-    {:tooltip  "Zoom to layer"
-     :icon     "locate"
-     :on-click #(re-frame/dispatch [:map/pan-to-layer layer])}]])
+     [layer-card-control
+      {:tooltip  (if visible? "Hide layer" "Show layer")
+       :icon     (if visible? "eye-on" "eye-off")
+       :on-click #(re-frame/dispatch [:map/toggle-layer-visibility layer])}]
+
+     [layer-card-control
+      {:tooltip  (or layer-info-label "Layer info")
+       :icon     "info-sign"
+       :on-click #(re-frame/dispatch [:map.layer/show-info layer])}]
+
+     [layer-card-control
+      {:tooltip  "Zoom to layer"
+       :icon     "locate"
+       :on-click #(re-frame/dispatch [:map/pan-to-layer layer])}]]))
 
 (defn- opacity-slider
   [{:keys [layer] {:keys [opacity]} :layer-state}]
@@ -455,31 +457,32 @@
   "To the right of the layer name. Basic controls for the layer, like getting info
    and enabling/disabling the layer. Differs from layer-card-controls in what
    controls are displayed."
-  [{:keys [layer tma?]
+  [{:keys [layer]
     {{:keys [icon tooltip] :as rich-layer} :rich-layer} :layer-state}]
-  [:div.layer-controls
+  (let [layer-info-label @(re-frame/subscribe [:branding/label :layer-info])]
+    [:div.layer-controls
 
-   (when rich-layer
+     (when rich-layer
+       [layer-control
+        {:tooltip  tooltip
+         :icon     icon
+         :on-click #(re-frame/dispatch [:map.rich-layer/configure rich-layer])}])
+
      [layer-control
-      {:tooltip  tooltip
-       :icon     icon
-       :on-click #(re-frame/dispatch [:map.rich-layer/configure rich-layer])}])
+      {:tooltip  (or layer-info-label "Layer info")
+       :icon     "info-sign"
+       :on-click #(re-frame/dispatch [:map.layer/show-info layer])}]
 
-   [layer-control
-    {:tooltip  (if tma? "Layer info" "Layer info / Download data")
-     :icon     "info-sign"
-     :on-click #(re-frame/dispatch [:map.layer/show-info layer])}]
-
-   [layer-control
-    {:tooltip  "Zoom to layer"
-     :icon     "locate"
-     :on-click #(re-frame/dispatch [:map/pan-to-layer layer])}]])
+     [layer-control
+      {:tooltip  "Zoom to layer"
+       :icon     "locate"
+       :on-click #(re-frame/dispatch [:map/pan-to-layer layer])}]]))
 
 (defn layer-catalogue-header
   "Top part of layer catalogue element. Always visible. Contains the layer status,
    name, and basic controls for the layer. Differs from layer-card-header in what
    controls are displayed."
-  [{:keys [layer _tma?] {:keys [active? visible?] :as layer-state} :layer-state :as props}]
+  [{:keys [layer] {:keys [active? visible?] :as layer-state} :layer-state :as props}]
   [:div.layer-header
    [b/tooltip {:content (if active? "Deactivate layer" "Activate layer")}
     [b/checkbox
@@ -493,7 +496,7 @@
 (defn layer-catalogue-node
   [{{:keys [active-layers visible-layers loading-fn expanded-fn error-fn opacity-fn rich-layer-fn]} :layer-props
     {:keys [tooltip] :as layer} :layer
-    :keys [id tma?]}]
+    :keys [id]}]
   (let [active? (some #{layer} active-layers)
         {:keys [alternate-views-selected timeline-selected] :as rich-layer} (rich-layer-fn layer)
         layer-state
@@ -510,4 +513,4 @@
                  (when active? " active-layer")
                  (when (or (seq tooltip) alternate-views-selected timeline-selected) " has-tooltip"))
      :nodeData  {:previewLayer layer}
-     :label     (reagent/as-element [layer-catalogue-header {:layer layer :layer-state layer-state :tma? tma?}])}))
+     :label     (reagent/as-element [layer-catalogue-header {:layer layer :layer-state layer-state}])}))

--- a/frontend/src/cljs/imas_seamap/map/views.cljs
+++ b/frontend/src/cljs/imas_seamap/map/views.cljs
@@ -327,7 +327,10 @@
         {:keys [query mouse-loc distance] :as transect-info} @(re-frame/subscribe [:transect/info])
         {:keys [region] :as region-info}              @(re-frame/subscribe [:map.layer.selection/info])
         download-info                                 @(re-frame/subscribe [:download/info])
-        boundary-filter                               @(re-frame/subscribe [:sok/boundary-layer-filter])
+        ;; Only subscribe to boundary-filter if state-of-knowledge feature is enabled
+        has-sok?                                      @(re-frame/subscribe [:feature/enabled? :state-of-knowledge])
+        boundary-filter                               (when has-sok?
+                                                        @(re-frame/subscribe [:sok/boundary-layer-filter]))
         mouse-pos                                     @(re-frame/subscribe [:ui/mouse-pos])]
     (into
      [:div.map-wrapper

--- a/frontend/src/cljs/imas_seamap/map/views.cljs
+++ b/frontend/src/cljs/imas_seamap/map/views.cljs
@@ -328,7 +328,7 @@
         {:keys [region] :as region-info}              @(re-frame/subscribe [:map.layer.selection/info])
         download-info                                 @(re-frame/subscribe [:download/info])
         ;; Only subscribe to boundary-filter if state-of-knowledge feature is enabled
-        has-sok?                                      @(re-frame/subscribe [:feature/enabled? :state-of-knowledge])
+        has-sok?                                      @(re-frame/subscribe [:feature/enabled? :feature/state-of-knowledge])
         boundary-filter                               (when has-sok?
                                                         @(re-frame/subscribe [:sok/boundary-layer-filter]))
         mouse-pos                                     @(re-frame/subscribe [:ui/mouse-pos])]

--- a/frontend/src/cljs/imas_seamap/map/views.cljs
+++ b/frontend/src/cljs/imas_seamap/map/views.cljs
@@ -320,7 +320,7 @@
     :useGetCapabilities true}])
 
 (defn map-component [& children]
-  (let [{:keys [center zoom bounds]}                  @(re-frame/subscribe [:map/props])
+  (let [{:keys [center zoom bounds crs]} @(re-frame/subscribe [:map/props])
         {:keys [layer-opacities visible-layers rich-layer-fn cql-filter-fn]} @(re-frame/subscribe [:map/layers])
         {:keys [grouped-base-layers active-base-layer]} @(re-frame/subscribe [:map/base-layers])
         feature-info                                  @(re-frame/subscribe [:map.feature/info])
@@ -335,7 +335,9 @@
       [leaflet/map-container
        (merge
         {:id                   "map"
-         :crs                  leaflet/crs-epsg3857
+         :crs                  (if crs
+                                  (leaflet/crs-from-keyword crs)
+                                  leaflet/crs-epsg3857)
          :preferCanvas         true
          :use-fly-to           false
          :center               center

--- a/frontend/src/cljs/imas_seamap/seamap_antarctica/core.cljs
+++ b/frontend/src/cljs/imas_seamap/seamap_antarctica/core.cljs
@@ -25,6 +25,8 @@
             [imas-seamap.story-maps.subs :as smsubs]
             [imas-seamap.protocols]
             [imas-seamap.subs :as subs]
+            [imas-seamap.subs.features]  ;; Phase 2: Feature flag subscriptions
+            [imas-seamap.subs.branding]  ;; Phase 2: Branding subscriptions
             [imas-seamap.seamap-antarctica.views :as views]
             [imas-seamap.config :as config]
             [imas-seamap.components :as components]))

--- a/frontend/src/cljs/imas_seamap/seamap_antarctica/map/views.cljs
+++ b/frontend/src/cljs/imas_seamap/seamap_antarctica/map/views.cljs
@@ -21,7 +21,7 @@
         {:keys [region] :as region-info}              @(re-frame/subscribe [:map.layer.selection/info])
         download-info                                 @(re-frame/subscribe [:download/info])
         ;; Only subscribe to boundary-filter if state-of-knowledge feature is enabled
-        has-sok?                                      @(re-frame/subscribe [:feature/enabled? :state-of-knowledge])
+        has-sok?                                      @(re-frame/subscribe [:feature/enabled? :feature/state-of-knowledge])
         boundary-filter                               (when has-sok?
                                                         @(re-frame/subscribe [:sok/boundary-layer-filter]))
         mouse-pos                                     @(re-frame/subscribe [:ui/mouse-pos])]

--- a/frontend/src/cljs/imas_seamap/seamap_antarctica/map/views.cljs
+++ b/frontend/src/cljs/imas_seamap/seamap_antarctica/map/views.cljs
@@ -20,7 +20,10 @@
         {:keys [query mouse-loc distance] :as transect-info} @(re-frame/subscribe [:transect/info])
         {:keys [region] :as region-info}              @(re-frame/subscribe [:map.layer.selection/info])
         download-info                                 @(re-frame/subscribe [:download/info])
-        boundary-filter                               @(re-frame/subscribe [:sok/boundary-layer-filter])
+        ;; Only subscribe to boundary-filter if state-of-knowledge feature is enabled
+        has-sok?                                      @(re-frame/subscribe [:feature/enabled? :state-of-knowledge])
+        boundary-filter                               (when has-sok?
+                                                        @(re-frame/subscribe [:sok/boundary-layer-filter]))
         mouse-pos                                     @(re-frame/subscribe [:ui/mouse-pos])]
     (into
      [:div.map-wrapper

--- a/frontend/src/cljs/imas_seamap/seamap_antarctica/views.cljs
+++ b/frontend/src/cljs/imas_seamap/seamap_antarctica/views.cljs
@@ -46,7 +46,7 @@
         :class "catalogue"
         :title (reagent/as-element
                 [b/tooltip {:content "All available map layers"} "Catalogue"])
-        :panel (reagent/as-element [views/left-drawer-catalogue false])}]
+        :panel (reagent/as-element [views/left-drawer-catalogue])}]
 
       [b/tab
        {:id    "active-layers"
@@ -55,7 +55,7 @@
                  [:<> "Active Layers"
                   (when (seq active-layers)
                     [:div.notification-bubble (count active-layers)])]])
-        :panel (reagent/as-element [views/left-drawer-active-layers false])}]
+        :panel (reagent/as-element [views/left-drawer-active-layers])}]
 
       [b/tab
        {:id    "featured-maps"

--- a/frontend/src/cljs/imas_seamap/seamap_antarctica/views.cljs
+++ b/frontend/src/cljs/imas_seamap/seamap_antarctica/views.cljs
@@ -74,7 +74,7 @@
         catalogue-open?    @(re-frame/subscribe [:left-drawer/open?])
         right-drawer-open? (seq @(re-frame/subscribe [:ui/right-sidebar]))
         loading?           @(re-frame/subscribe [:app/loading?])
-        has-layer-preview? @(re-frame/subscribe [:feature/enabled? :layer-preview])]
+        has-layer-preview? @(re-frame/subscribe [:feature/enabled? :feature/layer-preview])]
     [:div#main-wrapper.seamap ;{:on-key-down handle-keydown :on-key-up handle-keyup}
      {:class (str (when catalogue-open? " catalogue-open") (when right-drawer-open? " right-drawer-open") (when loading? " loading"))}
      [:div#content-wrapper

--- a/frontend/src/cljs/imas_seamap/seamap_antarctica/views.cljs
+++ b/frontend/src/cljs/imas_seamap/seamap_antarctica/views.cljs
@@ -73,7 +73,8 @@
         _ #_{:keys [handle-keydown handle-keyup]} (use-hotkeys hot-keys)
         catalogue-open?    @(re-frame/subscribe [:left-drawer/open?])
         right-drawer-open? (seq @(re-frame/subscribe [:ui/right-sidebar]))
-        loading?           @(re-frame/subscribe [:app/loading?])]
+        loading?           @(re-frame/subscribe [:app/loading?])
+        has-layer-preview? @(re-frame/subscribe [:feature/enabled? :layer-preview])]
     [:div#main-wrapper.seamap ;{:on-key-down handle-keydown :on-key-up handle-keyup}
      {:class (str (when catalogue-open? " catalogue-open") (when right-drawer-open? " right-drawer-open") (when loading? " loading"))}
      [:div#content-wrapper
@@ -121,4 +122,6 @@
       [views/layers-control]]
      ;; Definitely no state-of-knowledge, and probably no generic pills for now at least:
      ;; [views/floating-pills]
-     [views/layer-preview @(re-frame/subscribe [:ui/preview-layer-url])]]))
+     (when has-layer-preview?
+       [views/layer-preview @(re-frame/subscribe [:ui/preview-layer-url])])]))
+

--- a/frontend/src/cljs/imas_seamap/seamap_antarctica/views.cljs
+++ b/frontend/src/cljs/imas_seamap/seamap_antarctica/views.cljs
@@ -16,13 +16,17 @@
 (defn left-drawer []
   (let [open? @(re-frame/subscribe [:left-drawer/open?])
         tab   @(re-frame/subscribe [:left-drawer/tab])
-        {:keys [active-layers]} @(re-frame/subscribe [:map/layers])]
+        {:keys [active-layers]} @(re-frame/subscribe [:map/layers])
+        ;; Use branding subscriptions instead of hard-coded values
+        logo @(re-frame/subscribe [:branding/logo])
+        brand-url @(re-frame/subscribe [:branding/url])
+        drawer-class @(re-frame/subscribe [:branding/drawer-class])]
     [components/drawer
      {:title
       [:<>
        [:div
-        [:a {:href "https://seamapantarctica-dev.imas.utas.edu.au/"} ; TODO: Replace with the URL for Seamap Antarctica production
-         [:img {:src "img/SeaMapAntarctica_Logo_RGB_1000px.png"}]]]
+        [:a {:href brand-url}
+         [:img {:src (:src logo) :alt (:alt logo)}]]]
        [b/button
         {:icon     "double-chevron-left"
          :minimal  true
@@ -31,7 +35,7 @@
       :size        "368px"
       :isOpen      open?
       :onClose     #(re-frame/dispatch [:left-drawer/close])
-      :className   "left-drawer seamap-drawer"
+      :className   (str "left-drawer " drawer-class)
       :isCloseButtonShown false
       :hasBackdrop false}
      [b/tabs

--- a/frontend/src/cljs/imas_seamap/subs/branding.cljs
+++ b/frontend/src/cljs/imas_seamap/subs/branding.cljs
@@ -13,30 +13,30 @@
 ;;; BRANDING CONFIG SUBSCRIPTIONS
 ;;; =============================================================================
 
+;; Returns the complete branding configuration for the current deployment.
 (re-frame/reg-sub
  :branding/config
- "Returns the complete branding configuration for the current deployment."
  :<- [:deployment/config]
  (fn [config _]
    (:branding config)))
 
+;; Returns the logo configuration (src, alt, height).
 (re-frame/reg-sub
  :branding/logo
- "Returns the logo configuration (src, alt, height)."
  :<- [:branding/config]
  (fn [branding _]
    (:logo branding)))
 
+;; Returns the main website URL for the deployment.
 (re-frame/reg-sub
  :branding/url
- "Returns the main website URL for the deployment."
  :<- [:branding/config]
  (fn [branding _]
    (:url branding)))
 
+;; Returns the deployment title.
 (re-frame/reg-sub
  :branding/title
- "Returns the deployment title."
  :<- [:branding/config]
  (fn [branding _]
    (:title branding)))
@@ -45,21 +45,21 @@
 ;;; LABEL SUBSCRIPTIONS
 ;;; =============================================================================
 
+;; Get a deployment-specific label by key.
+;;
+;; Usage:
+;;   @(re-frame/subscribe [:branding/label :region-control])
+;;   => "Find Data in Region" (for TMA)
+;;   => "Select region" (for Australia)
 (re-frame/reg-sub
  :branding/label
- "Get a deployment-specific label by key.
-
-  Usage:
-    @(re-frame/subscribe [:branding/label :region-control])
-    => 'Find Data in Region' (for TMA)
-    => 'Select region' (for Australia)"
  :<- [:branding/config]
  (fn [branding [_ label-key]]
    (get-in branding [:labels label-key])))
 
+;; Returns all labels for the deployment.
 (re-frame/reg-sub
  :branding/labels
- "Returns all labels for the deployment."
  :<- [:branding/config]
  (fn [branding _]
    (:labels branding)))
@@ -68,24 +68,24 @@
 ;;; COLOR SUBSCRIPTIONS
 ;;; =============================================================================
 
+;; Returns the color overrides for the deployment.
+;; Used to generate CSS custom properties.
 (re-frame/reg-sub
  :branding/colors
- "Returns the color overrides for the deployment.
-  Used to generate CSS custom properties."
  :<- [:deployment/config]
  (fn [config _]
    (:colors config)))
 
+;; Returns the CSS class for the deployment (e.g., "seamap", "tas-marine-atlas").
 (re-frame/reg-sub
  :branding/css-class
- "Returns the CSS class for the deployment (e.g., 'seamap', 'tas-marine-atlas')."
  :<- [:deployment/config]
  (fn [config _]
    (:css-class config)))
 
+;; Returns the drawer CSS class for the deployment.
 (re-frame/reg-sub
  :branding/drawer-class
- "Returns the drawer CSS class for the deployment."
  :<- [:deployment/config]
  (fn [config _]
    (:drawer-class config)))
@@ -94,18 +94,18 @@
 ;;; WELCOME CONTENT SUBSCRIPTIONS
 ;;; =============================================================================
 
+;; Returns the welcome dialogue configuration.
+;; Includes title and content (which may be a keyword or hiccup).
 (re-frame/reg-sub
  :branding/welcome
- "Returns the welcome dialogue configuration.
-  Includes title and content (which may be a keyword or hiccup)."
  :<- [:branding/config]
  (fn [branding _]
    (:welcome branding)))
 
+;; Returns the resolved welcome content (hiccup).
+;; If content is a keyword, looks it up in the content registry.
 (re-frame/reg-sub
  :branding/welcome-content
- "Returns the resolved welcome content (hiccup).
-  If content is a keyword, looks it up in the content registry."
  :<- [:branding/welcome]
  (fn [welcome _]
    (let [content (:content welcome)]
@@ -113,9 +113,9 @@
        (content/get-content content)
        content))))
 
+;; Returns the welcome dialogue title.
 (re-frame/reg-sub
  :branding/welcome-title
- "Returns the welcome dialogue title."
  :<- [:branding/welcome]
  (fn [welcome _]
    (:title welcome)))
@@ -124,21 +124,21 @@
 ;;; LINKS SUBSCRIPTIONS
 ;;; =============================================================================
 
+;; Get a deployment-specific external link by key.
+;;
+;; Usage:
+;;   @(re-frame/subscribe [:branding/link :sea-country])
+;;   => "https://storymaps.arcgis.com/..." (for TMA)
+;;   => nil (for other deployments)
 (re-frame/reg-sub
  :branding/link
- "Get a deployment-specific external link by key.
-
-  Usage:
-    @(re-frame/subscribe [:branding/link :sea-country])
-    => 'https://storymaps.arcgis.com/...' (for TMA)
-    => nil (for other deployments)"
  :<- [:branding/config]
  (fn [branding [_ link-key]]
    (get-in branding [:links link-key])))
 
+;; Returns all external links for the deployment.
 (re-frame/reg-sub
  :branding/links
- "Returns all external links for the deployment."
  :<- [:branding/config]
  (fn [branding _]
    (:links branding)))
@@ -147,30 +147,30 @@
 ;;; MAP CONFIG SUBSCRIPTIONS
 ;;; =============================================================================
 
+;; Returns the map configuration (CRS, center, zoom).
 (re-frame/reg-sub
  :map/config
- "Returns the map configuration (CRS, center, zoom)."
  :<- [:deployment/config]
  (fn [config _]
    (:map config)))
 
+;; Returns the map CRS for the deployment.
 (re-frame/reg-sub
  :map/crs
- "Returns the map CRS for the deployment."
  :<- [:map/config]
  (fn [map-config _]
    (:crs map-config)))
 
+;; Returns the initial map center coordinates.
 (re-frame/reg-sub
  :map/initial-center
- "Returns the initial map center coordinates."
  :<- [:map/config]
  (fn [map-config _]
    (:center map-config)))
 
+;; Returns the initial map zoom level.
 (re-frame/reg-sub
  :map/initial-zoom
- "Returns the initial map zoom level."
  :<- [:map/config]
  (fn [map-config _]
    (:zoom map-config)))
@@ -179,23 +179,23 @@
 ;;; UI LAYOUT SUBSCRIPTIONS
 ;;; =============================================================================
 
+;; Returns the ordered list of left drawer tabs for the deployment.
 (re-frame/reg-sub
  :ui/tabs
- "Returns the ordered list of left drawer tabs for the deployment."
  :<- [:deployment/config]
  (fn [config _]
    (:tabs config)))
 
+;; Returns the ordered list of map controls for the deployment.
 (re-frame/reg-sub
  :ui/controls
- "Returns the ordered list of map controls for the deployment."
  :<- [:deployment/config]
  (fn [config _]
    (:controls config)))
 
+;; Returns the right drawer slot mappings for the deployment.
 (re-frame/reg-sub
  :ui/drawers
- "Returns the right drawer slot mappings for the deployment."
  :<- [:deployment/config]
  (fn [config _]
    (:drawers config)))

--- a/frontend/src/cljs/imas_seamap/subs/branding.cljs
+++ b/frontend/src/cljs/imas_seamap/subs/branding.cljs
@@ -1,0 +1,201 @@
+;;; Seamap: view and interact with Australian coastal habitat data
+;;; Copyright (c) 2017, Institute of Marine & Antarctic Studies.  Written by Condense Pty Ltd.
+;;; Released under the Affero General Public Licence (AGPL) v3.  See LICENSE file for details.
+(ns imas-seamap.subs.branding
+  "Branding subscriptions for deployment-specific UI elements.
+
+   These subscriptions provide access to deployment-specific branding:
+   logos, colors, labels, welcome content, etc."
+  (:require [re-frame.core :as re-frame]
+            [imas-seamap.config.content :as content]))
+
+;;; =============================================================================
+;;; BRANDING CONFIG SUBSCRIPTIONS
+;;; =============================================================================
+
+(re-frame/reg-sub
+ :branding/config
+ "Returns the complete branding configuration for the current deployment."
+ :<- [:deployment/config]
+ (fn [config _]
+   (:branding config)))
+
+(re-frame/reg-sub
+ :branding/logo
+ "Returns the logo configuration (src, alt, height)."
+ :<- [:branding/config]
+ (fn [branding _]
+   (:logo branding)))
+
+(re-frame/reg-sub
+ :branding/url
+ "Returns the main website URL for the deployment."
+ :<- [:branding/config]
+ (fn [branding _]
+   (:url branding)))
+
+(re-frame/reg-sub
+ :branding/title
+ "Returns the deployment title."
+ :<- [:branding/config]
+ (fn [branding _]
+   (:title branding)))
+
+;;; =============================================================================
+;;; LABEL SUBSCRIPTIONS
+;;; =============================================================================
+
+(re-frame/reg-sub
+ :branding/label
+ "Get a deployment-specific label by key.
+
+  Usage:
+    @(re-frame/subscribe [:branding/label :region-control])
+    => 'Find Data in Region' (for TMA)
+    => 'Select region' (for Australia)"
+ :<- [:branding/config]
+ (fn [branding [_ label-key]]
+   (get-in branding [:labels label-key])))
+
+(re-frame/reg-sub
+ :branding/labels
+ "Returns all labels for the deployment."
+ :<- [:branding/config]
+ (fn [branding _]
+   (:labels branding)))
+
+;;; =============================================================================
+;;; COLOR SUBSCRIPTIONS
+;;; =============================================================================
+
+(re-frame/reg-sub
+ :branding/colors
+ "Returns the color overrides for the deployment.
+  Used to generate CSS custom properties."
+ :<- [:deployment/config]
+ (fn [config _]
+   (:colors config)))
+
+(re-frame/reg-sub
+ :branding/css-class
+ "Returns the CSS class for the deployment (e.g., 'seamap', 'tas-marine-atlas')."
+ :<- [:deployment/config]
+ (fn [config _]
+   (:css-class config)))
+
+(re-frame/reg-sub
+ :branding/drawer-class
+ "Returns the drawer CSS class for the deployment."
+ :<- [:deployment/config]
+ (fn [config _]
+   (:drawer-class config)))
+
+;;; =============================================================================
+;;; WELCOME CONTENT SUBSCRIPTIONS
+;;; =============================================================================
+
+(re-frame/reg-sub
+ :branding/welcome
+ "Returns the welcome dialogue configuration.
+  Includes title and content (which may be a keyword or hiccup)."
+ :<- [:branding/config]
+ (fn [branding _]
+   (:welcome branding)))
+
+(re-frame/reg-sub
+ :branding/welcome-content
+ "Returns the resolved welcome content (hiccup).
+  If content is a keyword, looks it up in the content registry."
+ :<- [:branding/welcome]
+ (fn [welcome _]
+   (let [content (:content welcome)]
+     (if (keyword? content)
+       (content/get-content content)
+       content))))
+
+(re-frame/reg-sub
+ :branding/welcome-title
+ "Returns the welcome dialogue title."
+ :<- [:branding/welcome]
+ (fn [welcome _]
+   (:title welcome)))
+
+;;; =============================================================================
+;;; LINKS SUBSCRIPTIONS
+;;; =============================================================================
+
+(re-frame/reg-sub
+ :branding/link
+ "Get a deployment-specific external link by key.
+
+  Usage:
+    @(re-frame/subscribe [:branding/link :sea-country])
+    => 'https://storymaps.arcgis.com/...' (for TMA)
+    => nil (for other deployments)"
+ :<- [:branding/config]
+ (fn [branding [_ link-key]]
+   (get-in branding [:links link-key])))
+
+(re-frame/reg-sub
+ :branding/links
+ "Returns all external links for the deployment."
+ :<- [:branding/config]
+ (fn [branding _]
+   (:links branding)))
+
+;;; =============================================================================
+;;; MAP CONFIG SUBSCRIPTIONS
+;;; =============================================================================
+
+(re-frame/reg-sub
+ :map/config
+ "Returns the map configuration (CRS, center, zoom)."
+ :<- [:deployment/config]
+ (fn [config _]
+   (:map config)))
+
+(re-frame/reg-sub
+ :map/crs
+ "Returns the map CRS for the deployment."
+ :<- [:map/config]
+ (fn [map-config _]
+   (:crs map-config)))
+
+(re-frame/reg-sub
+ :map/initial-center
+ "Returns the initial map center coordinates."
+ :<- [:map/config]
+ (fn [map-config _]
+   (:center map-config)))
+
+(re-frame/reg-sub
+ :map/initial-zoom
+ "Returns the initial map zoom level."
+ :<- [:map/config]
+ (fn [map-config _]
+   (:zoom map-config)))
+
+;;; =============================================================================
+;;; UI LAYOUT SUBSCRIPTIONS
+;;; =============================================================================
+
+(re-frame/reg-sub
+ :ui/tabs
+ "Returns the ordered list of left drawer tabs for the deployment."
+ :<- [:deployment/config]
+ (fn [config _]
+   (:tabs config)))
+
+(re-frame/reg-sub
+ :ui/controls
+ "Returns the ordered list of map controls for the deployment."
+ :<- [:deployment/config]
+ (fn [config _]
+   (:controls config)))
+
+(re-frame/reg-sub
+ :ui/drawers
+ "Returns the right drawer slot mappings for the deployment."
+ :<- [:deployment/config]
+ (fn [config _]
+   (:drawers config)))

--- a/frontend/src/cljs/imas_seamap/subs/branding.cljs
+++ b/frontend/src/cljs/imas_seamap/subs/branding.cljs
@@ -199,3 +199,10 @@
  :<- [:deployment/config]
  (fn [config _]
    (:drawers config)))
+
+;; Returns the complete layout configuration for the deployment (Phase 4).
+(re-frame/reg-sub
+ :layout/config
+ :<- [:deployment/config]
+ (fn [config _]
+   (:layout config)))

--- a/frontend/src/cljs/imas_seamap/subs/features.cljs
+++ b/frontend/src/cljs/imas_seamap/subs/features.cljs
@@ -34,7 +34,7 @@
 ;; Check if a specific feature is enabled for the current deployment.
 ;;
 ;; Usage in components:
-;;   (let [has-sok? @(re-frame/subscribe [:feature/enabled? :state-of-knowledge])]
+;;   (let [has-sok? @(re-frame/subscribe [:feature/enabled? :feature/state-of-knowledge])]
 ;;     (when has-sok?
 ;;       [state-of-knowledge-panel]))
 ;;

--- a/frontend/src/cljs/imas_seamap/subs/features.cljs
+++ b/frontend/src/cljs/imas_seamap/subs/features.cljs
@@ -13,16 +13,16 @@
 ;;; DEPLOYMENT CONFIG SUBSCRIPTIONS
 ;;; =============================================================================
 
+;; Returns the complete deployment configuration from app-db.
+;; This includes all settings: features, branding, map config, etc.
 (re-frame/reg-sub
  :deployment/config
- "Returns the complete deployment configuration from app-db.
-  This includes all settings: features, branding, map config, etc."
  (fn [db _]
    (get db :deployment-config)))
 
+;; Returns the current deployment ID (e.g., :seamap-australia)
 (re-frame/reg-sub
  :deployment/id
- "Returns the current deployment ID (e.g., :seamap-australia)"
  :<- [:deployment/config]
  (fn [config _]
    (:id config)))
@@ -31,36 +31,34 @@
 ;;; FEATURE FLAG SUBSCRIPTIONS
 ;;; =============================================================================
 
+;; Check if a specific feature is enabled for the current deployment.
+;;
+;; Usage in components:
+;;   (let [has-sok? @(re-frame/subscribe [:feature/enabled? :state-of-knowledge])]
+;;     (when has-sok?
+;;       [state-of-knowledge-panel]))
+;;
+;; Or using the helper function:
+;;   (when (feature? :state-of-knowledge)
+;;     [state-of-knowledge-panel])
 (re-frame/reg-sub
  :feature/enabled?
- "Check if a specific feature is enabled for the current deployment.
-
-  Usage in components:
-    (let [has-sok? @(re-frame/subscribe [:feature/enabled? :state-of-knowledge])]
-      (when has-sok?
-        [state-of-knowledge-panel]))
-
-  Or using the helper function:
-    (when (feature? :state-of-knowledge)
-      [state-of-knowledge-panel])"
  :<- [:deployment/config]
  (fn [config [_ feature-key]]
    (contains? (:features config) feature-key)))
 
+;; Returns the set of all enabled features for the current deployment.
+;; Useful for debugging or displaying feature information.
 (re-frame/reg-sub
  :feature/all
- "Returns the set of all enabled features for the current deployment.
-
-  Useful for debugging or displaying feature information."
  :<- [:deployment/config]
  (fn [config _]
    (:features config)))
 
+;; Check if a specific feature is disabled (inverse of :feature/enabled?).
+;; Convenience subscription for conditional logic.
 (re-frame/reg-sub
  :feature/disabled?
- "Check if a specific feature is disabled (inverse of :feature/enabled?).
-
-  Convenience subscription for conditional logic."
  :<- [:deployment/config]
  (fn [config [_ feature-key]]
    (not (contains? (:features config) feature-key))))

--- a/frontend/src/cljs/imas_seamap/subs/features.cljs
+++ b/frontend/src/cljs/imas_seamap/subs/features.cljs
@@ -1,0 +1,90 @@
+;;; Seamap: view and interact with Australian coastal habitat data
+;;; Copyright (c) 2017, Institute of Marine & Antarctic Studies.  Written by Condense Pty Ltd.
+;;; Released under the Affero General Public Licence (AGPL) v3.  See LICENSE file for details.
+(ns imas-seamap.subs.features
+  "Feature flag subscriptions for deployment-specific functionality.
+
+   These subscriptions provide a clean way to check which features are enabled
+   for the current deployment, eliminating the need to pass flags like `tma?`
+   through multiple component layers."
+  (:require [re-frame.core :as re-frame]))
+
+;;; =============================================================================
+;;; DEPLOYMENT CONFIG SUBSCRIPTIONS
+;;; =============================================================================
+
+(re-frame/reg-sub
+ :deployment/config
+ "Returns the complete deployment configuration from app-db.
+  This includes all settings: features, branding, map config, etc."
+ (fn [db _]
+   (get db :deployment-config)))
+
+(re-frame/reg-sub
+ :deployment/id
+ "Returns the current deployment ID (e.g., :seamap-australia)"
+ :<- [:deployment/config]
+ (fn [config _]
+   (:id config)))
+
+;;; =============================================================================
+;;; FEATURE FLAG SUBSCRIPTIONS
+;;; =============================================================================
+
+(re-frame/reg-sub
+ :feature/enabled?
+ "Check if a specific feature is enabled for the current deployment.
+
+  Usage in components:
+    (let [has-sok? @(re-frame/subscribe [:feature/enabled? :state-of-knowledge])]
+      (when has-sok?
+        [state-of-knowledge-panel]))
+
+  Or using the helper function:
+    (when (feature? :state-of-knowledge)
+      [state-of-knowledge-panel])"
+ :<- [:deployment/config]
+ (fn [config [_ feature-key]]
+   (contains? (:features config) feature-key)))
+
+(re-frame/reg-sub
+ :feature/all
+ "Returns the set of all enabled features for the current deployment.
+
+  Useful for debugging or displaying feature information."
+ :<- [:deployment/config]
+ (fn [config _]
+   (:features config)))
+
+(re-frame/reg-sub
+ :feature/disabled?
+ "Check if a specific feature is disabled (inverse of :feature/enabled?).
+
+  Convenience subscription for conditional logic."
+ :<- [:deployment/config]
+ (fn [config [_ feature-key]]
+   (not (contains? (:features config) feature-key))))
+
+;;; =============================================================================
+;;; HELPER FUNCTIONS (for use in components)
+;;; =============================================================================
+
+(defn feature?
+  "Convenience function to check if a feature is enabled.
+   Returns a boolean value immediately (derefs the subscription).
+
+  Usage:
+    (when (feature? :plot-component)
+      [plot-display])
+
+  This is cleaner than:
+    (when @(re-frame/subscribe [:feature/enabled? :plot-component])
+      [plot-display])"
+  [feature-key]
+  @(re-frame/subscribe [:feature/enabled? feature-key]))
+
+(defn features
+  "Returns the set of all enabled features.
+   Convenience function that derefs the subscription."
+  []
+  @(re-frame/subscribe [:feature/all]))

--- a/frontend/src/cljs/imas_seamap/tas_marine_atlas/core.cljs
+++ b/frontend/src/cljs/imas_seamap/tas_marine_atlas/core.cljs
@@ -22,6 +22,8 @@
             [imas-seamap.story-maps.subs :as smsubs]
             [imas-seamap.protocols]
             [imas-seamap.subs :as subs]
+            [imas-seamap.subs.features]  ;; Phase 2: Feature flag subscriptions
+            [imas-seamap.subs.branding]  ;; Phase 2: Branding subscriptions
             [imas-seamap.tas-marine-atlas.subs :as tmasubs]
             [imas-seamap.tas-marine-atlas.views :refer [layout-app]]
             [imas-seamap.config :as config]

--- a/frontend/src/cljs/imas_seamap/tas_marine_atlas/views.cljs
+++ b/frontend/src/cljs/imas_seamap/tas_marine_atlas/views.cljs
@@ -171,7 +171,7 @@
         :class "catalogue"
         :title (reagent/as-element
                 [b/tooltip {:content "All available map layers"} "Catalogue"])
-        :panel (reagent/as-element [left-drawer-catalogue true])}]
+        :panel (reagent/as-element [left-drawer-catalogue])}]
 
       [b/tab
        {:id    "active-layers"
@@ -180,7 +180,7 @@
                  [:<> "Active Layers"
                   (when (seq active-layers)
                     [:div.notification-bubble (count active-layers)])]])
-        :panel (reagent/as-element [left-drawer-active-layers true])}]
+        :panel (reagent/as-element [left-drawer-active-layers])}]
 
       [b/tab
        {:id    "featured-maps"

--- a/frontend/src/cljs/imas_seamap/tas_marine_atlas/views.cljs
+++ b/frontend/src/cljs/imas_seamap/tas_marine_atlas/views.cljs
@@ -145,18 +145,22 @@
 (defn- left-drawer []
   (let [open? @(re-frame/subscribe [:left-drawer/open?])
         tab   @(re-frame/subscribe [:left-drawer/tab])
-        {:keys [active-layers]} @(re-frame/subscribe [:map/layers])]
+        {:keys [active-layers]} @(re-frame/subscribe [:map/layers])
+        ;; Use branding subscriptions instead of hard-coded values
+        logo @(re-frame/subscribe [:branding/logo])
+        brand-url @(re-frame/subscribe [:branding/url])
+        drawer-class @(re-frame/subscribe [:branding/drawer-class])]
     [components/drawer
      {:title
       [:<>
        [:div
-        [:a {:href "https://tasmarineatlas.org/"}
-         [:img {:src "img/TMA_Banner_size_website.png"}]]]]
+        [:a {:href brand-url}
+         [:img {:src (:src logo) :alt (:alt logo)}]]]]
       :position    "left"
       :size        "368px"
       :isOpen      open?
       :onClose     #(re-frame/dispatch [:left-drawer/close])
-      :className   "left-drawer tas-marine-atlas-drawer"
+      :className   (str "left-drawer " drawer-class)
       :isCloseButtonShown false
       :hasBackdrop false}
      [b/tabs

--- a/frontend/src/cljs/imas_seamap/views.cljs
+++ b/frontend/src/cljs/imas_seamap/views.cljs
@@ -16,6 +16,7 @@
             [imas-seamap.components :as components]
             [imas-seamap.map.utils :refer [layer-search-keywords]]
             [imas-seamap.fx :refer [show-message]]
+            [imas-seamap.subs.features]  ; Phase 3: feature flag subscriptions
             [goog.string.format]
             #_[debux.cs.core :refer [dbg] :include-macros true]))
 
@@ -106,7 +107,7 @@
 (defn- layers->nodes
   "group-ordering is the category keys to order by, eg [:organisation :data_category]"
   [layers [ordering & ordering-remainder :as group-ordering] sorting-info expanded-states id-base
-   layer-props open-all? tma?]
+   layer-props open-all?]
   (for [[val layer-subset] (sort-by (->sort-by sorting-info ordering) (group-by ordering layers))
         ;; sorting-info maps category key -> label -> [sort-key,id].
         ;; We use the id for a stable node-id:
@@ -128,14 +129,13 @@
      :className  (-> ordering name (string/replace "_" "-"))
      :childNodes (concat
                   (if (seq ordering-remainder)
-                    (layers->nodes layer-subset (rest group-ordering) sorting-info expanded-states id-str layer-props open-all? tma?)
+                    (layers->nodes layer-subset (rest group-ordering) sorting-info expanded-states id-str layer-props open-all?)
                     (map-indexed
                      (fn [i layer]
                        (layer-catalogue-node
                         {:id          (str id-str "-" i)
                          :layer       layer
-                         :layer-props layer-props
-                         :tma?        tma?}))
+                         :layer-props layer-props}))
                      layer-subset))
                   
                   ;; Dummy element appended inside of category ordering content for achieving styling
@@ -143,7 +143,7 @@
                     [{:id (str id-str "-" (inc (count layer-subset)))
                       :className "tree-cap"}]))}))
 
-(defn- layer-catalogue-tree [catid _layers _ordering _id _layer-props _open-all? _tma?]
+(defn- layer-catalogue-tree [catid _layers _ordering _id _layer-props _open-all?]
   (let [expanded-states (re-frame/subscribe [:ui.catalogue/nodes catid])
         sorting-info (re-frame/subscribe [:sorting/info])
         on-open (fn [node]
@@ -157,9 +157,9 @@
                      (when (seq childNodes)
                        ;; If we have children, toggle expanded state, else add to map
                        (re-frame/dispatch [:ui.catalogue/toggle-node catid id]))))]
-    (fn [_catid layers ordering id layer-props open-all? tma?]
+    (fn [_catid layers ordering id layer-props open-all?]
      [:div.tab-body {:id id}
-      [b/tree {:contents (layers->nodes layers ordering @sorting-info @expanded-states id layer-props open-all? tma?)
+      [b/tree {:contents (layers->nodes layers ordering @sorting-info @expanded-states id layer-props open-all?)
                :onNodeCollapse on-close
                :onNodeExpand on-open
                :onNodeClick on-click
@@ -167,7 +167,7 @@
                                     (re-frame/dispatch [:map/update-preview-layer preview-layer]))
                :onNodeMouseLeave #(re-frame/dispatch [:map/update-preview-layer nil])}]])))
 
-(defn layer-catalogue [catid layers layer-props tma?]
+(defn layer-catalogue [catid layers layer-props]
   (let [selected-tab @(re-frame/subscribe [:ui.catalogue/tab catid])
         select-tab   #(re-frame/dispatch [:ui.catalogue/select-tab catid %1])
         open-all?    (>= (count @(re-frame/subscribe [:map.layers/filter])) 3)]
@@ -178,12 +178,12 @@
       {:id    "cat"
        :title "By Category"
        :panel (reagent/as-element
-               [layer-catalogue-tree catid layers [:category :data_classification] "cat" layer-props open-all? tma?])}]
+               [layer-catalogue-tree catid layers [:category :data_classification] "cat" layer-props open-all?])}]
      [b/tab
       {:id    "org"
        :title "By Organisation"
        :panel (reagent/as-element
-               [layer-catalogue-tree catid layers [:category :organisation :data_classification] "org" layer-props open-all? tma?])}]]))
+               [layer-catalogue-tree catid layers [:category :organisation :data_classification] "org" layer-props open-all?])}]]))
 
 (defn- viewport-only-toggle []
   (let [[icon text] (if @(re-frame/subscribe [:map/viewport-only?])
@@ -234,7 +234,7 @@
               200))))}])))
 
 (defn- active-layer-selection-list
-  [{:keys [layers visible-layers loading-fn error-fn expanded-fn opacity-fn rich-layer-fn tma?]}]
+  [{:keys [layers visible-layers loading-fn error-fn expanded-fn opacity-fn rich-layer-fn]}]
   [components/items-selection-list
    {:items
     (for [{:keys [id] :as layer} layers]
@@ -249,8 +249,7 @@
           :errors?   (error-fn layer)
           :expanded? (expanded-fn layer)
           :opacity   (opacity-fn layer)
-          :rich-layer (rich-layer-fn layer)}
-         :tma? tma?}]})
+          :rich-layer (rich-layer-fn layer)}}]})
     :disabled    false
     :data-path   [:map :active-layers]
     :has-handle  false
@@ -817,7 +816,7 @@
                         data_classification]))
        :keywords    #(layer-search-keywords categories %)}}]))
 
-(defn left-drawer-catalogue [tma?]
+(defn left-drawer-catalogue []
   (let [{:keys [filtered-layers active-layers visible-layers viewport-layers loading-layers error-layers expanded-layers layer-opacities rich-layer-fn]} @(re-frame/subscribe [:map/layers])
         viewport-only? @(re-frame/subscribe [:map/viewport-only?])
         catalogue-layers (filterv #(or (not viewport-only?) ((set viewport-layers) %)) filtered-layers)]
@@ -830,10 +829,9 @@
        :error-fn       error-layers
        :expanded-fn    expanded-layers
        :opacity-fn     layer-opacities
-       :rich-layer-fn  rich-layer-fn}
-      tma?]]))
+       :rich-layer-fn  rich-layer-fn}]]))
 
-(defn left-drawer-active-layers [tma?]
+(defn left-drawer-active-layers []
   (let [{:keys [active-layers visible-layers loading-layers error-layers expanded-layers layer-opacities rich-layer-fn]} @(re-frame/subscribe [:map/layers])]
     [active-layer-selection-list
      {:layers         active-layers
@@ -842,8 +840,7 @@
       :error-fn       error-layers
       :expanded-fn    expanded-layers
       :opacity-fn     layer-opacities
-      :rich-layer-fn  rich-layer-fn
-      :tma?           tma?}]))
+      :rich-layer-fn  rich-layer-fn}]))
 
 (defn left-drawer []
   (let [open? @(re-frame/subscribe [:left-drawer/open?])
@@ -878,7 +875,7 @@
         :class "catalogue"
         :title (reagent/as-element
                 [b/tooltip {:content "All available map layers"} "Catalogue"])
-        :panel (reagent/as-element [left-drawer-catalogue false])}]
+        :panel (reagent/as-element [left-drawer-catalogue])}]
 
       [b/tab
        {:id    "active-layers"
@@ -887,7 +884,7 @@
                  [:<> "Active Layers"
                   (when (seq active-layers)
                     [:div.notification-bubble (count active-layers)])]])
-        :panel (reagent/as-element [left-drawer-active-layers false])}]
+        :panel (reagent/as-element [left-drawer-active-layers])}]
 
       [b/tab
        {:id    "featured-maps"

--- a/frontend/src/cljs/imas_seamap/views.cljs
+++ b/frontend/src/cljs/imas_seamap/views.cljs
@@ -847,13 +847,16 @@
 (defn left-drawer []
   (let [open? @(re-frame/subscribe [:left-drawer/open?])
         tab   @(re-frame/subscribe [:left-drawer/tab])
-        {:keys [active-layers]} @(re-frame/subscribe [:map/layers])]
+        {:keys [active-layers]} @(re-frame/subscribe [:map/layers])
+        logo @(re-frame/subscribe [:branding/logo])
+        brand-url @(re-frame/subscribe [:branding/url])
+        drawer-class @(re-frame/subscribe [:branding/drawer-class])]
     [components/drawer
      {:title
       [:<>
        [:div
-        [:a {:href "https://seamapaustralia.org/"}
-         [:img {:src "img/Seamap2_V2_RGB.png"}]]]
+        [:a {:href brand-url}
+         [:img {:src (:src logo) :alt (:alt logo)}]]]
        [b/button
         {:icon     "double-chevron-left"
          :minimal  true
@@ -862,7 +865,7 @@
       :size        "368px"
       :isOpen      open?
       :onClose     #(re-frame/dispatch [:left-drawer/close])
-      :className   "left-drawer seamap-drawer"
+      :className   (str "left-drawer " drawer-class)
       :isCloseButtonShown false
       :hasBackdrop false}
      [b/tabs

--- a/frontend/src/cljs/imas_seamap/views.cljs
+++ b/frontend/src/cljs/imas_seamap/views.cljs
@@ -669,6 +669,7 @@
 
 (defn custom-leaflet-controls []
   (let [has-settings? @(re-frame/subscribe [:feature/enabled? :settings])
+        has-region-select? @(re-frame/subscribe [:feature/enabled? :region-select])
         has-data-in-region? @(re-frame/subscribe [:feature/enabled? :data-in-region])]
     [:div.custom-leaflet-controls.leaflet-top.leaflet-left.leaflet-touch
      [menu-button]
@@ -686,7 +687,8 @@
       :icon     "search"}]
 
     [transect-control]
-    [region-control]
+    (when has-region-select?
+      [region-control])
     (when has-data-in-region?
       [data-in-region-control])
 

--- a/frontend/src/cljs/imas_seamap/views.cljs
+++ b/frontend/src/cljs/imas_seamap/views.cljs
@@ -17,6 +17,7 @@
             [imas-seamap.map.utils :refer [layer-search-keywords]]
             [imas-seamap.fx :refer [show-message]]
             [imas-seamap.subs.features]  ; Phase 3: feature flag subscriptions
+            [imas-seamap.config.components :as components-registry]  ; Phase 4: component registry
             [imas-seamap.dev.deployment-switcher :as dev-switcher]  ; Test harness
             [goog.string.format]
             #_[debux.cs.core :refer [dbg] :include-macros true]))
@@ -1039,12 +1040,27 @@
         _ #_{:keys [handle-keydown handle-keyup]} (use-hotkeys hot-keys)
         catalogue-open?    @(re-frame/subscribe [:left-drawer/open?])
         right-drawer-open? (seq @(re-frame/subscribe [:ui/right-sidebar]))
-        loading?           @(re-frame/subscribe [:app/loading?])]
-    [:div#main-wrapper.seamap ;{:on-key-down handle-keydown :on-key-up handle-keyup}
-     {:class (str (when catalogue-open? " catalogue-open") (when right-drawer-open? " right-drawer-open") (when loading? " loading"))}
+        loading?           @(re-frame/subscribe [:app/loading?])
+
+        ;; Phase 4: Configuration-driven layout
+        css-class          @(re-frame/subscribe [:branding/css-class])
+        layout-config      @(re-frame/subscribe [:layout/config])
+        footer-components  (:footer layout-config)
+        has-floating-pills? @(re-frame/subscribe [:feature/enabled? :floating-pills])]
+    [:div#main-wrapper
+     {:class (str css-class
+                  (when catalogue-open? " catalogue-open")
+                  (when right-drawer-open? " right-drawer-open")
+                  (when loading? " loading"))}
      [:div#content-wrapper
       [map-component]
-      [plot-component]]
+
+      ;; Footer components (conditional based on layout config)
+      (when (seq footer-components)
+        (for [component-key footer-components]
+          ^{:key component-key}
+          (when-let [component (components-registry/get-component component-key)]
+            [component])))]
      
      ;; TODO: Update helper-overlay for new Seamap version (or remove?)
      [helper-overlay
@@ -1086,9 +1102,44 @@
      [:div.custom-leaflet-controls.leaflet-top.leaflet-right.leaflet-touch
       {:style {:font "12px/1.5 \"Helvetica Neue\", Arial, Helvetica, sans-serif"}} ; font style for Leaflet map-component - needs to be inherited into custom controls
       [layers-control]]
-     [floating-pills]
+
+     ;; Floating pills (conditional based on feature flag)
+     (when has-floating-pills?
+       [floating-pills])
+
      [layer-preview @(re-frame/subscribe [:ui/preview-layer-url])]
 
      ;; Test harness: Deployment switcher (only shows in dev mode)
      [dev-switcher/switcher-panel]]))
+
+;;; =============================================================================
+;;; Component Registration (Phase 4: Populate component registry)
+;;; =============================================================================
+
+;; Register components from this namespace into the component registry
+;; This happens once when the namespace loads, avoiding circular dependencies
+(components-registry/register-components!
+ {;; Footer components
+  :footer/plot              plot-component
+
+  ;; Drawer components
+  :drawer/catalogue         left-drawer-catalogue
+  :drawer/active-layers     left-drawer-active-layers
+
+  ;; Overlays
+  :overlay/welcome          welcome-dialogue
+  :overlay/outage           outage-message-dialogue
+  :overlay/settings         settings-overlay
+  :overlay/info-card        info-card
+  :overlay/loading          loading-display
+  :overlay/helper           helper-overlay
+  :overlay/layer-preview    layer-preview
+  :overlay/omnibar          layers-search-omnibar
+
+  ;; State of Knowledge components (from imported namespace)
+  :pill/boundaries          floating-boundaries-pill
+  :pill/zones               floating-zones-pill
+
+  ;; Story Maps components (from imported namespace)
+  :drawer/featured-map      featured-map-drawer})
 

--- a/frontend/src/cljs/imas_seamap/views.cljs
+++ b/frontend/src/cljs/imas_seamap/views.cljs
@@ -668,9 +668,9 @@
      :icon     "minus"}]]))
 
 (defn custom-leaflet-controls []
-  (let [has-settings? @(re-frame/subscribe [:feature/enabled? :settings])
-        has-region-select? @(re-frame/subscribe [:feature/enabled? :region-select])
-        has-data-in-region? @(re-frame/subscribe [:feature/enabled? :data-in-region])]
+  (let [has-settings? @(re-frame/subscribe [:feature/enabled? :feature/settings])
+        has-region-select? @(re-frame/subscribe [:feature/enabled? :feature/region-select])
+        has-data-in-region? @(re-frame/subscribe [:feature/enabled? :feature/data-in-region])]
     [:div.custom-leaflet-controls.leaflet-top.leaflet-left.leaflet-touch
      [menu-button]
      (when has-settings?
@@ -794,9 +794,9 @@
         {dynamic-pills :filtered} @(re-frame/subscribe [:dynamic-pills])
         open-pill                @(re-frame/subscribe [:ui/open-pill])
         ;; Feature flags for individual pills
-        has-sok?                 @(re-frame/subscribe [:feature/enabled? :state-of-knowledge])
-        has-boundaries-pill?     @(re-frame/subscribe [:feature/enabled? :boundaries-pill])
-        has-zones-pill?          @(re-frame/subscribe [:feature/enabled? :zones-pill])]
+        has-sok?                 @(re-frame/subscribe [:feature/enabled? :feature/state-of-knowledge])
+        has-boundaries-pill?     @(re-frame/subscribe [:feature/enabled? :feature/boundaries-pill])
+        has-zones-pill?          @(re-frame/subscribe [:feature/enabled? :feature/zones-pill])]
     [:div
      {:class (str "floating-pills" (when collapsed " collapsed"))}
 
@@ -1080,9 +1080,9 @@
         css-class          @(re-frame/subscribe [:branding/css-class])
         layout-config      @(re-frame/subscribe [:layout/config])
         footer-components  (:footer layout-config)
-        has-floating-pills? @(re-frame/subscribe [:feature/enabled? :floating-pills])
-        has-settings?      @(re-frame/subscribe [:feature/enabled? :settings])
-        has-layer-preview? @(re-frame/subscribe [:feature/enabled? :layer-preview])]
+        has-floating-pills? @(re-frame/subscribe [:feature/enabled? :feature/floating-pills])
+        has-settings?      @(re-frame/subscribe [:feature/enabled? :feature/settings])
+        has-layer-preview? @(re-frame/subscribe [:feature/enabled? :feature/layer-preview])]
     [:div#main-wrapper
      {:class (str css-class
                   (when catalogue-open? " catalogue-open")

--- a/frontend/src/cljs/imas_seamap/views.cljs
+++ b/frontend/src/cljs/imas_seamap/views.cljs
@@ -771,27 +771,37 @@
         boundaries               @(re-frame/subscribe [:sok/boundaries])
         active-boundary          @(re-frame/subscribe [:sok/active-boundary])
         {dynamic-pills :filtered} @(re-frame/subscribe [:dynamic-pills])
-        open-pill                @(re-frame/subscribe [:ui/open-pill])]
+        open-pill                @(re-frame/subscribe [:ui/open-pill])
+        ;; Feature flags for individual pills
+        has-sok?                 @(re-frame/subscribe [:feature/enabled? :state-of-knowledge])
+        has-boundaries-pill?     @(re-frame/subscribe [:feature/enabled? :boundaries-pill])
+        has-zones-pill?          @(re-frame/subscribe [:feature/enabled? :zones-pill])]
     [:div
      {:class (str "floating-pills" (when collapsed " collapsed"))}
 
-     [floating-state-of-knowledge-pill
-      {:expanded?       (= open-pill "state-of-knowledge")
-       :boundaries      boundaries
-       :active-boundary active-boundary}]
-     
-     (when (and state-of-knowledge-open? active-boundary)
+     ;; State of Knowledge pill - only show if feature enabled
+     (when has-sok?
+       [floating-state-of-knowledge-pill
+        {:expanded?       (= open-pill "state-of-knowledge")
+         :boundaries      boundaries
+         :active-boundary active-boundary}])
+
+     ;; Boundaries pill - only show if feature enabled AND SOK is open with boundary
+     (when (and has-boundaries-pill? state-of-knowledge-open? active-boundary)
        [floating-boundaries-pill
         (merge
          valid-boundaries
          {:expanded?       (= open-pill "boundaries")
           :active-boundary active-boundary})])
-     
-     (when (and state-of-knowledge-open? (= (:id active-boundary) "amp"))
+
+     ;; Zones pill - only show if feature enabled AND SOK is open with AMP boundary
+     (when (and has-zones-pill? state-of-knowledge-open? (= (:id active-boundary) "amp"))
        [floating-zones-pill
         (merge
          valid-boundaries
          {:expanded? (= open-pill "zones")})])
+
+     ;; Dynamic pills (always shown when floating-pills feature is enabled)
      (for [{:keys [id] :as dp} dynamic-pills]
        ^{:key (str id)}
        [dynamic-pill dp])]))

--- a/frontend/src/cljs/imas_seamap/views.cljs
+++ b/frontend/src/cljs/imas_seamap/views.cljs
@@ -654,13 +654,15 @@
      :icon     "minus"}]]))
 
 (defn custom-leaflet-controls []
-  [:div.custom-leaflet-controls.leaflet-top.leaflet-left.leaflet-touch
-   [menu-button]
-   [settings-button]
-   [zoom-control]
+  (let [has-settings? @(re-frame/subscribe [:feature/enabled? :settings])]
+    [:div.custom-leaflet-controls.leaflet-top.leaflet-left.leaflet-touch
+     [menu-button]
+     (when has-settings?
+       [settings-button])
+     [zoom-control]
 
-   [control-block
-    [print-control]
+     [control-block
+      [print-control]
 
     [control-block-child
      {:on-click #(re-frame/dispatch [:layers-search-omnibar/open])
@@ -694,7 +696,7 @@
      {:on-click #(re-frame/dispatch [:help-layer/toggle])
       :tooltip  "Show Help Overlay"
       :id       "overlay-control"
-      :icon     "help"}]]])
+      :icon     "help"}]]]))
 
 (defmulti dynamic-pill-region-control #(get-in % [:region-control :controller-type]))
 
@@ -1059,7 +1061,8 @@
         css-class          @(re-frame/subscribe [:branding/css-class])
         layout-config      @(re-frame/subscribe [:layout/config])
         footer-components  (:footer layout-config)
-        has-floating-pills? @(re-frame/subscribe [:feature/enabled? :floating-pills])]
+        has-floating-pills? @(re-frame/subscribe [:feature/enabled? :floating-pills])
+        has-settings?      @(re-frame/subscribe [:feature/enabled? :settings])]
     [:div#main-wrapper
      {:class (str css-class
                   (when catalogue-open? " catalogue-open")
@@ -1105,7 +1108,8 @@
        :helperPosition "top"}]
      [welcome-dialogue]
      [outage-message-dialogue]
-     [settings-overlay]
+     (when has-settings?
+       [settings-overlay])
      [info-card]
      [loading-display]
      [left-drawer]

--- a/frontend/src/cljs/imas_seamap/views.cljs
+++ b/frontend/src/cljs/imas_seamap/views.cljs
@@ -613,6 +613,20 @@
       :disabled? (not habitat-layers?)
       :id        "select-control"}]))
 
+;;; FIXME: shares the events with the region-control, but has different effects
+(defn data-in-region-control []
+  (let [{:keys [selecting? region]} @(re-frame/subscribe [:map.layer.selection/info])
+        [tooltip icon dispatch]
+        (cond
+          selecting?            ["Cancel Selecting"    "undo"   :map.layer.selection/disable]
+          region                ["Clear Selection"     "eraser" :map.layer.selection/clear]
+          :else                 ["Find Data in Region" "path-search" :map.layer.selection/enable])]
+    [control-block-child
+     {:on-click  #(re-frame/dispatch [dispatch])
+      :tooltip   tooltip
+      :icon      icon
+      :id        "select-control"}]))
+
 (defn- leaflet-control-button [{:keys [on-click tooltip icon id]}]
   [:div.leaflet-bar.leaflet-control
    (when id {:id id})
@@ -654,7 +668,8 @@
      :icon     "minus"}]]))
 
 (defn custom-leaflet-controls []
-  (let [has-settings? @(re-frame/subscribe [:feature/enabled? :settings])]
+  (let [has-settings? @(re-frame/subscribe [:feature/enabled? :settings])
+        has-data-in-region? @(re-frame/subscribe [:feature/enabled? :data-in-region])]
     [:div.custom-leaflet-controls.leaflet-top.leaflet-left.leaflet-touch
      [menu-button]
      (when has-settings?
@@ -672,6 +687,8 @@
 
     [transect-control]
     [region-control]
+    (when has-data-in-region?
+      [data-in-region-control])
 
     [control-block-child
      {:on-click #(re-frame/dispatch [:create-save-state])

--- a/frontend/src/cljs/imas_seamap/views.cljs
+++ b/frontend/src/cljs/imas_seamap/views.cljs
@@ -17,6 +17,7 @@
             [imas-seamap.map.utils :refer [layer-search-keywords]]
             [imas-seamap.fx :refer [show-message]]
             [imas-seamap.subs.features]  ; Phase 3: feature flag subscriptions
+            [imas-seamap.dev.deployment-switcher :as dev-switcher]  ; Test harness
             [goog.string.format]
             #_[debux.cs.core :refer [dbg] :include-macros true]))
 
@@ -1086,5 +1087,8 @@
       {:style {:font "12px/1.5 \"Helvetica Neue\", Arial, Helvetica, sans-serif"}} ; font style for Leaflet map-component - needs to be inherited into custom controls
       [layers-control]]
      [floating-pills]
-     [layer-preview @(re-frame/subscribe [:ui/preview-layer-url])]]))
+     [layer-preview @(re-frame/subscribe [:ui/preview-layer-url])]
+
+     ;; Test harness: Deployment switcher (only shows in dev mode)
+     [dev-switcher/switcher-panel]]))
 

--- a/frontend/src/cljs/imas_seamap/views.cljs
+++ b/frontend/src/cljs/imas_seamap/views.cljs
@@ -1062,7 +1062,8 @@
         layout-config      @(re-frame/subscribe [:layout/config])
         footer-components  (:footer layout-config)
         has-floating-pills? @(re-frame/subscribe [:feature/enabled? :floating-pills])
-        has-settings?      @(re-frame/subscribe [:feature/enabled? :settings])]
+        has-settings?      @(re-frame/subscribe [:feature/enabled? :settings])
+        has-layer-preview? @(re-frame/subscribe [:feature/enabled? :layer-preview])]
     [:div#main-wrapper
      {:class (str css-class
                   (when catalogue-open? " catalogue-open")
@@ -1124,7 +1125,8 @@
      (when has-floating-pills?
        [floating-pills])
 
-     [layer-preview @(re-frame/subscribe [:ui/preview-layer-url])]
+     (when has-layer-preview?
+       [layer-preview @(re-frame/subscribe [:ui/preview-layer-url])])
 
      ;; Test harness: Deployment switcher (only shows in dev mode)
      [dev-switcher/switcher-panel]]))

--- a/frontend/src/ui/css/app.scss
+++ b/frontend/src/ui/css/app.scss
@@ -795,3 +795,115 @@ input.leaflet-control-layers-selector[type="radio"] {
 }
 
 .data-in-region-drawer .bp3-non-ideal-state { height: 150px; }
+
+/* Deployment Switcher Styles (dev-only UI for testing configuration system) */
+.deployment-switcher {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  z-index: 10000;
+}
+
+.deployment-switcher .switcher-toggle {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 50px;
+  height: 50px;
+  background: #137CBD;
+  color: white;
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+  transition: transform 0.2s;
+}
+
+.deployment-switcher .switcher-toggle:hover {
+  transform: scale(1.1);
+}
+
+.deployment-switcher .switcher-panel {
+  position: fixed;
+  top: 80px;
+  right: 20px;
+  width: 800px;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
+.deployment-switcher .panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+  border-bottom: 1px solid #e1e8ed;
+  padding-bottom: 10px;
+}
+
+.deployment-switcher .header-actions {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.deployment-switcher .deployments-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 15px;
+}
+
+.deployment-switcher .deployment-card {
+  padding: 15px;
+}
+
+.deployment-switcher .deployment-card.current {
+  border: 2px solid #0F9960;
+}
+
+.deployment-switcher .deployment-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.deployment-switcher .deployment-info .info-row {
+  display: flex;
+  justify-content: space-between;
+  padding: 5px 0;
+  font-size: 0.9em;
+}
+
+.deployment-switcher .deployment-info .label {
+  font-weight: 600;
+  color: #5C7080;
+}
+
+.deployment-switcher .section {
+  margin-top: 20px;
+  padding-top: 20px;
+  border-top: 1px solid #e1e8ed;
+}
+
+.deployment-switcher .feature-list ul {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.deployment-switcher .test-section {
+  margin: 10px 0;
+  padding: 10px;
+  background: #f5f8fa;
+  border-radius: 3px;
+}
+
+.deployment-switcher .test-result {
+  margin-top: 10px;
+  padding: 10px;
+  background: white;
+  border-radius: 3px;
+}

--- a/frontend/test/cljs/imas_seamap/config_test.cljs
+++ b/frontend/test/cljs/imas_seamap/config_test.cljs
@@ -76,10 +76,19 @@
 
 (deftest feature-sets-are-valid
   (testing "Each deployment has a valid feature set"
-    (let [valid-features #{:state-of-knowledge :data-in-region :featured-maps
-                           :floating-pills :plot-component :transect-control
-                           :data-providers :data-download :boundaries-pill
-                           :zones-pill}]
+    (let [valid-features #{:feature/state-of-knowledge
+                           :feature/data-in-region
+                           :feature/featured-maps
+                           :feature/floating-pills
+                           :feature/plot-component
+                           :feature/transect-control
+                           :feature/data-providers
+                           :feature/data-download
+                           :feature/boundaries-pill
+                           :feature/zones-pill
+                           :feature/settings
+                           :feature/region-select
+                           :feature/layer-preview}]
       (doseq [[deployment-id config] deployments/deployments]
         (testing (str "Deployment " deployment-id " features")
           (is (set? (:features config)) "Features should be a set")
@@ -95,28 +104,28 @@
           fos (deployments/get-deployment :futures-of-seafood)]
 
       (testing "State of Knowledge feature"
-        (is (contains? (:features australia) :state-of-knowledge))
-        (is (not (contains? (:features tma) :state-of-knowledge)))
-        (is (contains? (:features antarctica) :state-of-knowledge))
-        (is (not (contains? (:features fos) :state-of-knowledge))))
+        (is (contains? (:features australia) :feature/state-of-knowledge))
+        (is (not (contains? (:features tma) :feature/state-of-knowledge)))
+        (is (contains? (:features antarctica) :feature/state-of-knowledge))
+        (is (not (contains? (:features fos) :feature/state-of-knowledge))))
 
       (testing "Data in Region feature"
-        (is (not (contains? (:features australia) :data-in-region)))
-        (is (contains? (:features tma) :data-in-region))
-        (is (not (contains? (:features antarctica) :data-in-region)))
-        (is (not (contains? (:features fos) :data-in-region))))
+        (is (not (contains? (:features australia) :feature/data-in-region)))
+        (is (contains? (:features tma) :feature/data-in-region))
+        (is (not (contains? (:features antarctica) :feature/data-in-region)))
+        (is (not (contains? (:features fos) :feature/data-in-region))))
 
       (testing "Featured Maps feature"
-        (is (contains? (:features australia) :featured-maps))
-        (is (contains? (:features tma) :featured-maps))
-        (is (not (contains? (:features antarctica) :featured-maps)))
-        (is (not (contains? (:features fos) :featured-maps))))
+        (is (contains? (:features australia) :feature/featured-maps))
+        (is (contains? (:features tma) :feature/featured-maps))
+        (is (not (contains? (:features antarctica) :feature/featured-maps)))
+        (is (not (contains? (:features fos) :feature/featured-maps))))
 
       (testing "Plot Component feature"
-        (is (contains? (:features australia) :plot-component))
-        (is (not (contains? (:features tma) :plot-component)))
-        (is (not (contains? (:features antarctica) :plot-component)))
-        (is (contains? (:features fos) :plot-component))))))
+        (is (contains? (:features australia) :feature/plot-component))
+        (is (not (contains? (:features tma) :feature/plot-component)))
+        (is (not (contains? (:features antarctica) :feature/plot-component)))
+        (is (contains? (:features fos) :feature/plot-component))))))
 
 ;;; =============================================================================
 ;;; Content Registry Tests (Phase 1)
@@ -159,12 +168,12 @@
     (setup-deployment-config :seamap-australia)
 
     (testing "Returns true for enabled features"
-      (is (true? @(re-frame/subscribe [:feature/enabled? :state-of-knowledge])))
-      (is (true? @(re-frame/subscribe [:feature/enabled? :featured-maps])))
-      (is (true? @(re-frame/subscribe [:feature/enabled? :plot-component]))))
+      (is (true? @(re-frame/subscribe [:feature/enabled? :feature/state-of-knowledge])))
+      (is (true? @(re-frame/subscribe [:feature/enabled? :feature/featured-maps])))
+      (is (true? @(re-frame/subscribe [:feature/enabled? :feature/plot-component]))))
 
     (testing "Returns false for disabled features"
-      (is (false? @(re-frame/subscribe [:feature/enabled? :data-in-region])))
+      (is (false? @(re-frame/subscribe [:feature/enabled? :feature/data-in-region])))
       (is (false? @(re-frame/subscribe [:feature/enabled? :nonexistent-feature]))))))
 
 (deftest feature-all-subscription-works
@@ -172,9 +181,9 @@
     (setup-deployment-config :seamap-australia)
     (let [features @(re-frame/subscribe [:feature/all])]
       (is (set? features))
-      (is (contains? features :state-of-knowledge))
-      (is (contains? features :featured-maps))
-      (is (not (contains? features :data-in-region))))))
+      (is (contains? features :feature/state-of-knowledge))
+      (is (contains? features :feature/featured-maps))
+      (is (not (contains? features :feature/data-in-region))))))
 
 (deftest deployment-id-subscription-works
   (testing "Deployment ID subscription returns correct value"
@@ -249,12 +258,12 @@
   (testing "TMA-specific behavior now comes from configuration"
     (testing "TMA deployment"
       (setup-deployment-config :tas-marine-atlas)
-      (is (false? @(re-frame/subscribe [:feature/enabled? :data-download])))
+      (is (false? @(re-frame/subscribe [:feature/enabled? :feature/data-download])))
       (is (= "Layer info" @(re-frame/subscribe [:branding/label :layer-info]))))
 
     (testing "Australia deployment"
       (setup-deployment-config :seamap-australia)
-      (is (true? @(re-frame/subscribe [:feature/enabled? :data-download])))
+      (is (true? @(re-frame/subscribe [:feature/enabled? :feature/data-download])))
       (is (= "Layer info / Download data"
              @(re-frame/subscribe [:branding/label :layer-info]))))))
 

--- a/frontend/test/cljs/imas_seamap/config_test.cljs
+++ b/frontend/test/cljs/imas_seamap/config_test.cljs
@@ -1,0 +1,286 @@
+;;; Seamap: view and interact with Australian coastal habitat data
+;;; Copyright (c) 2017, Institute of Marine & Antarctic Studies.  Written by Condense Pty Ltd.
+;;; Released under the Affero General Public Licence (AGPL) v3.  See LICENSE file for details.
+(ns imas-seamap.config-test
+  "Tests for the configuration-driven architecture (Phases 1-3).
+
+   These tests verify:
+   - Deployment configurations are valid
+   - Feature flag subscriptions work correctly
+   - Branding subscriptions return expected values
+   - Component migrations work properly"
+  (:require [cljs.test :refer-macros [deftest testing is use-fixtures]]
+            [re-frame.core :as re-frame]
+            [imas-seamap.config.deployments :as deployments]
+            [imas-seamap.config.content :as content]
+            [imas-seamap.subs.features]
+            [imas-seamap.subs.branding]))
+
+;;; =============================================================================
+;;; Test Fixtures
+;;; =============================================================================
+
+(defn reset-re-frame
+  "Reset re-frame state between tests"
+  [f]
+  (re-frame/clear-subscription-cache!)
+  (f))
+
+(use-fixtures :each reset-re-frame)
+
+;;; =============================================================================
+;;; Deployment Configuration Tests (Phase 1)
+;;; =============================================================================
+
+(deftest deployment-configs-exist
+  (testing "All four deployments are defined"
+    (is (= 4 (count deployments/deployments)))
+    (is (contains? deployments/deployments :seamap-australia))
+    (is (contains? deployments/deployments :tas-marine-atlas))
+    (is (contains? deployments/deployments :seamap-antarctica))
+    (is (contains? deployments/deployments :futures-of-seafood))))
+
+(deftest deployment-configs-have-required-keys
+  (testing "Each deployment has all required configuration keys"
+    (let [required-keys #{:id :css-class :drawer-class :branding :map
+                          :features :drawers :tabs :controls}]
+      (doseq [[deployment-id config] deployments/deployments]
+        (testing (str "Deployment " deployment-id)
+          (is (every? #(contains? config %) required-keys)
+              (str "Missing keys: "
+                   (clojure.set/difference required-keys (set (keys config))))))))))
+
+(deftest branding-configs-are-valid
+  (testing "Each deployment has valid branding configuration"
+    (doseq [[deployment-id config] deployments/deployments]
+      (testing (str "Deployment " deployment-id " branding")
+        (let [branding (:branding config)]
+          (is (map? (:logo branding)) "Logo should be a map")
+          (is (string? (:src (:logo branding))) "Logo src should be a string")
+          (is (string? (:url branding)) "URL should be a string")
+          (is (string? (:title branding)) "Title should be a string")
+          (is (map? (:welcome branding)) "Welcome should be a map"))))))
+
+(deftest map-configs-are-valid
+  (testing "Each deployment has valid map configuration"
+    (doseq [[deployment-id config] deployments/deployments]
+      (testing (str "Deployment " deployment-id " map config")
+        (let [map-config (:map config)]
+          (is (keyword? (:crs map-config)) "CRS should be a keyword")
+          (is (vector? (:center map-config)) "Center should be a vector")
+          (is (= 2 (count (:center map-config))) "Center should have 2 coordinates")
+          (is (number? (first (:center map-config))) "Latitude should be a number")
+          (is (number? (second (:center map-config))) "Longitude should be a number")
+          (is (number? (:zoom map-config)) "Zoom should be a number")
+          (is (>= (:zoom map-config) 1) "Zoom should be >= 1"))))))
+
+(deftest feature-sets-are-valid
+  (testing "Each deployment has a valid feature set"
+    (let [valid-features #{:state-of-knowledge :data-in-region :featured-maps
+                           :floating-pills :plot-component :transect-control
+                           :data-providers :data-download :boundaries-pill
+                           :zones-pill}]
+      (doseq [[deployment-id config] deployments/deployments]
+        (testing (str "Deployment " deployment-id " features")
+          (is (set? (:features config)) "Features should be a set")
+          (is (every? valid-features (:features config))
+              (str "Invalid features: "
+                   (clojure.set/difference (:features config) valid-features))))))))
+
+(deftest feature-matrix-matches-expected
+  (testing "Feature matrix matches documented behavior"
+    (let [australia (deployments/get-deployment :seamap-australia)
+          tma (deployments/get-deployment :tas-marine-atlas)
+          antarctica (deployments/get-deployment :seamap-antarctica)
+          fos (deployments/get-deployment :futures-of-seafood)]
+
+      (testing "State of Knowledge feature"
+        (is (contains? (:features australia) :state-of-knowledge))
+        (is (not (contains? (:features tma) :state-of-knowledge)))
+        (is (contains? (:features antarctica) :state-of-knowledge))
+        (is (not (contains? (:features fos) :state-of-knowledge))))
+
+      (testing "Data in Region feature"
+        (is (not (contains? (:features australia) :data-in-region)))
+        (is (contains? (:features tma) :data-in-region))
+        (is (not (contains? (:features antarctica) :data-in-region)))
+        (is (not (contains? (:features fos) :data-in-region))))
+
+      (testing "Featured Maps feature"
+        (is (contains? (:features australia) :featured-maps))
+        (is (contains? (:features tma) :featured-maps))
+        (is (not (contains? (:features antarctica) :featured-maps)))
+        (is (not (contains? (:features fos) :featured-maps))))
+
+      (testing "Plot Component feature"
+        (is (contains? (:features australia) :plot-component))
+        (is (not (contains? (:features tma) :plot-component)))
+        (is (not (contains? (:features antarctica) :plot-component)))
+        (is (contains? (:features fos) :plot-component))))))
+
+;;; =============================================================================
+;;; Content Registry Tests (Phase 1)
+;;; =============================================================================
+
+(deftest welcome-content-exists
+  (testing "Welcome content exists for all deployments"
+    (is (some? (content/get-content :welcome/seamap-australia)))
+    (is (some? (content/get-content :welcome/tas-marine-atlas)))
+    (is (some? (content/get-content :welcome/seamap-antarctica)))
+    (is (some? (content/get-content :welcome/futures-of-seafood)))))
+
+(deftest welcome-content-is-hiccup
+  (testing "Welcome content is valid Reagent hiccup"
+    (doseq [content-key [:welcome/seamap-australia
+                         :welcome/tas-marine-atlas
+                         :welcome/seamap-antarctica
+                         :welcome/futures-of-seafood]]
+      (let [content (content/get-content content-key)]
+        (is (vector? content) (str content-key " should be a vector"))
+        (is (keyword? (first content)) (str content-key " should start with a keyword"))))))
+
+;;; =============================================================================
+;;; Feature Subscription Tests (Phase 2)
+;;; =============================================================================
+
+(defn- setup-deployment-config
+  "Helper to set up a deployment config in app-db for testing"
+  [deployment-id]
+  (let [config (deployments/get-deployment deployment-id)]
+    (re-frame/dispatch-sync [:boot
+                             "http://localhost:8000/api/"
+                             "http://localhost:8000/media/"
+                             "http://localhost:8888/"
+                             "/img/"
+                             config])))
+
+(deftest feature-enabled-subscription-works
+  (testing "Feature enabled subscription returns correct values"
+    (setup-deployment-config :seamap-australia)
+
+    (testing "Returns true for enabled features"
+      (is (true? @(re-frame/subscribe [:feature/enabled? :state-of-knowledge])))
+      (is (true? @(re-frame/subscribe [:feature/enabled? :featured-maps])))
+      (is (true? @(re-frame/subscribe [:feature/enabled? :plot-component]))))
+
+    (testing "Returns false for disabled features"
+      (is (false? @(re-frame/subscribe [:feature/enabled? :data-in-region])))
+      (is (false? @(re-frame/subscribe [:feature/enabled? :nonexistent-feature]))))))
+
+(deftest feature-all-subscription-works
+  (testing "Feature all subscription returns complete feature set"
+    (setup-deployment-config :seamap-australia)
+    (let [features @(re-frame/subscribe [:feature/all])]
+      (is (set? features))
+      (is (contains? features :state-of-knowledge))
+      (is (contains? features :featured-maps))
+      (is (not (contains? features :data-in-region))))))
+
+(deftest deployment-id-subscription-works
+  (testing "Deployment ID subscription returns correct value"
+    (setup-deployment-config :tas-marine-atlas)
+    (is (= :tas-marine-atlas @(re-frame/subscribe [:deployment/id])))))
+
+;;; =============================================================================
+;;; Branding Subscription Tests (Phase 2)
+;;; =============================================================================
+
+(deftest branding-logo-subscription-works
+  (testing "Branding logo subscription returns correct values"
+    (setup-deployment-config :seamap-australia)
+    (let [logo @(re-frame/subscribe [:branding/logo])]
+      (is (map? logo))
+      (is (= "img/Seamap2_V2_RGB.png" (:src logo)))
+      (is (= "Seamap Australia" (:alt logo)))
+      (is (= 96 (:height logo))))))
+
+(deftest branding-label-subscription-works
+  (testing "Branding labels differ between deployments"
+    (testing "TMA has different region-control label"
+      (setup-deployment-config :tas-marine-atlas)
+      (is (= "Find Data in Region"
+             @(re-frame/subscribe [:branding/label :region-control]))))
+
+    (testing "Australia has different region-control label"
+      (setup-deployment-config :seamap-australia)
+      (is (= "Select region"
+             @(re-frame/subscribe [:branding/label :region-control]))))
+
+    (testing "Layer info label differs between deployments"
+      (setup-deployment-config :tas-marine-atlas)
+      (is (= "Layer info"
+             @(re-frame/subscribe [:branding/label :layer-info])))
+
+      (setup-deployment-config :seamap-australia)
+      (is (= "Layer info / Download data"
+             @(re-frame/subscribe [:branding/label :layer-info]))))))
+
+(deftest branding-colors-subscription-works
+  (testing "Branding colors subscription works"
+    (testing "TMA has custom colors"
+      (setup-deployment-config :tas-marine-atlas)
+      (let [colors @(re-frame/subscribe [:branding/colors])]
+        (is (map? colors))
+        (is (= "rgb(18, 37, 55)" (:color-1 colors)))))
+
+    (testing "Australia has no color overrides"
+      (setup-deployment-config :seamap-australia)
+      (let [colors @(re-frame/subscribe [:branding/colors])]
+        (is (or (nil? colors) (empty? colors)))))))
+
+(deftest map-config-subscriptions-work
+  (testing "Map config subscriptions return correct values"
+    (testing "Antarctica has different CRS"
+      (setup-deployment-config :seamap-antarctica)
+      (is (= :epsg-3031 @(re-frame/subscribe [:map/crs])))
+      (is (= [-80 -90] @(re-frame/subscribe [:map/initial-center])))
+      (is (= 2 @(re-frame/subscribe [:map/initial-zoom]))))
+
+    (testing "Australia has standard CRS"
+      (setup-deployment-config :seamap-australia)
+      (is (= :epsg-3857 @(re-frame/subscribe [:map/crs])))
+      (is (= 4 @(re-frame/subscribe [:map/initial-zoom]))))))
+
+;;; =============================================================================
+;;; Integration Tests (Phase 3)
+;;; =============================================================================
+
+(deftest tma-flag-elimination-works
+  (testing "TMA-specific behavior now comes from configuration"
+    (testing "TMA deployment"
+      (setup-deployment-config :tas-marine-atlas)
+      (is (false? @(re-frame/subscribe [:feature/enabled? :data-download])))
+      (is (= "Layer info" @(re-frame/subscribe [:branding/label :layer-info]))))
+
+    (testing "Australia deployment"
+      (setup-deployment-config :seamap-australia)
+      (is (true? @(re-frame/subscribe [:feature/enabled? :data-download])))
+      (is (= "Layer info / Download data"
+             @(re-frame/subscribe [:branding/label :layer-info]))))))
+
+;;; =============================================================================
+;;; Summary Report
+;;; =============================================================================
+
+(defn run-all-tests-and-report
+  "Run all tests and return a summary report"
+  []
+  (let [results (atom {:passed 0 :failed 0 :errors []})]
+    (println "\n=== Configuration System Test Report ===\n")
+
+    ;; Run tests (simplified - in real implementation would use cljs.test/run-tests)
+    (try
+      (deployment-configs-exist)
+      (swap! results update :passed inc)
+      (catch js/Error e
+        (swap! results update :failed inc)
+        (swap! results update :errors conj {:test "deployment-configs-exist" :error (str e)})))
+
+    (println "\nTests passed:" (:passed @results))
+    (println "Tests failed:" (:failed @results))
+    (when (seq (:errors @results))
+      (println "\nErrors:")
+      (doseq [error (:errors @results)]
+        (println "  -" (:test error) ":" (:error error))))
+
+    @results))


### PR DESCRIPTION
**DO NOT MERGE YET!!**

This is an experiment for feedback.  (Claude wrote most of the code, there's a few dangling ends that could be tidied up)

*Motivation:* We have a growing number of deployments all sharing the same codebase.  We accomodate a few tweaks between the different versions, but the methodology (a separate entrypoint, with different UI components overridden as needed) is starting to feel a bit strained.

*Goal:* a single entrypoint, with a configuration being chosen (currently by an arg to `init` to select from some pre-defined configurations, but it could be sourced from an API call, etc).

*Approach:* The goal is a fairly light touch, with feature-flags used where necessary, rather than a fully-dynamic system where entirely new UIs can be constructed.  So, key features are defined as keywords, which feed into a feature-flag subscription.  A few smaller pieces, such as log and spash-screen text, and a CSS class to specialise styling, are also configuration entries.  (also, map initial zoom/extent and CRS)

*TODO:* I haven't added anything yet to customise subs/handlers registration.  My current thinking is to have another registry, indexed by feature-flag again, where each the features configured for a given deployment are used to load a register a bag of subs and handlers.